### PR TITLE
Redesign DDDA as Miro-first multi-project accelerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,94 @@
+# DDDA — Domain-Driven Design Accelerator
+
+DDDA je pracovní prostředí pro řízenou doménovou analýzu, návrh socio-technické architektury a inkrementální modernizaci systémů. Jedna instalace obsluhuje více navzájem oddělených projektů. Primárním workshopovým a modelovacím rozhraním je Miro; sémantickým zdrojem pravdy jsou verzované YAML artefakty v Gitu.
+
+## Základní principy
+
+- **Business a doména před technologií.**
+- **Miro jako primární plocha pro spolupráci.**
+- **YAML jako kanonický sémantický model.**
+- **Git jako historie, audit a mechanismus review.**
+- **Mermaid jako textová a automatizovatelná reprezentace diagramů.**
+- **Explicitní hranice, ownership dat, integrační kontrakty a quality attributes.**
+- **Hypotézy nejsou fakta:** každý artefakt má stav, původ, vlastníka a validační historii.
+
+## Metodický tok
+
+```text
+Align
+  ↓
+Discover
+  ↓
+Big Picture EventStorming
+  ↓
+Process Modeling
+  ↓
+Decompose
+  ↓
+Strategize
+  ↓
+Connect
+  ↓
+Organize
+  ↓
+Define
+  ↓
+Design-Level EventStorming
+  ↓
+Code
+```
+
+EventStorming není jedna aktivita. DDDA rozlišuje:
+
+1. **Big Picture EventStorming** pro společné porozumění doméně a hotspotům.
+2. **Process Modeling** pro rozpad vybraných business toků.
+3. **Design-Level EventStorming** pro návrh behaviorálního modelu uvnitř konkrétního bounded contextu.
+
+Stavové modely vznikají postupně jako:
+
+1. pozorovaný životní cyklus,
+2. kandidátní životní cyklus,
+3. validovaný business state machine,
+4. implementační state machine, pouze pokud je skutečně potřebná.
+
+## Struktura repozitáře
+
+```text
+.
+├── ddda/
+│   ├── schemas/              # validační schémata
+│   └── scaffolds/            # definice Miro scaffoldů a metodického toku
+├── docs/
+│   ├── product/              # dokumentace produktu DDDA
+│   ├── methodology/          # metodika a gates
+│   └── cookbooks/            # praktické postupy krok za krokem
+├── examples/
+│   └── life-insurance-greenfield/
+├── projects/                 # pracovní projekty; každý projekt je nezávislý
+└── tools/                    # validační, renderovací a synchronizační nástroje
+```
+
+## Rychlý start
+
+1. Vytvořte nový adresář projektu podle kuchařky `docs/cookbooks/01-zalozeni-projektu.md`.
+2. Zvolte typ projektu a pracovní workflow.
+3. Vytvořte nebo připojte Miro board.
+4. Vygenerujte scaffold z `ddda/scaffolds/strategic-ddd-method-board.yaml`.
+5. Veďte workshop v Miru a průběžně synchronizujte artefakty do YAML.
+6. Validujte YAML proti schématům a generujte Mermaid pohledy.
+7. Přijímejte změny přes Git review a metodické gates.
+
+## Dokumentace
+
+- [Architektura produktu](docs/product/01-architektura-ddda.md)
+- [Struktura workspace a projektů](docs/product/02-workspace-a-projekty.md)
+- [Miro scaffolding](docs/product/03-miro-scaffolding.md)
+- [Synchronizace Miro ↔ YAML ↔ Git](docs/product/04-synchronizace.md)
+- [Typy projektů](docs/product/05-typy-projektu.md)
+- [Metodický tok a gates](docs/methodology/01-metodicky-tok-a-gates.md)
+- [Kuchařky](docs/cookbooks/README.md)
+- [Referenční příklad životní pojišťovny](examples/life-insurance-greenfield/README.md)
+
+## Stav implementace
+
+Tato větev zavádí cílovou strukturu, metodiku, scaffoldy, schémata, kuchařky a referenční příklad. Živý konektor k Miro API vyžaduje registraci Miro aplikace, OAuth tokeny a mapování konkrétního boardu; kontrakt, metadata a konfliktní strategie jsou již definovány v dokumentaci a schématech.

--- a/ddda/scaffolds/strategic-ddd-method-board.yaml
+++ b/ddda/scaffolds/strategic-ddd-method-board.yaml
@@ -1,0 +1,326 @@
+schema_version: 1.0.0
+scaffold_id: strategic-ddd-method-board
+name: Strategický DDD metodický board
+language: cs
+purpose: >-
+  Miro scaffold pro řízený průchod od business cíle přes discovery,
+  dekompozici a strategický návrh až k design-level modelu a implementačnímu hand-offu.
+layout:
+  direction: left-to-right
+  stage_width: 4200
+  stage_height: 2600
+  stage_gap: 350
+  navigation_height: 240
+  origin:
+    x: 0
+    y: 0
+visual_language:
+  colors:
+    business_goal: '#F5D547'
+    domain_event: '#F28C28'
+    temporal_event: '#F7B267'
+    pivot_event: '#E4572E'
+    command: '#4A90E2'
+    actor: '#F4F4F4'
+    policy: '#B084CC'
+    read_model: '#7BDFF2'
+    external_system: '#F2F2F2'
+    hotspot: '#E94F64'
+    value: '#A8D08D'
+    bounded_context: '#D6E4FF'
+    lifecycle: '#CDECCF'
+    gate: '#242424'
+  conventions:
+    - Doménové události jsou pojmenovány v minulém čase.
+    - Hypotézy jsou označeny statusem candidate nebo observed.
+    - Validované závěry mají ownera a datum validace.
+    - Červená barva znamená hotspot, riziko nebo nezodpovězenou otázku.
+managed_metadata:
+  required:
+    - artifact_id
+    - artifact_type
+    - project_id
+    - schema_version
+    - stage
+    - status
+  optional:
+    - yaml_path
+    - git_revision
+    - miro_item_id
+    - source_reference
+    - owner
+    - validation_date
+stages:
+  - id: align
+    order: 10
+    title: Align
+    objective: Sjednotit business problém, cíl, scope, aktéry, omezení a očekávané rozhodnutí.
+    x: 0
+    y: 400
+    required_frames:
+      - id: align-brief
+        title: Business a discovery brief
+        purpose: Zachytit problém, cíle, scope, aktéry, constraints a assumptions.
+        templates:
+          - business-goals
+          - stakeholders
+          - scope-in-out
+          - assumptions
+          - quality-attribute-scenarios
+      - id: align-inputs
+        title: Vstupy a zdroje
+        purpose: Evidovat dokumenty, systémy, experty a důvěryhodnost podkladů.
+    gate: G1
+  - id: discover
+    order: 20
+    title: Discover
+    objective: Vytvořit společné porozumění doméně, významným událostem, jazykům, hotspotům a životním cyklům.
+    x: 4550
+    y: 400
+    required_frames:
+      - id: big-picture-es
+        title: Big Picture EventStorming
+        purpose: Zachytit business fakta v čase napříč celým scopem.
+        lanes:
+          - legend
+          - timeline
+          - domain-events
+          - temporal-events
+          - pivot-events
+          - actors-and-systems
+          - hotspots-and-questions
+        allowed_artifact_types:
+          - domain_event
+          - temporal_event
+          - pivot_event
+          - actor
+          - external_system
+          - hotspot
+      - id: glossary
+        title: Doménový slovník
+        purpose: Zachytit pojmy, definice, kontext použití, konflikty významu a zdroj.
+      - id: observed-lifecycles
+        title: Pozorované životní cykly
+        purpose: Popsat pozorované stavy a přechody bez předčasného návrhu cílového modelu.
+        lifecycle_maturity: observed
+      - id: discovery-hotspots
+        title: Hotspoty a otevřené otázky
+        purpose: Prioritizovat nejasnosti podle dopadu na hranice, data, pravidla a rozhodnutí.
+    gate: G2
+  - id: process-modeling
+    order: 30
+    title: Process Modeling
+    objective: Rozpracovat vybrané end-to-end scénáře a business rozhodování.
+    x: 9100
+    y: 400
+    required_frames:
+      - id: process-model
+        title: Process Modeling
+        lanes:
+          - actor
+          - command-or-action
+          - ui
+          - policy-or-procedure
+          - external-system
+          - domain-event
+          - read-model
+          - value
+          - hotspots
+        allowed_artifact_types:
+          - actor
+          - command
+          - policy
+          - procedure
+          - external_system
+          - domain_event
+          - read_model
+          - value
+          - hotspot
+      - id: scenario-catalog
+        title: Katalog scénářů
+        purpose: Evidovat happy paths, varianty, výjimky, rozhodovací body a business hodnotu.
+    gate: null
+  - id: decompose
+    order: 40
+    title: Decompose
+    objective: Formulovat kandidátní subdomény, odpovědnosti a hranice podle jazyka, pravidel, dat a životních cyklů.
+    x: 13650
+    y: 400
+    required_frames:
+      - id: capability-and-subdomain-map
+        title: Capability a kandidátní subdomény
+      - id: candidate-lifecycles
+        title: Kandidátní životní cykly
+        lifecycle_maturity: candidate
+      - id: boundary-hypotheses
+        title: Hypotézy hranic
+        purpose: Zaznamenat důvody pro spojení či oddělení modelů a odpovědností.
+    gate: G3
+  - id: strategize
+    order: 50
+    title: Strategize
+    objective: Klasifikovat subdomény a určit investiční, sourcingovou a evoluční strategii.
+    x: 18200
+    y: 400
+    required_frames:
+      - id: core-supporting-generic
+        title: Core / Supporting / Generic
+      - id: differentiation-complexity
+        title: Diferenciace × komplexita
+      - id: build-buy-partner
+        title: Build / Buy / Partner
+      - id: strategic-risks
+        title: Strategická rizika a Wardley hypotézy
+    gate: G4
+  - id: connect
+    order: 60
+    title: Connect
+    objective: Navrhnout bounded contexts, vztahy, integrační kontrakty a ownership dat.
+    x: 22750
+    y: 400
+    required_frames:
+      - id: context-map
+        title: Context Map
+      - id: data-ownership
+        title: Data ownership a system of record
+      - id: integration-contracts
+        title: Integrační kontrakty
+      - id: context-relationship-decisions
+        title: Rozhodnutí o vztazích kontextů
+    gate: G5
+  - id: organize
+    order: 70
+    title: Organize
+    objective: Srovnat architektonické hranice s ownershipem týmů a požadovanými interakcemi.
+    x: 27300
+    y: 400
+    required_frames:
+      - id: team-topology
+        title: Team Topology
+      - id: cognitive-load
+        title: Kognitivní zátěž a mezery v kompetencích
+      - id: interaction-modes
+        title: Collaboration / X-as-a-Service / Facilitating
+      - id: governance
+        title: Governance, fitness functions a decision ownership
+    gate: G6
+  - id: define
+    order: 80
+    title: Define
+    objective: Validovat bounded contexts a rozpracovat behaviorální model prioritních oblastí.
+    x: 31850
+    y: 400
+    required_frames:
+      - id: bounded-context-canvases
+        title: Bounded Context Canvases
+      - id: design-level-es
+        title: Design-Level EventStorming
+        lanes:
+          - actor
+          - command
+          - external-system
+          - aggregate-or-consistency-boundary
+          - invariant
+          - domain-event
+          - policy-or-procedure
+          - projection-or-read-model
+          - hotspot
+        allowed_artifact_types:
+          - actor
+          - command
+          - external_system
+          - aggregate
+          - invariant
+          - domain_event
+          - policy
+          - procedure
+          - projection
+          - read_model
+          - hotspot
+      - id: validated-lifecycles
+        title: Validované business state machines
+        lifecycle_maturity: validated
+      - id: quality-attributes
+        title: Quality attribute scenarios
+      - id: adrs
+        title: Architektonická rozhodnutí
+    gate: G7
+  - id: code
+    order: 90
+    title: Code
+    objective: Převést validovaný model do implementačních hranic, kontraktů, testů a evolučního plánu.
+    x: 36400
+    y: 400
+    required_frames:
+      - id: implementation-boundaries
+        title: Implementační hranice
+      - id: implementation-state-machines
+        title: Implementační state machines
+        lifecycle_maturity: implementation
+        optional: true
+      - id: contract-and-invariant-tests
+        title: Contract a invariant tests
+      - id: migration-slices
+        title: Inkrementy, strangler slices a roadmap
+      - id: observability
+        title: Observabilita a provozní zpětná vazba
+    gate: G8
+gates:
+  - id: G1
+    name: Discovery připraveno
+    criteria:
+      - Business problém a očekávané rozhodnutí jsou explicitní.
+      - Scope a out-of-scope jsou odsouhlaseny.
+      - Jsou identifikováni doménoví experti a vlastníci rozhodnutí.
+      - Prioritní quality attributes a omezení mají alespoň pracovní podobu.
+  - id: G2
+    name: Společné porozumění doméně
+    criteria:
+      - Big Picture EventStorming pokrývá významný end-to-end tok.
+      - Události jsou formulovány jako business fakta v minulém čase.
+      - Existuje pracovní slovník a backlog hotspotů.
+      - Klíčové pozorované životní cykly mají zdroj a nejistoty.
+  - id: G3
+    name: Dekompoziční hypotézy připraveny
+    criteria:
+      - Kandidátní subdomény mají popsanou odpovědnost a důvod hranice.
+      - Kandidátní životní cykly nejsou vydávány za validovaný návrh.
+      - Konflikty jazyka, pravidel a ownershipu jsou explicitní.
+  - id: G4
+    name: Strategická klasifikace odsouhlasena
+    criteria:
+      - Core, Supporting a Generic klasifikace má business zdůvodnění.
+      - Sourcing a investiční strategie odpovídá diferenciaci a rizikům.
+  - id: G5
+    name: Context Map připravena
+    criteria:
+      - Každý bounded context má odpovědnost a ownera.
+      - Vlastnictví klíčových dat je jednoznačné nebo je evidován konflikt.
+      - Vztahy a integrační kontrakty mají směr a očekávání.
+  - id: G6
+    name: Socio-technický ownership připraven
+    criteria:
+      - Každá prioritní oblast má odpovědný tým nebo explicitní mezeru.
+      - Interakční módy týmů jsou časově omezené a zdůvodněné.
+      - Kognitivní zátěž a platform/enabling potřeby jsou vyhodnoceny.
+  - id: G7
+    name: Doménový návrh připraven pro implementaci
+    criteria:
+      - Prioritní bounded contexts mají canvas a validační záznam.
+      - Design-Level EventStorming pokrývá klíčové command-event flows.
+      - Invarianty a business lifecycle jsou validovány expertem.
+      - Quality attributes jsou promítnuty do rozhodnutí.
+  - id: G8
+    name: Implementační hand-off připraven
+    criteria:
+      - Implementační hranice nejsou mechanicky zaměněny za bounded contexts.
+      - Kontrakty a invarianty mají testovací strategii.
+      - Migrace, observabilita, rizika a rollback jsou explicitní.
+synchronization:
+  semantic_owner: yaml
+  visual_owner: miro
+  derived_outputs:
+    - mermaid
+  conflict_strategy: explicit-review
+  deletion_policy: tombstone-first
+  unmanaged_miro_items: preserve

--- a/ddda/schemas/miro-scaffold.schema.json
+++ b/ddda/schemas/miro-scaffold.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ddda.local/schemas/miro-scaffold.schema.json",
+  "title": "DDDA Miro Scaffold",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "scaffold_id",
+    "name",
+    "language",
+    "layout",
+    "visual_language",
+    "managed_metadata",
+    "stages",
+    "gates",
+    "synchronization"
+  ],
+  "properties": {
+    "schema_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "scaffold_id": {"type": "string", "pattern": "^[a-z0-9-]+$"},
+    "name": {"type": "string", "minLength": 1},
+    "language": {"type": "string", "enum": ["cs"]},
+    "purpose": {"type": "string"},
+    "layout": {
+      "type": "object",
+      "required": ["direction", "stage_width", "stage_height", "stage_gap", "origin"],
+      "properties": {
+        "direction": {"type": "string", "enum": ["left-to-right", "top-to-bottom"]},
+        "stage_width": {"type": "number", "exclusiveMinimum": 0},
+        "stage_height": {"type": "number", "exclusiveMinimum": 0},
+        "stage_gap": {"type": "number", "minimum": 0},
+        "navigation_height": {"type": "number", "minimum": 0},
+        "origin": {
+          "type": "object",
+          "required": ["x", "y"],
+          "properties": {"x": {"type": "number"}, "y": {"type": "number"}},
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": true
+    },
+    "visual_language": {
+      "type": "object",
+      "required": ["colors", "conventions"],
+      "properties": {
+        "colors": {
+          "type": "object",
+          "additionalProperties": {"type": "string", "pattern": "^#[0-9A-Fa-f]{6}$"}
+        },
+        "conventions": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "managed_metadata": {
+      "type": "object",
+      "required": ["required"],
+      "properties": {
+        "required": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}},
+        "optional": {"type": "array", "uniqueItems": true, "items": {"type": "string"}}
+      }
+    },
+    "stages": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "order", "title", "objective", "x", "y", "required_frames"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z0-9-]+$"},
+          "order": {"type": "integer", "minimum": 0},
+          "title": {"type": "string", "minLength": 1},
+          "objective": {"type": "string", "minLength": 1},
+          "x": {"type": "number"},
+          "y": {"type": "number"},
+          "gate": {"type": ["string", "null"]},
+          "required_frames": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "title"],
+              "properties": {
+                "id": {"type": "string", "pattern": "^[a-z0-9-]+$"},
+                "title": {"type": "string", "minLength": 1},
+                "purpose": {"type": "string"},
+                "optional": {"type": "boolean"},
+                "lifecycle_maturity": {"type": "string", "enum": ["observed", "candidate", "validated", "implementation"]},
+                "templates": {"type": "array", "items": {"type": "string"}},
+                "lanes": {"type": "array", "items": {"type": "string"}},
+                "allowed_artifact_types": {"type": "array", "items": {"type": "string"}}
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "gates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "criteria"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^G[0-9]+$"},
+          "name": {"type": "string"},
+          "criteria": {"type": "array", "minItems": 1, "items": {"type": "string"}}
+        }
+      }
+    },
+    "synchronization": {
+      "type": "object",
+      "required": ["semantic_owner", "visual_owner", "conflict_strategy", "deletion_policy"],
+      "properties": {
+        "semantic_owner": {"const": "yaml"},
+        "visual_owner": {"const": "miro"},
+        "derived_outputs": {"type": "array", "items": {"type": "string"}},
+        "conflict_strategy": {"const": "explicit-review"},
+        "deletion_policy": {"const": "tombstone-first"},
+        "unmanaged_miro_items": {"enum": ["preserve", "ignore", "report"]}
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/cookbooks/01-zalozeni-projektu.md
+++ b/docs/cookbooks/01-zalozeni-projektu.md
@@ -1,0 +1,64 @@
+# Kuchařka 01 — Založení projektu
+
+## Výsledek
+
+Vznikne izolovaný projekt s manifestem, adresářovou strukturou, workflow profilem, prázdným Miro mappingem a počátečním backlogem otázek.
+
+## Předpoklady
+
+- existuje klon repozitáře,
+- je znám pracovní název, sponsor a dominantní typ projektu,
+- `project_id` ještě není použit,
+- žádný Miro token se nebude ukládat do Gitu.
+
+## Postup
+
+1. Zvolte stabilní `project_id`, například `life-insurance-greenfield`.
+2. Vyberte typ podle `docs/product/05-typy-projektu.md`.
+3. Vytvořte adresář `projects/<project_id>/` a podadresáře dle produktové dokumentace.
+4. Vytvořte `project.yaml`.
+5. Do `README.md` zapište business problém, očekávané rozhodnutí, scope, out-of-scope, role a známá omezení.
+6. Do `inputs/catalog.yaml` zapište dostupné vstupy a jejich důvěryhodnost.
+7. Do `artifacts/align/hotspots.yaml` zapište počáteční nejistoty.
+8. V `sync/miro-map.yaml` ponechte board ID jako odkaz na environment variable.
+9. Proveďte schema validaci.
+10. Založte feature branch a commitněte bootstrap odděleně od doménových závěrů.
+
+## Minimální manifest
+
+```yaml
+schema_version: 1.0.0
+project_id: claims-modernization
+name: Modernizace likvidace pojistných událostí
+project_type: legacy-modernization
+language: cs
+status: proposed
+workflow:
+  profile: legacy-modernization
+  current_stage: align
+  completed_gates: []
+miro:
+  board_id_env: DDDA_CLAIMS_MIRO_BOARD_ID
+owners:
+  business_sponsor: null
+  architecture_owner: null
+```
+
+## Kontroly
+
+- `project_id` je unikátní a nemění se s názvem.
+- Typ projektu odpovídá hlavnímu problému, ne preferované technologii.
+- Citlivost vstupů je explicitní.
+- Board nebo board area není sdílena s jiným projektem bez explicitní izolace.
+- V manifestu není token.
+
+## Typické chyby
+
+- projekt je pojmenován podle řešení, například `microservices-migration`, místo business scope,
+- scope je celý podnik bez rozhodnutí, které má discovery umožnit,
+- copied project obsahuje staré `artifact_id` a Miro mapping,
+- tým začne vytvářet bounded contexts před G2.
+
+## Navazující krok
+
+Pokračujte kuchařkou `02-priprava-miro-boardu.md` a poté gate G1.

--- a/docs/cookbooks/02-priprava-miro-boardu.md
+++ b/docs/cookbooks/02-priprava-miro-boardu.md
@@ -1,0 +1,45 @@
+# Kuchařka 02 — Příprava Miro boardu
+
+## Výsledek
+
+Board obsahuje navigační osu, frame pro relevantní fáze, legendy, instrukce, gate checklisty a metadata projektu.
+
+## Vstupy
+
+- validní `project.yaml`,
+- scaffold `ddda/scaffolds/strategic-ddd-method-board.yaml`,
+- Miro board přidělený pouze danému projektu,
+- seznam účastníků a plán workshopů.
+
+## Postup
+
+1. Ověřte, že board ID odpovídá projektu.
+2. Načtěte scaffold a zvolte workflow profile; nepovinné fáze lze skrýt, nikoli tiše odstranit z metodiky.
+3. Vytvořte horní navigaci Align → Discover → Process Modeling → Decompose → Strategize → Connect → Organize → Define → Code.
+4. Vytvořte frame podle souřadnic a velikostí scaffoldů.
+5. Do každého frame vložte cíl, vstupy, facilitační instrukci, legendu, pracovní oblast, otázky a gate.
+6. Označte frame metadata `project_id`, `stage`, `artifact_type=frame` a `scaffold_id`.
+7. Připravte parkoviště pro out-of-scope témata a oblast pro rozhodnutí.
+8. Zamkněte navigaci, legendy a instrukce; pracovní plochy nechte editovatelné.
+9. Proveďte dry-run synchronizace a uložte počáteční `miro-map.yaml`.
+10. Udělejte desetiminutovou technickou zkoušku s facilitátorem.
+
+## Kontroly
+
+- Big Picture ES je v Discover, nikoli v Define.
+- Process Modeling je explicitní most před Decompose.
+- Design-Level ES je až v Define a je vázán na konkrétní bounded context.
+- Lifecycle frames jsou na úrovních observed, candidate, validated a volitelně implementation.
+- Barvy odpovídají centrální legendě.
+
+## Chyby
+
+- jeden obří frame bez metodického toku,
+- import starého boardu bez stabilních ID,
+- metadata jsou pouze v textu sticky note,
+- zamknutá pracovní plocha nebo naopak odemčená legenda,
+- přepis workshopových poznámek automatickou synchronizací.
+
+## Navazující krok
+
+Proveďte G1 a naplánujte Big Picture EventStorming.

--- a/docs/cookbooks/03-big-picture-eventstorming.md
+++ b/docs/cookbooks/03-big-picture-eventstorming.md
@@ -1,0 +1,64 @@
+# Kuchařka 03 — Big Picture EventStorming
+
+## Výsledek
+
+Vznikne společný obraz významného end-to-end business dění, pracovní slovník, hotspoty, pivot events a pozorované životní cykly.
+
+## Předpoklady
+
+- G1 je splněn nebo podmíněně schválen,
+- účastní se business role s reálnou znalostí procesu,
+- scope workshopu je formulován businessově,
+- frame `big-picture-es` je připraven.
+
+## Role
+
+- facilitátor řídí postup a chrání business-first diskusi,
+- doménoví experti popisují fakta a výjimky,
+- zapisovatel spravuje otázky a rozhodnutí,
+- architekt sleduje hranice, pravidla a quality attributes, ale nenavrhuje služby.
+
+## Postup
+
+1. Připomeňte cíl, scope, časový limit a barevnou legendu.
+2. Účastníci zapisují samostatně významné doménové události v minulém čase.
+3. Události se řadí na časovou osu; duplicity se dočasně zachovají, pokud mohou vyjadřovat rozdílný význam.
+4. Doplňte časové události a externí spouštěče.
+5. Označte pivot events, které mění fázi procesu, odpovědnost nebo business riziko.
+6. Doplňte aktéry a externí systémy pouze tam, kde pomáhají porozumění.
+7. Červeně evidujte nejasnosti, výjimky, konfliktní jazyk a chybějící vlastníky.
+8. Projděte unhappy paths, ruční zásahy, storna a regulatorní scénáře.
+9. Identifikujte klíčové objekty s pozorovanými stavy; přesuňte je do frame observed lifecycles.
+10. Proveďte společný playback od začátku do konce.
+11. Povýšte stabilní poznámky na spravované artefakty; ostatní ponechte jako workshopové poznámky.
+12. Synchronizujte do YAML a vytvořte backlog otázek.
+
+## Facilitační otázky
+
+- Co se stalo předtím a jak to víme?
+- Co je business fakt a co pouze technická notifikace?
+- Kdo může tento výsledek zpochybnit nebo zvrátit?
+- Jaká výjimka je drahá, častá nebo regulatorně významná?
+- Používají dvě skupiny stejný pojem jinak?
+- Kdy se mění odpovědnost za data nebo rozhodnutí?
+
+## Definition of Done
+
+- hlavní tok lze přehrát jako srozumitelný příběh,
+- události jsou businessové a v minulém čase,
+- existuje explicitní seznam hotspotů,
+- důležité pojmy mají pracovní definice,
+- životní cykly jsou označeny jako observed, nikoli target,
+- nejasnosti mají ownera nebo plán validace.
+
+## Typické chyby
+
+- kreslení současné systémové architektury místo business dění,
+- nahrazování událostí stavovými hodnotami `StatusChanged`,
+- snaha vyřešit všechny hotspoty během jednoho workshopu,
+- předčasné zakreslení bounded contexts,
+- dominance jednoho technického účastníka.
+
+## Navazující krok
+
+Vyberte scénáře s vysokou hodnotou, nejistotou nebo rizikem a pokračujte Process Modelingem.

--- a/docs/cookbooks/04-process-modeling.md
+++ b/docs/cookbooks/04-process-modeling.md
@@ -1,0 +1,32 @@
+# Kuchařka 04 — Process Modeling
+
+## Výsledek
+
+Prioritní scénář je rozpracován do aktérů, akcí/commandů, rozhodovacích policies, externích systémů, událostí, read modelů, hodnoty a výjimek.
+
+## Postup
+
+1. Vyberte scénář podle business hodnoty, nejistoty nebo rizika.
+2. Definujte spouštěč, očekávaný výsledek a hranici scénáře.
+3. Vyznačte aktéra a jeho záměr.
+4. Přidejte command/action; používejte business jazyk.
+5. Doplňte UI pouze jako interakční bod, nikoli návrh obrazovky.
+6. U rozhodovacích míst popište policy/procedure a požadovaná fakta.
+7. Vyznačte externí systém pouze tam, kde má vlastní odpovědnost nebo kontrakt.
+8. Po každé významné změně zapište doménovou událost.
+9. Doplňte read model nebo informaci, kterou aktér potřebuje k rozhodnutí.
+10. Označte vytvořenou business hodnotu a náklady zpoždění/chyby.
+11. Projděte alternativy, timeouty, ruční zásahy a zamítnutí.
+12. Zapište signály pro kandidátní hranice: změna jazyka, pravidel, vlastníka, lifecycle nebo tempa změn.
+
+## Kontroly
+
+- model lze přečíst jako příčinný příběh,
+- policy není zaměněna za technický workflow engine,
+- read model neimplikuje databázovou tabulku,
+- technický endpoint není command bez business záměru,
+- hodnotu lze spojit s business cílem z Align.
+
+## Navazující krok
+
+Výsledky použijte v Decompose pro formulaci subdomén a boundary hypotheses.

--- a/docs/cookbooks/05-design-level-eventstorming.md
+++ b/docs/cookbooks/05-design-level-eventstorming.md
@@ -1,0 +1,48 @@
+# Kuchařka 05 — Design-Level EventStorming
+
+## Výsledek
+
+Uvnitř jednoho validovaného bounded contextu vznikne behaviorální model commandů, consistency boundaries/agregátů, invariantů, událostí, policies a projekcí.
+
+## Předpoklady
+
+- bounded context má jasnou odpovědnost, ownera a hranici,
+- Context Map a data ownership jsou alespoň pracovně schváleny,
+- je vybrán konkrétní business scénář,
+- účastní se doménový expert a vývojáři odpovědní za implementaci.
+
+## Postup
+
+1. Uveďte název bounded contextu, jeho odpovědnost a out-of-scope.
+2. Vezměte jeden scénář z Process Modelingu.
+3. Zapište command jako záměr aktéra nebo policy.
+4. Určete fakta potřebná pro rozhodnutí a jejich vlastníka.
+5. Navrhněte consistency boundary pouze pro pravidla, která musí být atomicky pravdivá.
+6. Formulujte invarianty jako testovatelné business věty.
+7. Zapište vzniklé doménové události v minulém čase.
+8. Doplňte policies, které reagují na události a mohou vyvolat další command.
+9. Doplňte projekce/read modely pro rozhodování a dotazy.
+10. Ověřte chybové scénáře, idempotenci, souběh a časové podmínky.
+11. Označte hranice konzistence, nikoli automaticky deployable služby.
+12. Přeneste rozhodnutí do YAML a relevantních ADR.
+
+## Kontrolní otázky
+
+- Musí být toto pravidlo pravdivé ihned, nebo stačí eventual consistency?
+- Který objekt je skutečným vlastníkem změny?
+- Je navržený agregát příliš velký kvůli pohodlí dotazu?
+- Není policy ve skutečnosti lidské rozhodnutí?
+- Je událost business fakt, nebo integrační obálka?
+- Co se stane při opakovaném commandu nebo doručení události?
+
+## Chyby
+
+- začít třídami, endpointy nebo databázovým schématem,
+- přenést jeden agregát přes více bounded contexts,
+- označit každou validaci jako invariant,
+- použít Design-Level ES k rozhodování o strategických hranicích,
+- zavést Event Sourcing jen proto, že model používá doménové události.
+
+## Navazující krok
+
+Validujte business lifecycle, vytvořte contract/invariant tests a ADR pro důležitá technická rozhodnutí.

--- a/docs/cookbooks/06-stavove-modely.md
+++ b/docs/cookbooks/06-stavove-modely.md
@@ -1,0 +1,79 @@
+# Kuchařka 06 — Stavové modely v metodickém toku
+
+## Výsledek
+
+Životní cyklus klíčového doménového objektu je dohledatelně rozvíjen od pozorované reality přes kandidátní a validovaný business model až k případné implementační state machine.
+
+## 1. Observed lifecycle — Discover
+
+Zachyťte pouze to, co je podloženo vstupy nebo zkušeností expertů:
+
+- pozorované stavy,
+- události nebo akce, které do nich vedou,
+- role oprávněné stav změnit,
+- výjimky a ruční zásahy,
+- zdroj evidence,
+- nejistotu.
+
+Neopravujte zde současnou realitu podle cílové představy.
+
+## 2. Candidate lifecycle — Decompose
+
+Použijte observed model jako vstup a formulujte hypotézu:
+
+- které stavy mají vlastní business význam,
+- kde se mění pravidla nebo odpovědnost,
+- zda jeden objekt neskrývá více nezávislých lifecycle,
+- které přechody jsou zakázané,
+- které lifecycle indikují hranici subdomény nebo bounded contextu.
+
+Každá změna proti observed modelu má důvod.
+
+## 3. Validated business state machine — Define
+
+S doménovým expertem schvalte:
+
+- počáteční a terminální stavy,
+- povolené přechody,
+- business command nebo rozhodnutí,
+- vzniklou událost,
+- preconditions a invarianty,
+- oprávněného aktéra,
+- časové a regulatorní podmínky.
+
+Model nesmí obsahovat technické retry, fronty nebo interní statusy, pokud nemají business význam.
+
+## 4. Implementation state machine — Code
+
+Vytvářejte pouze tehdy, pokud explicitní automat zlepšuje správnost, audit nebo srozumitelnost. Může obsahovat technické mezistavy, ale musí mapovat zpět na business model.
+
+Doplňte:
+
+- persistence a recovery,
+- souběh a idempotenci,
+- timeouty a retry,
+- observabilitu,
+- migraci existujících instancí,
+- testy zakázaných přechodů.
+
+## Povinná traceability
+
+```yaml
+artifact_id: lifecycle-policy-validated
+artifact_type: lifecycle
+maturity: validated
+supersedes: lifecycle-policy-candidate
+based_on:
+  - lifecycle-policy-observed
+validated_by:
+  - Head of Policy Operations
+validation_date: 2026-07-22
+```
+
+## Kontroly
+
+- stav není pouze hodnota z legacy databáze bez business významu,
+- přechod má příčinu a výsledný business fakt,
+- kandidátní model není označen jako validovaný,
+- implementační stav nemění význam business lifecycle,
+- dva bounded contexts nesdílejí jeden autoritativní stav bez jasného ownershipu.

--- a/docs/cookbooks/07-synchronizace-miro-yaml-git.md
+++ b/docs/cookbooks/07-synchronizace-miro-yaml-git.md
@@ -1,0 +1,69 @@
+# Kuchařka 07 — Synchronizace Miro, YAML a Git
+
+## Výsledek
+
+Změny jsou bezpečně přeneseny mezi Mirem a YAML, konflikty jsou explicitní a Git obsahuje auditovatelný commit.
+
+## Předpoklady
+
+- projekt má validní manifest,
+- board mapping patří správnému projektu,
+- Miro token je v prostředí,
+- pracovní větev je čistá,
+- před write operací byl proveden pull nebo kontrola board revision.
+
+## Doporučený rytmus
+
+### Před workshopem
+
+1. Pull z Gitu.
+2. Validace YAML.
+3. Dry-run push do Mira.
+4. Push scaffoldů a posledních schválených artefaktů.
+5. Kontrola board revision a mapování.
+
+### Po workshopu
+
+1. Uzavřete aktivní editaci boardu.
+2. Proveďte dry-run pull.
+3. Zkontrolujte nové, změněné, smazané a nespravované objekty.
+4. Vyřešte strukturální chyby a konflikty.
+5. Povýšte relevantní workshopové poznámky na artefakty.
+6. Vygenerujte Mermaid výstupy.
+7. Zkontrolujte diff.
+8. Commitněte se zdrojem workshopu a board revision.
+9. Otevřete pull request pro významné sémantické změny.
+
+## Řešení konfliktu
+
+1. Neprovádějte další push.
+2. Otevřete conflict record.
+3. Porovnejte base, YAML a Miro hodnotu.
+4. Určete sémantického ownera pole.
+5. Zvolte accept YAML, accept Miro nebo manual merge.
+6. Zapište důvod a řešitele.
+7. Validujte a proveďte nový dry-run.
+8. Conflict record ponechte jako auditní stopu.
+
+## Mazání
+
+Nepoužívejte okamžité hard delete. Nejprve nastavte tombstone, ověřte odkazy a ownership, teprve poté potvrďte odstranění.
+
+## Kontroly
+
+- nulový diff při opakovaném běhu,
+- žádná změna `artifact_id`,
+- nespravované Miro objekty zůstaly zachovány,
+- Mermaid odpovídá YAML,
+- token ani citlivý obsah není v logu,
+- commit zpráva uvádí projekt a zdroj změny.
+
+## Příklad commit message
+
+```text
+sync(life-insurance): import Big Picture ES workshop 2026-07-22
+
+Board revision: 18731
+Validated by: Product Director, Head of Underwriting
+Conflicts resolved: 2
+```

--- a/docs/cookbooks/08-gate-review.md
+++ b/docs/cookbooks/08-gate-review.md
@@ -1,0 +1,62 @@
+# Kuchařka 08 — Gate review
+
+## Výsledek
+
+Vznikne explicitní rozhodnutí `pass`, `conditional-pass` nebo `fail`, včetně evidence, podmínek, vlastníků a termínů.
+
+## Příprava
+
+1. Určete gate a rozhodnutí, které má umožnit.
+2. Připravte odkazy na artefakty a změny od poslední revize.
+3. Ověřte strukturální validaci.
+4. Seznamte otevřené konflikty, rizika a assumptions.
+5. Pozvěte business ownera, architektonického ownera a relevantní experty.
+
+## Agenda 45 minut
+
+- 5 min: cíl a rozhodovací práva,
+- 10 min: playback hlavních závěrů,
+- 10 min: evidence a změny,
+- 10 min: rizika, konflikty a neznámé,
+- 5 min: checklist,
+- 5 min: rozhodnutí a akce.
+
+## Rozhodnutí
+
+### Pass
+
+Kritéria jsou splněna a nejsou známé blokující nejistoty.
+
+### Conditional pass
+
+Lze pokračovat, ale podmínky mají explicitního ownera, termín a definovaný dopad při nesplnění.
+
+### Fail
+
+Podklady nestačí pro zamýšlené rozhodnutí. Review určí konkrétní doplnění; nejde o obecný požadavek „udělat více analýzy“.
+
+## Záznam
+
+```yaml
+gate: G5
+project_id: life-insurance-greenfield
+decision: conditional-pass
+date: 2026-07-22
+decision_owner: Chief Architect
+conditions:
+  - action: Potvrdit ownership klientských kontaktních údajů.
+    owner: Customer Director
+    due: 2026-07-29
+    blocking_for: G7
+evidence:
+  - artifacts/connect/context-map.yaml
+  - artifacts/connect/data-ownership.yaml
+```
+
+## Chyby
+
+- gate schvaluje pouze architekt bez business ownera,
+- checklist nahrazuje diskusi o rizicích,
+- conditional pass nemá termín,
+- neexistuje odkaz na konkrétní revizi artefaktů,
+- kandidátní model je přejmenován na validovaný bez evidence.

--- a/docs/cookbooks/09-pridani-typu-projektu.md
+++ b/docs/cookbooks/09-pridani-typu-projektu.md
@@ -1,0 +1,28 @@
+# Kuchařka 09 — Přidání typu projektu
+
+## Výsledek
+
+Vznikne nový konzistentní workflow profil, který nemění stávající projekty a má dokumentaci, scaffoldové odchylky, gate pravidla a referenční použití.
+
+## Postup
+
+1. Popište problém, který stávající typy nepokrývají.
+2. Ověřte, zda nestačí `workflow.extensions`.
+3. Zvolte kanonický název a legacy aliases.
+4. Definujte kdy typ použít a kdy jej nepoužít.
+5. Určete povinné, volitelné a vynechané fáze; každé vynechání zdůvodněte.
+6. Doplňte specifické vstupy, rizika, artefakty a gates.
+7. Určete změny Miro scaffoldů bez duplikace celého boardu.
+8. Aktualizujte katalog typů, schema enum/profil a bootstrap validaci.
+9. Přidejte varianty do dotčených kuchařek.
+10. Přidejte minimální referenční projekt nebo fixture.
+11. Ověřte zpětnou kompatibilitu existujících manifestů.
+
+## Kontroly
+
+- typ není pojmenován podle technologie,
+- profil řeší odlišný rozhodovací problém, ne pouze jiné názvosloví,
+- aliases jsou mapovány na jeden kanonický typ,
+- gate kritéria jsou rozhodnutelná,
+- nový typ má alespoň jeden příklad a negativní příklad,
+- dokumentace, schema a kuchařky jsou změněny v jednom pull requestu.

--- a/docs/cookbooks/10-legacy-modernizace.md
+++ b/docs/cookbooks/10-legacy-modernizace.md
@@ -1,0 +1,58 @@
+# Kuchařka 10 — Legacy modernizace
+
+## Výsledek
+
+Vznikne businessově ukotvený modernizační plán s cílovými hranicemi, seams, přechodnými stavy, ownershipem dat, migračními slices, observabilitou a rollbackem.
+
+## Předpoklady
+
+- je znám business důvod modernizace,
+- je dostupná alespoň minimální provozní a technická evidence,
+- stakeholderům je jasné, že cílem není automaticky přepis 1:1,
+- kontinuita provozu a regulatorní omezení jsou explicitní.
+
+## Postup
+
+1. V Align formulujte měřitelné business a provozní cíle modernizace.
+2. Oddělte business Big Picture ES od technického runtime flow legacy systému.
+3. Inventarizujte faktické vlastníky dat, batch procesy, integrační body a manuální workarounds.
+4. Identifikujte change coupling, runtime coupling a knowledge ownership.
+5. V Decompose navrhněte cílové doménové hranice podle jazyka, pravidel a lifecycle; ne podle modulů legacy aplikace.
+6. V Connect určete transitional contracts, anti-corruption layers a dočasné system-of-record.
+7. Vyberte seams, které umožní odebrat business slice end-to-end.
+8. Seřaďte slices podle business hodnoty, rizika, závislostí a schopnosti měřit výsledek.
+9. Pro každý slice definujte dual-run/parallel-run potřebu, migraci dat, reconcile, rollback a observabilitu.
+10. Zaveďte fitness functions pro snižování coupling a odstraňování dočasných vazeb.
+11. Evidujte přechodné bounded contexts a datum/condition jejich zániku.
+12. Po každém slice aktualizujte Context Map, data ownership a provozní evidence.
+
+## Povinné artefakty
+
+- as-is evidence map,
+- observed business lifecycle,
+- current data ownership a system-of-record,
+- target Context Map,
+- transition Context Map,
+- seam catalog,
+- migration slice backlog,
+- risk and rollback plan,
+- observability plan,
+- ADR pro významné kompromisy.
+
+## Kontroly
+
+- každý slice přináší business nebo provozní hodnotu,
+- nevzniká dlouhodobě sdílená databáze jako skrytý integrační kontrakt,
+- dual-write má vlastníka, reconcile a konečné datum,
+- přechodné řešení má exit criteria,
+- nový model není kolonizován názvy a omezeními legacy systému bez důvodu,
+- organizace má tým schopný převzít ownership nového kontextu.
+
+## Typické chyby
+
+- přepis obrazovku po obrazovce bez změny hranic,
+- extrakce mikroservis podle tabulek,
+- big-bang migrace bez business nutnosti,
+- ignorování historických dat a reportingu,
+- dočasná integrace bez plánu odstranění,
+- cílový model bez plánu přechodu.

--- a/docs/cookbooks/README.md
+++ b/docs/cookbooks/README.md
@@ -1,0 +1,42 @@
+# Kuchařky DDDA
+
+Kuchařky jsou provozní návody krok za krokem. Metodická dokumentace vysvětluje proč a kdy; kuchařka říká co připravit, co udělat, jak ověřit výsledek a co dělat při problému.
+
+## Katalog
+
+| Kuchařka | Použijte, když |
+|---|---|
+| [01 — Založení projektu](01-zalozeni-projektu.md) | vytváříte nový izolovaný projekt v existující instalaci |
+| [02 — Příprava Miro boardu](02-priprava-miro-boardu.md) | potřebujete založit scaffold a připravit workshop |
+| [03 — Big Picture EventStorming](03-big-picture-eventstorming.md) | facilitujete doménové discovery napříč end-to-end tokem |
+| [04 — Process Modeling](04-process-modeling.md) | rozpracováváte prioritní scénář a rozhodování |
+| [05 — Design-Level EventStorming](05-design-level-eventstorming.md) | navrhujete chování uvnitř validovaného bounded contextu |
+| [06 — Stavové modely](06-stavove-modely.md) | převádíte observed lifecycle na candidate, validated a případně implementation model |
+| [07 — Synchronizace](07-synchronizace-miro-yaml-git.md) | přenášíte změny mezi Mirem a YAML/Gitem |
+| [08 — Gate review](08-gate-review.md) | potvrzujete připravenost k dalšímu kroku |
+| [09 — Přidání typu projektu](09-pridani-typu-projektu.md) | rozšiřujete DDDA o nový workflow profil |
+| [10 — Legacy modernizace](10-legacy-modernizace.md) | připravujete seams, strangler slices a přechodné stavy |
+
+## Standardní struktura kuchařky
+
+Každá kuchařka má:
+
+1. účel a očekávaný výsledek,
+2. předpoklady,
+3. vstupy,
+4. role,
+5. postup,
+6. kontrolní body,
+7. výstupy a jejich umístění,
+8. typické chyby,
+9. varianty podle typu projektu,
+10. navazující krok.
+
+## Pravidlo konzistence
+
+Při změně metodického toku, scaffoldů, schémat nebo synchronizačního kontraktu je nutné ve stejném pull requestu aktualizovat:
+
+- produktovou dokumentaci,
+- dotčené kuchařky,
+- referenční příklad,
+- validační schéma nebo test, pokud se mění formát.

--- a/docs/methodology/01-metodicky-tok-a-gates.md
+++ b/docs/methodology/01-metodicky-tok-a-gates.md
@@ -1,0 +1,108 @@
+# Metodický tok a gates
+
+## Princip
+
+DDDA používá evoluční tok. Každá fáze snižuje jiný typ nejistoty. Gate potvrzuje dostatečnost podkladů pro další rozhodnutí; nepotvrzuje absolutní správnost modelu.
+
+## Tok
+
+### Align
+
+**Otázka:** Proč tuto práci děláme a jaké rozhodnutí má umožnit?
+
+Výstupy: business problém, cíle, scope, aktéři, constraints, assumptions, prioritní quality attributes, inventory vstupů.
+
+Gate G1: scope, sponsor, experti a očekávané rozhodnutí jsou explicitní.
+
+### Discover
+
+**Otázka:** Co se v doméně skutečně děje a jak o tom lidé mluví?
+
+Výstupy: Big Picture ES, slovník, aktéři, systémy, hotspoty, pozorované životní cykly.
+
+Gate G2: end-to-end tok je dostatečně pokrytý a klíčové nejistoty jsou viditelné.
+
+### Process Modeling
+
+**Otázka:** Jak probíhají prioritní scénáře, rozhodnutí, výjimky a tvorba hodnoty?
+
+Výstupy: process models a katalog scénářů. Fáze nemá samostatný povinný gate; její výsledky vstupují do G3.
+
+### Decompose
+
+**Otázka:** Kde se mění jazyk, pravidla, lifecycle, data ownership nebo tempo změn?
+
+Výstupy: kandidátní subdomény, boundary hypotheses, kandidátní životní cykly.
+
+Gate G3: hypotézy hranic mají důvody, nejistoty a validační plán.
+
+### Strategize
+
+**Otázka:** Kde se podnik diferencuje a kam má investovat?
+
+Výstupy: Core/Supporting/Generic, diferenciace × komplexita, sourcing a evoluční strategie.
+
+Gate G4: klasifikace má business zdůvodnění a vlastníka.
+
+### Connect
+
+**Otázka:** Jaké modelové hranice potřebujeme a jak spolu budou komunikovat?
+
+Výstupy: bounded contexts, context map, data ownership, kontrakty, relationship patterns.
+
+Gate G5: směry vztahů, ownership a očekávání kontraktů jsou explicitní.
+
+### Organize
+
+**Otázka:** Kdo vlastní změnu a jaké týmové interakce jsou potřeba?
+
+Výstupy: team topology, interaction modes, cognitive load, governance a fitness functions.
+
+Gate G6: prioritní hranice mají vlastníka nebo explicitní organizační gap.
+
+### Define
+
+**Otázka:** Jak se prioritní bounded context chová a jaká pravidla musí chránit?
+
+Výstupy: Bounded Context Canvas, Design-Level ES, agregátní/consistency boundaries, invarianty, validované business lifecycle, quality attribute scénáře a ADR.
+
+Gate G7: model je validován doménovým expertem a připraven na implementační rozhodnutí.
+
+### Code
+
+**Otázka:** Jak model převést do bezpečně evolvující implementace?
+
+Výstupy: implementační hranice, kontrakty, testy invariantů, případné state machines, observabilita, migrační slices a rollback.
+
+Gate G8: implementace a migrace mají testovatelný kontrakt, rizika a provozní strategii.
+
+## Pravidla přechodu
+
+- Fáze lze iterovat a vracet se zpět.
+- Přeskočení fáze musí být zdůvodněno v decision logu.
+- Gate lze schválit podmíněně; podmínky mají ownera a termín.
+- Model s `candidate` statusem se nesmí prezentovat jako schválená cílová architektura.
+- Technologická volba před G5 je výjimka vyžadující constraint nebo experimentální hypotézu.
+
+## Evidence
+
+Každé důležité tvrzení má obsahovat alespoň jeden typ evidence:
+
+- workshop a seznam validujících účastníků,
+- konkrétní zdrojový dokument,
+- kód nebo databázové schéma,
+- provozní měření,
+- regulatorní požadavek,
+- explicitní rozhodnutí vlastníka.
+
+## Gate review
+
+Gate review má 30–60 minut a používá strukturu:
+
+1. rozhodnutí, které má gate umožnit,
+2. změny od minulé revize,
+3. evidence,
+4. otevřené konflikty a rizika,
+5. checklist,
+6. rozhodnutí: pass / conditional pass / fail,
+7. vlastníci akcí.

--- a/docs/product/01-architektura-ddda.md
+++ b/docs/product/01-architektura-ddda.md
@@ -1,0 +1,161 @@
+# Architektura produktu DDDA
+
+## 1. Účel a hranice produktu
+
+DDDA koordinuje doménové discovery, strategický a taktický DDD návrh, socio-technické rozhodování a přípravu implementace. Nejde o CASE nástroj, náhradu architekta ani generátor mikroservis. Produkt poskytuje konzistentní pracovní tok, strukturované artefakty, vizuální scaffoldy, validaci a dohledatelnost rozhodnutí.
+
+## 2. Architektonické cíle
+
+Prioritní quality attributes:
+
+| Quality attribute | Požadavek | Architektonický mechanismus |
+|---|---|---|
+| Konzistence | Stejný pojem a artefakt nesmí mít nekontrolovaně různé reprezentace | stabilní `artifact_id`, YAML schémata, explicitní konflikty |
+| Auditovatelnost | Musí být dohledatelné kdo, kdy a proč změnu provedl | Git historie, zdroj artefaktu, validační záznam |
+| Modifikovatelnost | Musí být možné přidávat typy projektů, artefaktů a scaffoldů | deklarativní YAML, verze schémat, adaptéry |
+| Přenositelnost | Model nesmí být uzamčen v Miru | YAML jako kanonický sémantický formát, Mermaid export |
+| Spolupráce | Workshop musí být snadný pro business i IT | Miro-first interakce, české instrukce, legendy a facilitační kroky |
+| Izolace projektů | Projekty nesmí sdílet stav ani artefakty bez explicitního odkazu | samostatný adresář, manifest, board a namespace ID |
+| Bezpečnost | Tokeny a citlivé podklady nesmí být commitovány | environment variables, `.gitignore`, omezené scope tokenů |
+
+## 3. Logické komponenty
+
+### 3.1 Workspace Registry
+
+Eviduje projekty v jedné instalaci. Každý projekt má:
+
+- stabilní `project_id`,
+- typ projektu,
+- vlastní Miro board nebo explicitně přidělenou board area,
+- vlastní adresář artefaktů,
+- vlastní synchronizační stav,
+- vlastní gates a rozhodnutí.
+
+Registry neobsahuje doménová data projektů; pouze odkazy a provozní metadata.
+
+### 3.2 Project Workspace
+
+Izolovaná jednotka práce. Obsahuje manifest, vstupy, artefakty, Mermaid výstupy, ADR, synchronizační stav a audit. Projekt může používat sdílené šablony, ale nesmí přímo měnit artefakty jiného projektu.
+
+### 3.3 Artifact Model
+
+Kanonická sémantická reprezentace. Každý spravovaný artefakt obsahuje minimálně:
+
+```yaml
+artifact_id: bc-policy-administration
+artifact_type: bounded_context
+schema_version: 1.0.0
+project_id: life-insurance-greenfield
+stage: define
+status: validated
+name: Správa pojistných smluv
+source:
+  kind: workshop
+  references:
+    - miro:board-id/frame-id
+ownership:
+  business_owner: Head of Policy Operations
+  team: policy-team
+revision:
+  git_commit: null
+  miro_modified_at: null
+```
+
+### 3.4 Miro Scaffold Renderer
+
+Z deklarativní definice vytváří:
+
+- navigační osu metodického toku,
+- frame pro jednotlivé fáze,
+- legendy a instrukce,
+- pracovní plochy pro workshop,
+- gate checklisty,
+- metadata pro synchronizaci.
+
+Renderer nesmí do scaffoldů zakódovat konkrétní doménové závěry.
+
+### 3.5 Synchronization Engine
+
+Porovnává sémantický stav YAML s objekty v Miru. Rozlišuje:
+
+- sémantická pole,
+- vizuální pole,
+- lokální workshopové poznámky,
+- odvozené výstupy.
+
+Nevyřešený souběžný konflikt se nikdy automaticky nepřepisuje. Vznikne conflict record k lidskému rozhodnutí.
+
+### 3.6 Mermaid Renderer
+
+Generuje textové pohledy pro:
+
+- context map,
+- lifecycle/state diagram,
+- team topology,
+- zjednodušený EventStorming flow,
+- integrační pohled.
+
+Mermaid je odvozený výstup; ruční změny generovaného souboru se nepovažují za změnu zdrojového modelu.
+
+### 3.7 Validation and Gate Engine
+
+Provádí dvě úrovně kontroly:
+
+1. **strukturální validaci** proti JSON Schema,
+2. **metodickou validaci** podle gate kritérií.
+
+Gate není automatické tvrzení, že je model správný. Potvrzuje, že existuje dostatečný a explicitně validovaný podklad pro další krok.
+
+## 4. Tok dat
+
+```mermaid
+flowchart LR
+    U[Účastníci workshopu] --> M[Miro board]
+    A[Architekt / agent] --> Y[YAML artefakty]
+    M <--> S[Sync engine]
+    S <--> Y
+    Y --> V[Schema a gate validace]
+    Y --> R[Mermaid renderer]
+    Y --> G[Git]
+    G --> CR[Review / pull request]
+```
+
+## 5. Vlastnictví dat
+
+| Druh informace | Zdroj pravdy | Poznámka |
+|---|---|---|
+| Název, význam, vztahy a stav artefaktu | YAML | sémantická data |
+| Pozice, velikost, barva a seskupení | Miro | vizuální data |
+| Historie změn | Git | audit a review |
+| Ad-hoc poznámky během workshopu | Miro | po triage se povyšují do YAML nebo zahodí |
+| Mermaid diagram | generovaný soubor | nepřepisovat ručně |
+| Rozhodnutí o konfliktu | conflict record + Git commit | explicitní lidská volba |
+
+## 6. Rozšiřitelnost
+
+Nový artefakt vyžaduje:
+
+1. definici typu a povinných polí,
+2. JSON Schema,
+3. mapování na Miro widgety,
+4. pravidla synchronizace,
+5. případný Mermaid renderer,
+6. metodické umístění a gate pravidla,
+7. kuchařku nebo rozšíření existující kuchařky.
+
+Nový typ projektu vyžaduje profil workflow, povinné a volitelné fáze, gate pravidla, doporučené vstupy, rizika a aliases.
+
+## 7. Bezpečnost a provoz
+
+- Miro token se načítá pouze z prostředí nebo bezpečného secret store.
+- Doporučené scope jsou nejmenší možné pro čtení a zápis konkrétních boardů.
+- Vstupní dokumenty mohou obsahovat citlivá data; projekt určuje klasifikaci a pravidla ukládání.
+- Log synchronizace nesmí obsahovat tokeny ani celé citlivé texty.
+- Automatizace musí podporovat dry-run.
+
+## 8. Architektonická omezení
+
+- Miro API a jeho datový model se mohou měnit; integrace musí být adaptér za interním kontraktem.
+- Absolutní vizuální shoda Miro a Mermaid není cílem.
+- Automatická inference bounded contexts, agregátů nebo invariantů je návrh k validaci, nikoli autoritativní rozhodnutí.
+- Živá synchronizace vyžaduje konkrétní Miro aplikaci, autentizaci a webhook/polling provozní konfiguraci.

--- a/docs/product/02-workspace-a-projekty.md
+++ b/docs/product/02-workspace-a-projekty.md
@@ -1,0 +1,129 @@
+# Workspace a více projektů
+
+## 1. Cíl
+
+Jedna rozbalená instalace DDDA musí obsloužit více nezávislých iniciativ bez kopírování metodiky a nástrojů. Sdílí se produktové šablony, schémata a nástroje; nesdílí se projektová fakta, synchronizační stav ani rozhodnutí.
+
+## 2. Doporučená struktura
+
+```text
+projects/
+└── <project-slug>/
+    ├── project.yaml
+    ├── inputs/
+    ├── artifacts/
+    │   ├── align/
+    │   ├── discover/
+    │   ├── decompose/
+    │   ├── strategize/
+    │   ├── connect/
+    │   ├── organize/
+    │   ├── define/
+    │   └── code/
+    ├── diagrams/
+    │   └── generated/
+    ├── decisions/
+    ├── workshops/
+    ├── sync/
+    │   ├── miro-map.yaml
+    │   ├── sync-state.yaml
+    │   └── conflicts/
+    └── README.md
+```
+
+## 3. Project manifest
+
+`project.yaml` je vstupním bodem projektu.
+
+```yaml
+schema_version: 1.0.0
+project_id: life-insurance-greenfield
+name: Greenfield životní pojišťovna
+project_type: greenfield-portfolio
+language: cs
+status: active
+miro:
+  board_id_env: DDDA_LIFE_MIRO_BOARD_ID
+  board_url: null
+workflow:
+  profile: greenfield-portfolio
+  current_stage: discover
+  completed_gates: [G1]
+repositories:
+  primary: .
+classification:
+  data_sensitivity: confidential
+owners:
+  business_sponsor: CEO
+  architecture_owner: Chief Architect
+```
+
+Board ID se doporučuje načítat z prostředí; veřejný manifest nemá obsahovat token.
+
+## 4. Identita a namespace
+
+`project_id`:
+
+- je stabilní a nemění se při přejmenování projektu,
+- používá formát lowercase kebab-case,
+- tvoří namespace všech `artifact_id`,
+- nesmí být opakovaně použit pro jinou iniciativu.
+
+`artifact_id` musí být unikátní alespoň v rámci projektu. Pro externí odkazy se používá plný tvar:
+
+```text
+ddda:<project_id>:<artifact_type>:<artifact_id>
+```
+
+## 5. Izolace
+
+Zakázané implicitní vazby:
+
+- jeden `sync-state.yaml` pro více projektů,
+- jeden Miro frame spravovaný dvěma projekty,
+- přímý relativní odkaz do `artifacts/` jiného projektu,
+- sdílený artefakt bez explicitního ownera.
+
+Sdílení se realizuje přes publikovaný kontrakt nebo referenci:
+
+```yaml
+external_reference:
+  project_id: customer-identity-platform
+  artifact_id: bc-customer-identity
+  contract_version: 2.1.0
+```
+
+## 6. Životní cyklus projektu
+
+| Stav | Význam |
+|---|---|
+| proposed | manifest existuje, scope není schválen |
+| active | probíhá práce |
+| paused | práce je dočasně zastavena |
+| completed | cílové gates byly dosaženy |
+| archived | artefakty jsou pouze pro čtení |
+
+Archivace nezruší historii ani odkazy. Miro board může být uzamčen, ale YAML a Git historie zůstávají autoritativní.
+
+## 7. Branching a review
+
+Doporučení:
+
+- menší změny: feature branch a pull request,
+- workshopový import: samostatný commit se zdrojovým Miro revision,
+- konflikty: samostatný commit s odkazem na conflict record,
+- gate approval: tag nebo podepsaný ADR/checkpoint commit.
+
+## 8. Bootstrap nového projektu
+
+Bootstrap musí:
+
+1. validovat unikátnost `project_id`,
+2. vytvořit adresářovou strukturu,
+3. zapsat manifest,
+4. zvolit workflow profile,
+5. připravit Miro mapping bez tokenu,
+6. vytvořit počáteční README a backlog otázek,
+7. spustit strukturální validaci.
+
+Podrobný postup je v kuchařce `docs/cookbooks/01-zalozeni-projektu.md`.

--- a/docs/product/03-miro-scaffolding.md
+++ b/docs/product/03-miro-scaffolding.md
@@ -1,0 +1,104 @@
+# Miro scaffolding
+
+## Účel
+
+Scaffold není výsledný doménový model. Je to řízená pracovní plocha, která účastníkům ukazuje, kde se v metodickém toku nacházejí, jaký typ otázky právě řeší, jaké artefakty mají vzniknout a jaká validační brána následuje.
+
+## Zásady návrhu boardu
+
+1. Tok je zleva doprava a vždy viditelný v horní navigaci.
+2. Každá fáze má vlastní frame, cíl, vstupy, instrukce, pracovní plochu a gate.
+3. Barvy mají stabilní význam napříč všemi projekty.
+4. Workshopové poznámky nejsou automaticky považovány za kanonické artefakty.
+5. Kandidátní a validované modely jsou vizuálně i metadatově odlišeny.
+6. Stavové diagramy nejsou jednorázový výstup; jejich zralost se mění v toku.
+
+## Umístění EventStormingu
+
+### Big Picture EventStorming — Discover
+
+Cíl: společné pochopení end-to-end business dění.
+
+Používat:
+
+- doménové události,
+- časové události,
+- pivot events,
+- aktéry a externí systémy,
+- hotspoty,
+- horizontální časovou osu.
+
+Nepoužívat zde agregáty, databáze ani návrh služeb.
+
+### Process Modeling — mezi Discover a Decompose
+
+Cíl: rozpracovat vybrané scénáře a rozhodování.
+
+Doporučená sekvence:
+
+```text
+Actor → Command/Action → UI → Policy/Procedure → External System → Event → Read Model → Value
+```
+
+Jde o most mezi širokým Big Picture pohledem a dekompozičními hypotézami. Nejde ještě o taktický návrh.
+
+### Design-Level EventStorming — Define
+
+Cíl: modelovat chování uvnitř konkrétního bounded contextu.
+
+Doporučená sekvence:
+
+```text
+Actor → Command → Aggregate/Consistency Boundary → Invariant → Domain Event
+      → Policy/Procedure → Command → Projection/Read Model
+```
+
+Design-Level ES musí navazovat na validovaný scope bounded contextu. Nesmí sloužit k dodatečnému maskování nejasných strategických hranic.
+
+## Stavové diagramy v metodickém toku
+
+| Fáze | Varianta | Otázka |
+|---|---|---|
+| Discover | observed | Jaké stavy a přechody dnes skutečně pozorujeme? |
+| Decompose | candidate | Jaké životní cykly naznačují odlišné modely nebo hranice? |
+| Define | validated | Jaký business state machine doménový expert schvaluje? |
+| Code | implementation | Je explicitní implementační automat potřebný a jak mapuje business model? |
+
+Přechod mezi úrovněmi není kopie. Každá další úroveň musí obsahovat zdůvodněné změny a odkazy na předchozí artefakt.
+
+## Struktura frame
+
+Každý spravovaný frame má:
+
+- identifikátor,
+- název a metodickou fázi,
+- cíl,
+- vstupy,
+- instrukci pro facilitátora,
+- legendu,
+- pracovní plochu,
+- oblast pro otázky a rozhodnutí,
+- gate checklist,
+- metadata synchronizace.
+
+## Spravované a nespravované objekty
+
+**Spravovaný objekt** má `artifact_id` a mapuje se do YAML. Synchronizace smí měnit jeho sémantický obsah podle pravidel.
+
+**Nespravovaný objekt** je dočasná workshopová poznámka, obrázek, hlasování nebo komentář. Synchronizace jej zachová, dokud jej člověk nepovýší na artefakt nebo neodstraní.
+
+## Povýšení workshopové poznámky
+
+1. Facilitátor označí poznámku jako kandidátní artefakt.
+2. Doplní typ, název, zdroj a status.
+3. Sync vytvoří YAML se stabilním `artifact_id`.
+4. Git review potvrdí nebo upraví sémantiku.
+5. Objekt v Miru obdrží `yaml_path` a `git_revision`.
+
+## Vizuální konvence
+
+Barvy jsou definovány v `ddda/scaffolds/strategic-ddd-method-board.yaml`. Barva pomáhá orientaci, ale není jediným nositelem významu. Typ artefaktu musí být vždy uložen i v metadatech a textovém označení.
+
+## Praktické omezení
+
+Miro je vhodné pro facilitaci a prostorové vztahy, nikoli jako jediný auditovatelný repozitář sémantiky. Proto se business význam, ownership, status a vztahy ukládají do YAML a verzují v Gitu.

--- a/docs/product/04-synchronizace.md
+++ b/docs/product/04-synchronizace.md
@@ -1,0 +1,159 @@
+# Synchronizace Miro ↔ YAML ↔ Git
+
+## 1. Cíl
+
+Synchronizace udržuje jednu doménovou informaci ve dvou pracovních reprezentacích:
+
+- Miro pro lidskou spolupráci, prostorové uspořádání a facilitaci,
+- YAML pro sémantiku, automatizaci, validaci a verzování.
+
+Git není třetí editovatelná reprezentace; je transportem, historií a review mechanismem YAML souborů.
+
+## 2. Rozdělení ownershipu
+
+| Pole | Owner |
+|---|---|
+| `name`, `description`, `status`, vztahy, ownership, evidence | YAML |
+| souřadnice, rozměry, z-index, vizuální seskupení | Miro |
+| barva | odvozená z typu; lokální override jen pokud je povolen |
+| komentáře a hlasování | Miro |
+| historie změn | Git |
+| Mermaid | generovaný výstup |
+
+Změna sémantiky v Miru je povolena, ale po importu se stává návrhem změny YAML a musí projít validací a případně review.
+
+## 3. Identita objektu
+
+Každý spravovaný Miro objekt nese minimálně:
+
+```yaml
+artifact_id: evt-policy-issued
+artifact_type: domain_event
+project_id: life-insurance-greenfield
+schema_version: 1.0.0
+stage: discover
+status: observed
+yaml_path: artifacts/discover/events/evt-policy-issued.yaml
+git_revision: 3f83a1d
+```
+
+Miro item ID není doménová identita. Při smazání a znovuvytvoření objektu se může změnit, zatímco `artifact_id` zůstává stabilní.
+
+## 4. Synchronizační cyklus
+
+### Pull z Mira
+
+1. Načti board revision a spravované objekty.
+2. Porovnej je s `miro-map.yaml` a posledním sync stavem.
+3. Rozděl změny na vizuální, sémantické, nové a smazané.
+4. Pro sémantické změny vytvoř nebo uprav YAML návrh.
+5. Validuj schéma a metodická pravidla.
+6. Ulož conflict records, pokud obě strany změnily stejné pole.
+7. Vygeneruj Mermaid a sync report.
+8. Commit provede člověk nebo schválená automatizace.
+
+### Push do Mira
+
+1. Validuj projekt a YAML.
+2. Načti aktuální board revision.
+3. Ověř, že od posledního pullu nevznikla neočekávaná změna.
+4. Vytvoř nebo aktualizuj spravované objekty.
+5. Zachovej vizuální vlastnosti vlastněné Mirem.
+6. Aktualizuj metadata a `miro-map.yaml`.
+7. Zapiš sync report.
+
+## 5. Detekce konfliktu
+
+Konflikt nastane, pokud se od společné base revision změnilo stejné sémantické pole na obou stranách.
+
+Příklad:
+
+```yaml
+conflict_id: conflict-2026-07-22-001
+artifact_id: bc-policy-administration
+field: description
+base: Spravuje životní cyklus pojistné smlouvy.
+yaml_value: Spravuje nabídku, vznik a změny smlouvy.
+miro_value: Spravuje aktivní pojistné smlouvy.
+resolution: pending
+owner: architecture-owner
+```
+
+Povolená řešení:
+
+- `accept_yaml`,
+- `accept_miro`,
+- `merge_manual`,
+- `supersede_artifact`.
+
+Last-write-wins je zakázán pro sémantická pole.
+
+## 6. Mazání
+
+Používá se tombstone-first:
+
+1. objekt dostane `status: deprecated` nebo `deleted_pending`,
+2. synchronizace upozorní na příchozí a odchozí odkazy,
+3. člověk potvrdí odstranění,
+4. YAML zůstane v Git historii,
+5. Miro objekt se odstraní nebo přesune do archivu.
+
+## 7. Idempotence
+
+Opakovaný pull nebo push bez mezilehlé změny nesmí vytvářet nové artefakty, měnit identifikátory ani posouvat prvky. Sync report musí uvádět nulový diff.
+
+## 8. Dry-run
+
+Každá write operace musí podporovat `--dry-run`. Výstup obsahuje:
+
+- počet nových, změněných a odstraněných objektů,
+- seznam dotčených YAML souborů,
+- konflikty,
+- validační chyby,
+- předpokládané Miro API operace.
+
+## 9. Miro mapping
+
+`sync/miro-map.yaml` mapuje identitu a vizuální stav:
+
+```yaml
+board_id: ${DDDA_LIFE_MIRO_BOARD_ID}
+board_revision: '18731'
+items:
+  evt-policy-issued:
+    miro_item_id: '3458764512345'
+    frame_id: big-picture-es
+    x: 1220
+    y: 840
+    width: 220
+    height: 140
+```
+
+## 10. Webhook versus polling
+
+- Webhook je vhodný pro rychlou detekci změn, ale událost nemusí obsahovat celý stav.
+- Polling je jednodušší pro lokální provoz a obnovu po výpadku.
+- Doporučený návrh: webhook označí projekt jako dirty; worker následně provede idempotentní pull.
+
+První implementace může používat pouze řízený pull/push z CLI. To omezuje provozní složitost a umožňuje ověřit model konfliktů před automatizací.
+
+## 11. Bezpečnost
+
+- Tokeny nikdy neukládat do YAML ani Gitu.
+- Board ID lze skrýt přes environment variable, pokud je citlivé.
+- Logovat pouze identifikátory a zkrácené diffy.
+- Před exportem citlivých workshopových dat ověřit klasifikaci projektu.
+
+## 12. Definition of Done konektoru
+
+Živý konektor je považován za dokončený, pokud prokazatelně zvládá:
+
+- create/update/read managed item,
+- zachování unmanaged item,
+- idempotentní opakování,
+- konflikt na stejném poli,
+- tombstone delete,
+- recovery po částečném selhání,
+- dry-run,
+- auditní sync report,
+- práci se dvěma projekty bez záměny boardů nebo namespace.

--- a/docs/product/05-typy-projektu.md
+++ b/docs/product/05-typy-projektu.md
@@ -1,0 +1,132 @@
+# Typy projektů a workflow profily
+
+Typ projektu nastavuje výchozí metodický tok, povinné gates, očekávané vstupy a typická rizika. Nejde o pevnou škatulku; profil lze upravit, ale odchylka musí být explicitní v `project.yaml`.
+
+## Přehled
+
+| Kanonický typ | Legacy aliases | Použití | Důraz |
+|---|---|---|---|
+| `greenfield-product` | new-product, green-field, startup | nový produkt nebo systém s jedním dominantním product scopem | discovery, diferenciace, rychlá validace hranic |
+| `greenfield-portfolio` | new-enterprise, program-greenfield | více produktů/domén v programu nebo nové společnosti | domain portfolio, context map, team topology, governance |
+| `legacy-modernization` | brownfield, strangler, replatforming | postupná náhrada nebo rozdělení existujícího systému | as-is discovery, seams, data ownership, migrační inkrementy |
+| `legacy-transformation` | core-replacement, business-transformation | souběžná změna business capability, operating modelu a core IT | cílové capability, přechodné stavy, governance, sourcing |
+| `integration-landscape` | integration-review, api-program | primárně vztahy mezi systémy a kontexty | ownership, kontrakty, coupling, ACL |
+| `purchased-product-adoption` | COTS, SaaS-adoption, package-implementation | bounded context je zčásti nebo zcela realizován koupeným produktem | fit-gap, konfigurační hranice, vendor model, anti-corruption layer |
+| `architecture-review` | assessment, health-check | zhodnocení existujícího návrhu nebo implementace | quality attributes, rizika, evidence, ADR |
+| `domain-discovery` | discovery-only, domain-analysis | časově omezené pochopení domény bez závazku implementace | jazyk, události, pravidla, subdomény, otázky |
+| `operating-model-and-teams` | team-topologies, org-design | změna ownershipu a týmového uspořádání | sociotechnické hranice, cognitive load, interaction modes |
+
+## 1. Greenfield product
+
+**Kdy použít:** nový digitální produkt, samostatná business capability nebo nový bounded product scope.
+
+Povinné fáze: Align, Discover, Process Modeling, Decompose, Strategize, Connect, Define. Organize je povinné před škálováním více týmů.
+
+Typická rizika:
+
+- předčasné mapování bounded context = mikroservisa,
+- product vision bez doménových expertů,
+- univerzální model pro všechny budoucí varianty,
+- CQRS/Event Sourcing jako výchozí technická preference.
+
+## 2. Greenfield portfolio
+
+**Kdy použít:** nová pojišťovna, banka, marketplace nebo transformační program s více produkty a týmy.
+
+Navíc vyžaduje:
+
+- portfolio subdomén,
+- schopnosti a value streams,
+- strategickou klasifikaci,
+- context map na více úrovních,
+- team topology a governance,
+- pravidla sdílených platforem a generic capabilities.
+
+## 3. Legacy modernization
+
+**Kdy použít:** stávající systém brání změnám, ale business scope zůstává převážně stabilní.
+
+Povinné doplňky:
+
+- mapa současných datových vlastníků a faktických system-of-record,
+- runtime a change coupling,
+- business kritičnost a provozní omezení,
+- seams a migrační slices,
+- přechodné integrační kontrakty,
+- observabilita a rollback.
+
+Big Picture ES zachycuje business realitu; technický tok legacy systému se dokumentuje odděleně, aby nekolonizoval cílový model.
+
+## 4. Legacy transformation
+
+**Kdy použít:** zároveň se mění produkty, procesy, regulace, organizace i core systém.
+
+Vyžaduje paralelní modelování:
+
+- as-is business reality,
+- target business capabilities a policies,
+- přechodných stavů,
+- změn ownershipu a operating modelu,
+- dočasných bounded contexts a anti-corruption vrstev.
+
+## 5. Integration landscape
+
+**Kdy použít:** hlavním problémem je nejasné vlastnictví dat, point-to-point integrace, konfliktní API nebo eventy.
+
+Process Modeling může být omezeno na integračně kritické scénáře. Povinné jsou Connect a quality attribute scénáře pro dostupnost, konzistenci, latenci a recoverability.
+
+## 6. Purchased product adoption
+
+**Kdy použít:** capability je realizována SaaS nebo COTS produktem.
+
+DDD modelování má smysl pro:
+
+- vymezení business odpovědnosti bounded contextu,
+- pojmenování interního a vendor jazyka,
+- fit-gap analýzu pravidel a lifecycle,
+- data ownership,
+- integrační a konfigurační hranice,
+- rozhodnutí, co chránit anti-corruption layerem.
+
+Taktické DDD uvnitř vendor produktu se nemodeluje bez přístupu a business důvodu. Modeluje se vlastní odpovědnost, adaptace a kontrakty.
+
+## 7. Architecture review
+
+**Kdy použít:** existuje konkrétní návrh, repozitář nebo provozovaný systém a cílem je rozhodnutí o riziku či investici.
+
+Workflow začíná Align a evidence inventory. EventStorming se používá pouze tam, kde je nutné ověřit, zda technické hranice odpovídají business chování.
+
+Výstupem je review report, prioritizovaná rizika, varianty, ADR a evoluční plán; nikoli automaticky kompletní nový model.
+
+## 8. Domain discovery
+
+**Kdy použít:** potřebujeme ohraničený discovery sprint nebo přípravu workshopu.
+
+Výchozí konec je G3. Další fáze jsou doporučením, ne součástí scope.
+
+## 9. Operating model and teams
+
+**Kdy použít:** hlavním problémem je ownership, fronty mezi týmy, kognitivní zátěž nebo nejasná role platform/enabling týmů.
+
+Doménové hranice musí existovat alespoň jako pracovní hypotézy. Organizační diagram nesmí být použit jako primární zdroj bounded contexts.
+
+## Volba typu
+
+Položte postupně otázky:
+
+1. Mění se především business model, software, integrace, nebo ownership týmů?
+2. Existuje provozovaný systém a musí být zachován kontinuální provoz?
+3. Je scope jeden produkt, nebo portfolio capability?
+4. Je významná část řešení koupená?
+5. Potřebujeme discovery, rozhodnutí, cílový návrh, nebo realizovatelnou migraci?
+
+Pokud odpovědi ukazují na více profilů, zvolte dominantní typ a přidejte `workflow.extensions`, například:
+
+```yaml
+project_type: legacy-transformation
+workflow:
+  profile: legacy-transformation
+  extensions:
+    - purchased-product-adoption
+    - operating-model-and-teams
+```

--- a/examples/life-insurance-greenfield/README.md
+++ b/examples/life-insurance-greenfield/README.md
@@ -1,0 +1,283 @@
+# Referenční projekt — Greenfield životní pojišťovna
+
+## 1. Scénář
+
+Skupina zakládá digitální životní pojišťovnu pro český a slovenský trh. Cílem není pouze nový policy administration system, ale provozní model celé pojišťovny: distribuce, underwriting, správa smluv, inkaso, pojistné události, zákaznická obsluha, finance, compliance a reporting.
+
+Projekt demonstruje profil `greenfield-portfolio` a průchod od Align po implementační hand-off.
+
+## 2. Business cíle
+
+- uvést první rizikové životní pojištění do 12 měsíců,
+- umožnit produktovým týmům měnit underwriting pravidla bez plošného release core systému,
+- zajistit auditovatelnost rozhodnutí a regulatorní reporting,
+- podporovat přímý i zprostředkovatelský distribuční kanál,
+- oddělit diferenciující schopnosti od generic SaaS/COTS capability.
+
+## 3. Předpoklady
+
+- zdravotní data mají vysokou citlivost,
+- platby, účetnictví, identita a e-signature mohou být koupené capability,
+- underwriting a návrh produktu jsou kandidáti Core Domain,
+- cílový systém musí podporovat postupné přidávání produktů,
+- konkrétní technologie nejsou v discovery předurčeny.
+
+## 4. Vstupy
+
+```text
+inputs/
+├── business-plan.md
+├── target-operating-model.md
+├── regulatory-requirements.md
+├── product-concept-term-life.md
+├── distribution-journeys.md
+├── underwriting-guidelines.md
+└── vendor-capability-catalog.md
+```
+
+Každý vstup má v katalogu ownera, datum, citlivost, důvěryhodnost a části relevantní pro projekt.
+
+## 5. Krok za krokem
+
+### Krok 1 — Align
+
+Prompt pro agenta:
+
+> Analyzuj vstupy projektu životní pojišťovny. Odděl fakta, předpoklady a otevřené otázky. Navrhni business problém, cíle, scope/out-of-scope, stakeholder mapu a prioritní quality attribute scénáře. Nenavrhuj technologie ani bounded contexts.
+
+Očekávaný výstup:
+
+- scope: od návrhu produktu a nabídky po vznik, servis a ukončení smlouvy a likvidaci plnění,
+- out-of-scope první inkrement: skupinové životní pojištění a investiční složka,
+- quality attributes: auditovatelnost, privacy, modifikovatelnost pravidel, dostupnost distribučního journey, recoverability plateb.
+
+Gate G1 schvaluje sponsor, Chief Product Officer a Chief Architect.
+
+### Krok 2 — Big Picture EventStorming
+
+Workshop začíná událostmi například:
+
+- ProduktNavržen,
+- ProduktSchválen,
+- ZájemceIdentifikován,
+- PotřebyZákazníkaZjištěny,
+- NabídkaVytvořena,
+- ZdravotníDotazníkVyplněn,
+- RizikoVyhodnoceno,
+- NabídkaPřijata,
+- SmlouvaUzavřena,
+- PrvníPojistnéPřijato,
+- PojistnáOchranaAktivována,
+- ZměnaSmlouvyProvedena,
+- PojistnáUdálostNahlášena,
+- NárokPosouzen,
+- PlněníVyplaceno,
+- SmlouvaUkončena.
+
+Hotspoty:
+
+- Kdy přesně vzniká pojistná ochrana?
+- Kdo vlastní klientská kontaktní data?
+- Je zdravotní posouzení součást nabídky, nebo samostatný model?
+- Jak se rozlišuje návrh produktu od jeho prodejní varianty?
+- Co je autoritativní stav platby při výpadku poskytovatele?
+
+Observed lifecycles:
+
+- nabídka,
+- underwriting case,
+- pojistná smlouva,
+- premium receivable,
+- claim.
+
+### Krok 3 — Process Modeling
+
+Prioritní scénář: sjednání rizikového životního pojištění.
+
+```text
+Zájemce
+→ Požádat o nabídku
+→ Zachytit potřeby a souhlasy
+→ Vyhodnotit distribuční vhodnost
+→ Vytvořit nabídku
+→ Vyžádat zdravotní informace
+→ Vyhodnotit riziko
+→ Upravit nebo potvrdit podmínky
+→ Přijmout nabídku
+→ Podepsat smlouvu
+→ Přijmout první pojistné
+→ Aktivovat pojistnou ochranu
+```
+
+Process Modeling odhalí, že distributor, underwriting a policy administration používají pojem „nabídka“ odlišně.
+
+### Krok 4 — Decompose
+
+Kandidátní subdomény:
+
+| Subdoména | Pracovní typ | Důvod |
+|---|---|---|
+| Product Design | Core | rychlost a kvalita produktových změn |
+| Underwriting | Core | diferenciující risk selection a pravidla |
+| Distribution Journey | Core/Supporting | diferenciace digitální distribuce; závisí na strategii |
+| Policy Administration | Supporting | kritická, ale převážně standardní capability |
+| Claims | Supporting/Core candidate | potenciální diferenciace v customer experience a automatizaci |
+| Billing and Collections | Generic/Supporting | možnost platformy nebo produktu |
+| Customer Identity and Consent | Generic with strict constraints | regulace, citlivost a enterprise reuse |
+| Finance and General Ledger | Generic | typicky koupená capability |
+| Regulatory Reporting | Supporting | lokální regulatorní znalost |
+
+Candidate lifecycle underwriting case je oddělen od lifecycle nabídky, protože má jiné rozhodování, citlivá data a ownership.
+
+### Krok 5 — Strategize
+
+Portfolio rozhodnutí:
+
+- build: Product Design a Underwriting Decisioning,
+- build/partner: Distribution Journey,
+- buy/configure: General Ledger, e-signature, payments,
+- evaluate COTS: Policy Administration,
+- vlastní ACL a canonical contracts kolem vendor produktů.
+
+### Krok 6 — Connect
+
+Kandidátní bounded contexts:
+
+- Product Definition,
+- Sales Proposition,
+- Underwriting,
+- Policy Administration,
+- Billing and Collections,
+- Claims Management,
+- Customer and Consent,
+- Distribution Partner Management,
+- Finance Integration,
+- Regulatory Reporting.
+
+Příklad vztahů:
+
+```mermaid
+flowchart LR
+    PD[Product Definition] -->|Published product version| SP[Sales Proposition]
+    SP -->|Underwriting request| UW[Underwriting]
+    UW -->|Risk decision| SP
+    SP -->|Accepted proposition| PA[Policy Administration]
+    PA -->|Premium schedule| BC[Billing and Collections]
+    PA -->|Coverage snapshot| CM[Claims Management]
+    BC -->|Payment status| PA
+    PA -->|Accounting events| FI[Finance Integration]
+    PA -->|Regulatory facts| RR[Regulatory Reporting]
+```
+
+Data ownership:
+
+- Product Definition vlastní verzovaný produktový model.
+- Underwriting vlastní underwriting case a risk decision.
+- Policy Administration vlastní pojistnou smlouvu a business stav ochrany.
+- Billing vlastní pohledávku, inkaso a reconcile s payment providerem.
+- Customer and Consent vlastní identitu, kontaktní preference a souhlasy; ostatní kontexty používají účelové snapshoty.
+
+### Krok 7 — Organize
+
+První cílové týmy:
+
+- Product and Underwriting stream-aligned team,
+- Sales Journey stream-aligned team,
+- Policy Lifecycle stream-aligned team,
+- Claims stream-aligned team,
+- Insurance Platform team pro společné technické capability a paved road,
+- dočasný enabling team pro DDD, security/privacy a event/API contract design.
+
+Platform team nevlastní business bounded contexts ostatních týmů. Enabling team nevytváří permanentní delivery závislost.
+
+### Krok 8 — Define
+
+Prioritní bounded context: Underwriting.
+
+Design-Level ES:
+
+```text
+Underwriter / automatická policy
+→ Vyhodnotit riziko
+→ UnderwritingCase
+→ musí existovat platná produktová verze, souhlasy a dostatečné evidence
+→ RizikoVyhodnoceno
+→ policy: pokud je potřeba doplnění
+→ VyžádatDoplňujícíInformace
+→ DoplňujícíInformaceVyžádány
+→ po doplnění znovu VyhodnotitRiziko
+→ RiskDecision projection pro Sales Proposition
+```
+
+Candidate agregáty/consistency boundaries:
+
+- `UnderwritingCase` chrání stav posouzení a vazbu na immutable evidence references,
+- produktový model se nekopíruje jako mutable objekt; používá se konkrétní published version,
+- zdravotní dokumenty mohou být vlastněny separátní secure evidence capability a v Underwritingu jsou pouze reference a odvozená fakta.
+
+Validovaný lifecycle:
+
+```text
+Opened → EvidencePending → ReadyForAssessment → Assessed
+       → Referred → Assessed
+       → Declined | OfferedWithTerms | AcceptedStandard
+```
+
+### Krok 9 — Code hand-off
+
+První vertical slice:
+
+- digitální žádost,
+- jednoduchý rules-based underwriting pro produkt s limitem,
+- accepted standard decision,
+- předání přijaté nabídky do Policy Administration,
+- audit trail a základní observabilita.
+
+Nevstupuje do prvního slice:
+
+- komplexní manual underwriting workbench,
+- claims,
+- skupinové produkty,
+- univerzální enterprise event bus.
+
+## 6. Výsledná adresářová mapa
+
+```text
+artifacts/
+├── align/
+│   ├── discovery-brief.yaml
+│   └── quality-attributes.yaml
+├── discover/
+│   ├── events.yaml
+│   ├── glossary.yaml
+│   ├── hotspots.yaml
+│   └── lifecycles-observed.yaml
+├── decompose/
+│   ├── candidate-subdomains.yaml
+│   └── candidate-lifecycles.yaml
+├── strategize/
+│   └── subdomain-strategy.yaml
+├── connect/
+│   ├── bounded-contexts.yaml
+│   ├── context-map.yaml
+│   └── data-ownership.yaml
+├── organize/
+│   └── team-topology.yaml
+├── define/
+│   ├── underwriting-context-canvas.yaml
+│   ├── underwriting-design-level-es.yaml
+│   ├── underwriting-lifecycle.yaml
+│   └── underwriting-invariants.yaml
+└── code/
+    └── slice-01-standard-underwriting.yaml
+```
+
+## 7. Co příklad záměrně netvrdí
+
+- že každý bounded context musí být samostatná mikroservisa,
+- že doménové události znamenají Event Sourcing,
+- že všechny uvedené hranice jsou univerzální pro každou pojišťovnu,
+- že koupený policy administration produkt nepotřebuje doménový model na straně pojišťovny,
+- že team topology je konečná organizační struktura.
+
+Příklad je metodický referenční model a musí být přizpůsoben konkrétní strategii, regulaci, distribučnímu modelu a sourcingu.

--- a/examples/life-insurance-greenfield/project.yaml
+++ b/examples/life-insurance-greenfield/project.yaml
@@ -1,0 +1,50 @@
+schema_version: 1.0.0
+project_id: life-insurance-greenfield
+name: Greenfield životní pojišťovna
+project_type: greenfield-portfolio
+language: cs
+status: active
+workflow:
+  profile: greenfield-portfolio
+  current_stage: define
+  completed_gates:
+    - G1
+    - G2
+    - G3
+    - G4
+    - G5
+    - G6
+  extensions:
+    - purchased-product-adoption
+miro:
+  board_id_env: DDDA_LIFE_MIRO_BOARD_ID
+  board_url: null
+repositories:
+  primary: .
+classification:
+  data_sensitivity: confidential
+  contains_health_data: true
+owners:
+  business_sponsor: CEO
+  architecture_owner: Chief Architect
+  product_owner: Chief Product Officer
+scope:
+  in:
+    - product design
+    - distribution journey
+    - underwriting
+    - policy administration
+    - billing and collections
+    - claims
+    - customer and consent
+    - finance integration
+    - regulatory reporting
+  out:
+    - group life insurance in first increment
+    - investment-linked products in first increment
+quality_attributes:
+  - auditability
+  - privacy
+  - modifiability
+  - availability
+  - recoverability


### PR DESCRIPTION
## Shrnutí

Tento pull request zavádí cílový redesign DDDA jako Miro-first, multi-project akcelerátor s YAML artefakty verzovanými v Gitu.

## Hlavní změny

- nový produktový README a navigace dokumentace,
- architektura produktu a model izolovaných workspace/projektů,
- detailní synchronizační kontrakt Miro ↔ YAML ↔ Git,
- deklarativní Miro scaffold podle metodického toku Align → Discover → Process Modeling → Decompose → Strategize → Connect → Organize → Define → Code,
- explicitní umístění Big Picture ES, Process Modelingu a Design-Level ES,
- čtyři úrovně stavových modelů: observed, candidate, validated, implementation,
- gates G1–G8,
- katalog projektových typů včetně legacy aliases, COTS/SaaS a modernizačních profilů,
- deset praktických kuchařek,
- rozsáhlý referenční greenfield příklad životní pojišťovny,
- JSON Schema pro scaffold.

## Důležitá architektonická rozhodnutí

- YAML je zdroj pravdy pro sémantiku.
- Miro vlastní vizuální polohu a workshopovou interakci.
- Git vlastní audit a review.
- Mermaid je generovaný odvozený pohled.
- Konflikty používají explicit review; žádný last-write-wins pro sémantická pole.
- Mazání je tombstone-first.
- Jeden DDDA workspace podporuje více izolovaných projektů.

## Omezení této změny

Živý Miro API konektor není aktivován, protože vyžaduje registraci Miro aplikace, OAuth/tokeny a konkrétní board configuration. Tento PR definuje jeho kontrakt, metadata, konfliktní strategii a Definition of Done; implementace může bezpečně navázat bez změny metodického modelu.

## Doporučené review

1. metodický tok a gates,
2. umístění EventStormingu a lifecycle modelů,
3. katalog projektových typů,
4. synchronizační ownership a konflikty,
5. konzistence produktové dokumentace, kuchařek a referenčního příkladu.