### PR TITLE
Automatizovat post-clone smoke test a inicializaci Miro boardu

### DIFF
--- a/.github/workflows/validate-ddda.yml
+++ b/.github/workflows/validate-ddda.yml
@@ -101,7 +101,13 @@ jobs:
       - name: Parse scripts and validate installation
         shell: pwsh
         run: ./scripts/Test-DDDAInstallation.ps1 -PlatformPath $PWD
-      - name: Bootstrap workspace and project
+      - name: Test Miro automation helpers
+        shell: pwsh
+        run: ./tests/powershell/Test-DDDAMiroAutomation.ps1 -PlatformPath $PWD
+      - name: Initialize platform after clone
+        shell: pwsh
+        run: ./scripts/Initialize-DDDAAfterClone.ps1 -PlatformPath $PWD -NonInteractive
+      - name: Bootstrap workspace, project and run offline doctor
         shell: pwsh
         run: |
           $workspace = Join-Path $env:RUNNER_TEMP "ddda-smoke-pwsh"
@@ -109,14 +115,8 @@ jobs:
           ./scripts/Initialize-DDDAWorkspace.ps1 -WorkspaceRoot $workspace -WorkspaceId "ci-smoke-pwsh" -WorkspaceName "CI smoke workspace"
           ./scripts/New-DDDAProject.ps1 -WorkspaceRoot $workspace -ProjectId "life-insurance-smoke-pwsh" -Name "Life Insurance Smoke" -Type "portfolio-program" -TypeAlias "greenfield-portfolio" -NoInitialCommit
           ./scripts/Test-DDDAInstallation.ps1 -PlatformPath $PWD -WorkspaceRoot $workspace -ProjectPath $project
-          if (-not (Test-Path (Join-Path $project "miro/miro-map.yaml"))) { throw "Missing miro-map.yaml" }
-      - name: Install packaged runtime and run offline doctor
-        shell: pwsh
-        run: |
-          $workspace = Join-Path $env:RUNNER_TEMP "ddda-smoke-pwsh"
-          $project = Join-Path $workspace "projects/life-insurance-smoke-pwsh"
-          ./scripts/Install-DDDAMiroRuntime.ps1 -PlatformPath $PWD
           ./scripts/Test-DDDAMiroConfiguration.ps1 -PlatformPath $PWD -ProjectPath $project
+          if (-not (Test-Path (Join-Path $project "miro/miro-map.yaml"))) { throw "Missing miro-map.yaml" }
 
   windows-powershell-51-smoke:
     runs-on: windows-latest
@@ -128,6 +128,7 @@ jobs:
         run: |
           if ($PSVersionTable.PSVersion.Major -ne 5) { throw "Expected Windows PowerShell 5.1" }
           ./scripts/Test-DDDAInstallation.ps1 -PlatformPath $PWD
+          ./tests/powershell/Test-DDDAMiroAutomation.ps1 -PlatformPath $PWD
           $workspace = Join-Path $env:RUNNER_TEMP "ddda-smoke-ps51"
           $output = ./scripts/Initialize-DDDAWorkspace.ps1 -WorkspaceRoot $workspace -WorkspaceId "ci-smoke-ps51" -WorkspaceName "CI smoke workspace" 6>&1 | Out-String
           $expected = "p$([char]0x0159)ipraven"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 .pytest_cache/
 *.pyc
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ DDDA je chat-first, Miro-first a Git-verzované pracovní prostředí pro domén
 - obousměrná synchronizace spravovaných artefaktů YAML ↔ Miro,
 - dry-run, explicitní konflikty, tombstone delete, auditní sync reporty a idempotentní mapping,
 - řízený polling worker pro průběžnou synchronizaci,
+- automatizovaná inicializace po clone a opakovatelný online Miro smoke test,
+- idempotentní inicializace cílového Miro boardu pro konkrétní projekt,
 - Mermaid jako odvozená textová projekce,
 - česká metodika, kuchařky, typové workflow a referenční projekt životní pojišťovny.
 
@@ -39,8 +41,10 @@ git clone `
 $WorkspaceRoot = (Resolve-Path .\DDDA-Workspace).Path
 $PlatformRoot = (Resolve-Path .\DDDA-Workspace\platform\ddd-accelerator).Path
 
-& (Join-Path $PlatformRoot 'scripts\Test-DDDAInstallation.ps1') `
-  -PlatformPath $PlatformRoot
+& (Join-Path $PlatformRoot 'scripts\Initialize-DDDAAfterClone.ps1') `
+  -PlatformPath $PlatformRoot `
+  -WithMiro `
+  -Full
 
 & (Join-Path $PlatformRoot 'scripts\Initialize-DDDAWorkspace.ps1') `
   -WorkspaceRoot $WorkspaceRoot
@@ -51,43 +55,45 @@ $PlatformRoot = (Resolve-Path .\DDDA-Workspace\platform\ddd-accelerator).Path
   -Name 'Nová životní pojišťovna' `
   -Type portfolio-program `
   -TypeAlias greenfield-portfolio
+
+& (Join-Path $PlatformRoot 'scripts\Initialize-DDDAProjectMiro.ps1') `
+  -WorkspaceRoot $WorkspaceRoot `
+  -ProjectId life-insurance-greenfield `
+  -CreateBoard
 ```
 
-## Zapojení Miro
+První online běh si vyžádá Miro access token se scopes `boards:read` a `boards:write`. Na Windows jej uloží pomocí DPAPI mimo Git root. Další smoke testy a inicializace projektových boardů stejný token znovu použijí.
 
-Miro app musí mít scope `boards:read` a `boards:write`. Token se neukládá do Gitu.
+Pouze offline inicializace bez Miro API:
 
 ```powershell
-$env:MIRO_ACCESS_TOKEN = '<token>'
-$env:LIFE_INSURANCE_GREENFIELD_MIRO_BOARD_ID = '<board-id>'
-
-& (Join-Path $PlatformRoot 'scripts\Install-DDDAMiroRuntime.ps1')
-
-$ProjectRoot = Join-Path $WorkspaceRoot 'projects\life-insurance-greenfield'
-
-& (Join-Path $PlatformRoot 'scripts\Test-DDDAMiroConfiguration.ps1') `
-  -ProjectPath $ProjectRoot `
-  -Online
-
-& (Join-Path $PlatformRoot 'scripts\Initialize-DDDAMiroBoard.ps1') `
-  -ProjectPath $ProjectRoot `
-  -DryRun
-
-& (Join-Path $PlatformRoot 'scripts\Initialize-DDDAMiroBoard.ps1') `
-  -ProjectPath $ProjectRoot
+& (Join-Path $PlatformRoot 'scripts\Initialize-DDDAAfterClone.ps1') `
+  -PlatformPath $PlatformRoot
 ```
+
+## Samostatný online Miro smoke test
+
+```powershell
+& (Join-Path $PlatformRoot 'scripts\Invoke-DDDAMiroSmokeTest.ps1') `
+  -PlatformPath $PlatformRoot `
+  -Full
+```
+
+Test vytvoří izolovaný workspace, projekt a board, ověří YAML ↔ Miro, `PromoteNew`, polling worker a idempotenci. Po úspěchu board a workspace odstraní; při chybě je ponechá pro diagnostiku.
 
 ## Řízený synchronizační worker
 
 Pro průběžnou spolupráci lze spustit polling worker. Worker nejméně jednou za 30 sekund provede kontrolovaný režim `Both`, zapisuje auditní report a při prvním konfliktu se ukončí s exit code `2`, aby se konflikt nešířil dál.
 
 ```powershell
+$ProjectRoot = Join-Path $WorkspaceRoot 'projects\life-insurance-greenfield'
+
 & (Join-Path $PlatformRoot 'scripts\Start-DDDAMiroSyncWorker.ps1') `
   -ProjectPath $ProjectRoot `
   -IntervalSeconds 60
 ```
 
-Worker neprovádí Git commit, push ani merge a neobnovuje OAuth token. Rotaci nebo refresh tokenu musí zajistit provozní prostředí; pro lokální práci lze token před spuštěním znovu nastavit v environment variable.
+Worker neprovádí Git commit, push ani merge a neobnovuje OAuth token. Rotaci nebo refresh tokenu musí zajistit provozní prostředí; pro lokální práci lze použít uložený token nebo `MIRO_ACCESS_TOKEN`.
 
 ## Ovládání přes chat
 
@@ -97,4 +103,4 @@ Typický prompt:
 
 ## Dokumentace
 
-Začni v [indexu dokumentace](docs/README.md), pokračuj [hlavním návodem](USAGE.md) a referenčním [greenfield příkladem životní pojišťovny](examples/life-insurance-greenfield/README.md).
+Začni v [indexu dokumentace](docs/README.md), pokračuj [hlavním návodem](USAGE.md), [inicializací po clone](docs/cookbooks/13-inicializace-po-clone.md), [inicializací cílového Miro boardu](docs/cookbooks/14-inicializace-ciloveho-miro-boardu.md) a referenčním [greenfield příkladem životní pojišťovny](examples/life-insurance-greenfield/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,11 @@
 
 1. [README platformy](../README.md)
 2. [Praktický provozní návod](../USAGE.md)
-3. [Založení projektu](cookbooks/01-zalozeni-projektu.md)
-4. [Miro board a synchronizace](cookbooks/02-priprava-miro-boardu.md)
-5. [Referenční projekt životní pojišťovny](../examples/life-insurance-greenfield/README.md)
+3. [Inicializace po clone](cookbooks/13-inicializace-po-clone.md)
+4. [Založení projektu](cookbooks/01-zalozeni-projektu.md)
+5. [Inicializace cílového Miro boardu](cookbooks/14-inicializace-ciloveho-miro-boardu.md)
+6. [Miro board a synchronizace](cookbooks/02-priprava-miro-boardu.md)
+7. [Referenční projekt životní pojišťovny](../examples/life-insurance-greenfield/README.md)
 
 ## Metodika
 
@@ -39,6 +41,8 @@
 - [10 Legacy modernizace](cookbooks/10-legacy-modernizace.md)
 - [11 Chat-first pracovní režim](cookbooks/11-chat-first-pracovni-rezim.md)
 - [12 Miro troubleshooting](cookbooks/12-miro-troubleshooting.md)
+- [13 Inicializace po clone](cookbooks/13-inicializace-po-clone.md)
+- [14 Inicializace cílového Miro boardu](cookbooks/14-inicializace-ciloveho-miro-boardu.md)
 
 ## Strukturní pravidlo
 

--- a/docs/cookbooks/13-inicializace-po-clone.md
+++ b/docs/cookbooks/13-inicializace-po-clone.md
@@ -1,0 +1,138 @@
+# 13 Inicializace DDDA po clone
+
+## Účel a rozhodnutí
+
+Tato aktivita ověřuje, že nový clone platformy je provozně použitelný dříve, než se nad ním založí klientský workspace nebo projekt. Odděluje dvě úrovně:
+
+1. **offline inicializaci** — Git root, povinné soubory, PowerShell syntaxi, Python a instalaci Miro runtime;
+2. **online Miro smoke test** — skutečné vytvoření testovacího boardu, obousměrná synchronizace, `PromoteNew`, idempotence a cleanup.
+
+Online smoke test není projektová práce. Používá izolovaný dočasný workspace, dočasný projekt a dočasný board.
+
+## Entry criteria
+
+- repozitář byl právě naklonován nebo výrazně aktualizován;
+- pracovní strom platformy je čistý;
+- je dostupný Git, PowerShell a Python 3.11+;
+- pro online test existuje Miro Developer team a aplikace se scopes `boards:read` a `boards:write`;
+- uživatel má access token této aplikace.
+
+## Jednorázová online inicializace
+
+Z kořene platformního repozitáře:
+
+```powershell
+.\scripts\Initialize-DDDAAfterClone.ps1 -WithMiro -Full
+```
+
+Při prvním běhu skript vyžádá token skrytým promptem. Na Windows jej uloží pomocí DPAPI mimo Git root:
+
+```text
+%LOCALAPPDATA%\DDDA\secrets\miro-access-token.xml
+```
+
+Token se nepíše do repozitáře, reportu ani příkazové historie. Při dalších bězích se použije uložená hodnota.
+
+## Rutinní offline kontrola
+
+Bez volání Miro API:
+
+```powershell
+.\scripts\Initialize-DDDAAfterClone.ps1
+```
+
+Skript provede:
+
+1. ověření, že `PlatformPath` je Git root;
+2. kontrolu čistého pracovního stromu;
+3. `Test-DDDAInstallation.ps1`;
+4. detekci funkčního `python` nebo `py`;
+5. instalaci runtime do `.ddda/runtime/miro-venv`;
+6. kontrolu vstupního bodu `python -m ddda_miro --help`;
+7. závěrečnou kontrolu čistého platformního repozitáře.
+
+## Rutinní online smoke test
+
+Zkrácený test bez polling workeru:
+
+```powershell
+.\scripts\Invoke-DDDAMiroSmokeTest.ps1
+```
+
+Plný test včetně dvou cyklů workeru:
+
+```powershell
+.\scripts\Invoke-DDDAMiroSmokeTest.ps1 -Full
+```
+
+Smoke test ověřuje:
+
+- token context a požadované scopes;
+- vytvoření izolovaného workspace a projektu;
+- offline a online doctor;
+- dry-run a vytvoření boardu;
+- YAML → Miro;
+- Miro → YAML;
+- explicitní `PromoteNew`;
+- volitelně polling worker;
+- závěrečný `Both --dry-run` s nulou operací a konfliktů;
+- čistotu platformního Git rootu.
+
+## Cleanup a diagnostika
+
+Výchozí chování:
+
+| Výsledek | Board | Workspace | Report |
+|---|---|---|---|
+| PASS | odstraní se | odstraní se | ponechá se |
+| FAIL | ponechá se | ponechá se | ponechá se |
+
+Report je mimo Git root:
+
+```text
+%LOCALAPPDATA%\DDDA\smoke-reports\<run-id>\result.json
+```
+
+Ponechání prostředků i po úspěchu:
+
+```powershell
+.\scripts\Invoke-DDDAMiroSmokeTest.ps1 -Full -KeepArtifacts
+```
+
+Cleanup také po chybě:
+
+```powershell
+.\scripts\Invoke-DDDAMiroSmokeTest.ps1 -Full -CleanupOnFailure
+```
+
+Výměna uloženého tokenu:
+
+```powershell
+.\scripts\Invoke-DDDAMiroSmokeTest.ps1 -ResetToken -Full
+```
+
+## YAML/Git výstupy
+
+Online smoke test nesmí měnit platformní repozitář. Všechny projektové soubory vznikají v dočasném workspace a po úspěchu jsou odstraněny. Trvale zůstává pouze lokální report a bezpečně uložený token.
+
+## Kontroly
+
+Definition of Done:
+
+- výstup končí `DDDA Miro smoke test: PASS`;
+- report má `result: passed`;
+- testovací board a workspace byly při výchozím režimu odstraněny;
+- `git status --short` platformy je prázdný;
+- v repozitáři není token ani lokální report.
+
+## Anti-patterny
+
+- ruční vykonávání jednotlivých REST kroků místo runneru;
+- ukládání tokenu do `.env`, Markdownu nebo PowerShell skriptu v repozitáři;
+- používání klientského projektového boardu pro smoke test;
+- pokračování po neúspěchu bez přečtení `failure_step` a Miro response body;
+- automatické mazání diagnostického boardu při chybě bez explicitního `-CleanupOnFailure`.
+
+## Navazující krok
+
+Po úspěšné inicializaci založ workspace a projekt. Cílový projektový board vytvoř podle kuchařky [14 Inicializace cílového Miro boardu](14-inicializace-ciloveho-miro-boardu.md).

--- a/docs/cookbooks/14-inicializace-ciloveho-miro-boardu.md
+++ b/docs/cookbooks/14-inicializace-ciloveho-miro-boardu.md
@@ -1,0 +1,131 @@
+# 14 Inicializace cílového Miro boardu
+
+## Účel a rozhodnutí
+
+Tato aktivita vytvoří nebo idempotentně aktualizuje Miro board konkrétního DDDA projektu. Workspace pouze vyhledá projekt; board, mapping a změnová historie patří projektovému repozitáři.
+
+Doporučená topologie:
+
+```text
+DDDA-Workspace/
+├── platform/ddd-accelerator/
+└── projects/
+    ├── project-a/ ── Miro board A
+    └── project-b/ ── Miro board B
+```
+
+Společný workspace board není náhradou projektových boardů. Pokud vznikne, má být samostatnou portfolio projekcí bez sdíleného `miro-map.yaml` s projektovými artefakty.
+
+## Entry criteria
+
+- inicializace po clone prošla;
+- `workspace.yaml` registruje cílový projekt;
+- projekt je samostatný čistý Git repozitář;
+- platformní repozitář je čistý;
+- projekt má `project.yaml`, `miro/miro-map.yaml` a scaffold konfiguraci;
+- Miro token má scopes `boards:read` a `boards:write`.
+
+## Vytvoření nového boardu
+
+```powershell
+.\scripts\Initialize-DDDAProjectMiro.ps1 `
+  -WorkspaceRoot 'C:\path\to\DDDA-Workspace' `
+  -ProjectId 'life-insurance-greenfield' `
+  -CreateBoard
+```
+
+Skript:
+
+1. načte projekt z `workspace.yaml`;
+2. ověří samostatný Git root projektu;
+3. ověří čistotu platformy a projektu;
+4. načte token ze secret store nebo environment variable;
+5. ověří token context;
+6. nainstaluje Miro runtime;
+7. provede povinný dry-run;
+8. vytvoří nebo aktualizuje board;
+9. provede online doctor;
+10. provede druhý kontrolní render;
+11. ověří stejné board ID a stejnou množinu mapped item ID;
+12. vypíše projektový Git diff k review.
+
+`-CreateBoard` je bezpečné použít opakovaně. Pokud už `miro-map.yaml` obsahuje `board_id`, renderer použije stávající board a nevytvoří další.
+
+## Pouze dry-run
+
+```powershell
+.\scripts\Initialize-DDDAProjectMiro.ps1 `
+  -WorkspaceRoot 'C:\path\to\DDDA-Workspace' `
+  -ProjectId 'life-insurance-greenfield' `
+  -CreateBoard `
+  -DryRun
+```
+
+Dry-run nevolá write endpointy a nesmí změnit projektový repozitář.
+
+## Aktualizace existujícího boardu
+
+Po změně scaffoldu nebo upgradu platformy:
+
+```powershell
+.\scripts\Initialize-DDDAProjectMiro.ps1 `
+  -WorkspaceRoot 'C:\path\to\DDDA-Workspace' `
+  -ProjectId 'life-insurance-greenfield'
+```
+
+Bez `-CreateBoard` musí být board ID dostupné z `project.yaml`, environment variable nebo `miro/miro-map.yaml`.
+
+## Vlastnictví dat
+
+| Prvek | Vlastník |
+|---|---|
+| Miro board | konkrétní DDDA projekt |
+| `miro/miro-map.yaml` | projektový Git repozitář |
+| access token | lokální secret store nebo runtime prostředí |
+| scaffold | platformní repozitář |
+| význam artefaktů | projektové YAML |
+| workshopová poloha a seskupení | Miro |
+
+`board_id` není secret a může být verzováno v projektovém mappingu. Access token secret je a do Gitu nepatří.
+
+## Git review a commit
+
+Po úspěšném vytvoření boardu zkontroluj:
+
+```powershell
+git -C 'C:\path\to\project' diff -- miro/miro-map.yaml
+```
+
+Potom v projektovém repozitáři:
+
+```powershell
+git add miro/miro-map.yaml
+git commit -m 'chore: initialize project Miro board'
+```
+
+Platformní repozitář musí zůstat čistý.
+
+## Kontroly
+
+Definition of Done:
+
+- online doctor vrátí cílový board;
+- první a kontrolní render používají stejné `board_id`;
+- množina `miro_item_id` se při kontrolním renderu nezmění;
+- druhý render neobsahuje `create_board`;
+- změny projektu jsou omezené na `miro/`;
+- platformní `git status --short` je prázdný;
+- projektový diff byl zkontrolován před commitem.
+
+## Anti-patterny
+
+- jeden bidirekcionálně synchronizovaný board pro více nezávislých projektových repozitářů;
+- ruční kopírování board ID mezi projekty;
+- vytvoření nového boardu při každém spuštění;
+- commit tokenu společně s mappingem;
+- render do špinavého projektu, kde nelze oddělit předchozí změny;
+- automatický commit nebo push bez review mappingu.
+
+## Navazující krok
+
+Po inicializaci spusť první projektový workshop a používej dry-run synchronizace podle kuchařky [07 Miro ↔ YAML ↔ Git](07-synchronizace-miro-yaml-git.md).

--- a/docs/cookbooks/README.md
+++ b/docs/cookbooks/README.md
@@ -28,4 +28,4 @@ Kuchařka je opakovatelný pracovní postup pro chat, workshop, Miro, YAML a Git
 
 ## Doporučené pořadí
 
-Pro nový projekt obvykle: 01 → 02 → 03 → 04 → 06 → 08. Po stabilizaci hranic následuje 05 pro konkrétní BC. Kuchařky 07, 11 a 12 jsou průřezové. Kuchařka 10 rozšiřuje tok legacy modernizace.
+Po novém clone začni kuchařkou 13. Potom obvykle následuje 01 → 14 → 02 → 03 → 04 → 06 → 08. Po stabilizaci hranic následuje 05 pro konkrétní BC. Kuchařky 07, 11 a 12 jsou průřezové. Kuchařka 10 rozšiřuje tok legacy modernizace.

--- a/scripts/Initialize-DDDAAfterClone.ps1
+++ b/scripts/Initialize-DDDAAfterClone.ps1
@@ -1,0 +1,71 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+    [switch]$WithMiro,
+    [switch]$Full,
+    [switch]$ResetToken,
+    [switch]$KeepArtifacts,
+    [switch]$CleanupOnFailure,
+    [switch]$ForceRecreateRuntime,
+    [switch]$NonInteractive
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+try {
+    [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
+    $OutputEncoding = [Console]::OutputEncoding
+}
+catch {
+}
+
+. (Join-Path $PSScriptRoot "private/DDDAMiroSupport.ps1")
+
+$platformRoot = (Resolve-Path $PlatformPath).Path
+$gitRoot = Invoke-DDDAGit -RepositoryPath $platformRoot -Arguments @("rev-parse", "--show-toplevel")
+if ([System.IO.Path]::GetFullPath($gitRoot).TrimEnd('\', '/') -ne [System.IO.Path]::GetFullPath($platformRoot).TrimEnd('\', '/')) {
+    throw "PlatformPath není Git root DDDA. Zadaná cesta: $platformRoot; Git root: $gitRoot"
+}
+
+Assert-DDDACleanGitRepository -RepositoryPath $platformRoot -Label "Platformní"
+
+Write-Host "=== DDDA inicializace po clone ==="
+Write-Host "Platforma: $platformRoot"
+
+Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/Test-DDDAInstallation.ps1") -Arguments @(
+    "-PlatformPath", $platformRoot
+)
+
+$pythonCommand = Resolve-DDDAPythonCommand
+$installArguments = @("-PlatformPath", $platformRoot, "-PythonCommand", $pythonCommand)
+if ($ForceRecreateRuntime) {
+    $installArguments += "-ForceRecreate"
+}
+Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/Install-DDDAMiroRuntime.ps1") -Arguments $installArguments
+
+$pythonExe = Join-Path $platformRoot ".ddda/runtime/miro-venv/Scripts/python.exe"
+if (-not (Test-Path $pythonExe)) {
+    throw "DDDA Miro runtime nebyl vytvořen: $pythonExe"
+}
+
+& $pythonExe -m ddda_miro --help *> $null
+Assert-DDDALastExitCode -Operation "Ověření DDDA Miro CLI"
+
+Assert-DDDACleanGitRepository -RepositoryPath $platformRoot -Label "Platformní"
+Write-Host "Offline inicializace po clone: PASS"
+
+if ($WithMiro) {
+    $smokeArguments = @("-PlatformPath", $platformRoot, "-SkipRuntimeInstall")
+    if ($Full) { $smokeArguments += "-Full" }
+    if ($ResetToken) { $smokeArguments += "-ResetToken" }
+    if ($KeepArtifacts) { $smokeArguments += "-KeepArtifacts" }
+    if ($CleanupOnFailure) { $smokeArguments += "-CleanupOnFailure" }
+    if ($NonInteractive) { $smokeArguments += "-NonInteractive" }
+
+    Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/Invoke-DDDAMiroSmokeTest.ps1") -Arguments $smokeArguments
+}
+
+Write-Host ""
+Write-Host "DDDA inicializace po clone: PASS"
+Write-Host "Další krok: založ workspace a projekt; poté spusť Initialize-DDDAProjectMiro.ps1."

--- a/scripts/Initialize-DDDAProjectMiro.ps1
+++ b/scripts/Initialize-DDDAProjectMiro.ps1
@@ -1,0 +1,199 @@
+﻿[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$WorkspaceRoot,
+    [Parameter(Mandatory = $true)][string]$ProjectId,
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+    [switch]$CreateBoard,
+    [switch]$DryRun,
+    [switch]$ResetToken,
+    [switch]$ForceRecreateRuntime,
+    [switch]$NonInteractive
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+try {
+    [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
+    $OutputEncoding = [Console]::OutputEncoding
+}
+catch {
+}
+
+. (Join-Path $PSScriptRoot "private/DDDAMiroSupport.ps1")
+
+function Invoke-ProjectMiroCli {
+    param([Parameter(Mandatory = $true)][string[]]$CommandArguments)
+
+    $raw = & $script:MiroPython -m ddda_miro --project $script:ProjectRoot --platform $script:PlatformRoot @CommandArguments 2>&1
+    $exitCode = $LASTEXITCODE
+    $text = ($raw | Out-String).Trim()
+
+    if ($exitCode -ne 0) {
+        throw ("DDDA Miro CLI selhalo: {0}`n{1}" -f ($CommandArguments -join " "), $text)
+    }
+
+    try {
+        return ($text | ConvertFrom-Json)
+    }
+    catch {
+        throw ("DDDA Miro CLI nevrátilo platný JSON.`nPříkaz: {0}`nVýstup:`n{1}" -f ($CommandArguments -join " "), $text)
+    }
+}
+
+$originalTokenExists = Test-Path Env:\MIRO_ACCESS_TOKEN
+$originalToken = $null
+if ($originalTokenExists) {
+    $originalToken = $env:MIRO_ACCESS_TOKEN
+}
+
+$script:PlatformRoot = (Resolve-Path $PlatformPath).Path
+$script:ProjectRoot = Get-DDDAWorkspaceProjectPath -WorkspaceRoot $WorkspaceRoot -ProjectId $ProjectId
+$script:MiroPython = $null
+
+try {
+    $platformGitRoot = Invoke-DDDAGit -RepositoryPath $script:PlatformRoot -Arguments @("rev-parse", "--show-toplevel")
+    if ([System.IO.Path]::GetFullPath($platformGitRoot).TrimEnd('\', '/') -ne [System.IO.Path]::GetFullPath($script:PlatformRoot).TrimEnd('\', '/')) {
+        throw "PlatformPath není Git root DDDA: $($script:PlatformRoot)"
+    }
+
+    $projectGitRoot = Invoke-DDDAGit -RepositoryPath $script:ProjectRoot -Arguments @("rev-parse", "--show-toplevel")
+    if ([System.IO.Path]::GetFullPath($projectGitRoot).TrimEnd('\', '/') -ne [System.IO.Path]::GetFullPath($script:ProjectRoot).TrimEnd('\', '/')) {
+        throw "Projekt není samostatný Git root: $($script:ProjectRoot)"
+    }
+
+    Assert-DDDACleanGitRepository -RepositoryPath $script:PlatformRoot -Label "Platformní"
+    Assert-DDDACleanGitRepository -RepositoryPath $script:ProjectRoot -Label "Projektový"
+
+    $accessToken = Get-DDDAMiroAccessToken -ResetToken:$ResetToken -NonInteractive:$NonInteractive
+    $env:MIRO_ACCESS_TOKEN = $accessToken
+    $null = Assert-DDDAMiroTokenScopes -AccessToken $accessToken
+
+    $pythonCommand = Resolve-DDDAPythonCommand
+    $installArguments = @("-PlatformPath", $script:PlatformRoot, "-PythonCommand", $pythonCommand)
+    if ($ForceRecreateRuntime) {
+        $installArguments += "-ForceRecreate"
+    }
+    Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $script:PlatformRoot "scripts/Install-DDDAMiroRuntime.ps1") -Arguments $installArguments
+
+    $script:MiroPython = Join-Path $script:PlatformRoot ".ddda/runtime/miro-venv/Scripts/python.exe"
+    if (-not (Test-Path $script:MiroPython)) {
+        throw "DDDA Miro runtime nebyl vytvořen: $($script:MiroPython)"
+    }
+
+    Write-Host "=== Projektový Miro preflight ==="
+    Write-Host "Workspace: $([System.IO.Path]::GetFullPath($WorkspaceRoot))"
+    Write-Host "Projekt:   $($script:ProjectRoot)"
+
+    $doctor = Invoke-ProjectMiroCli -CommandArguments @("doctor")
+    if (-not (Get-DDDAObjectPropertyValue -InputObject $doctor -Name "scaffold_exists" -DefaultValue $false)) {
+        throw "Projektový Miro scaffold nebyl nalezen."
+    }
+
+    $renderArguments = @("render")
+    if ($CreateBoard) {
+        $renderArguments += "--create-board"
+    }
+
+    Write-Host ""
+    Write-Host "=== Povinný dry-run ==="
+    $preview = Invoke-ProjectMiroCli -CommandArguments ($renderArguments + "--dry-run")
+    $preview | ConvertTo-Json -Depth 20 | Write-Host
+
+    if ($DryRun) {
+        Assert-DDDACleanGitRepository -RepositoryPath $script:PlatformRoot -Label "Platformní"
+        Assert-DDDACleanGitRepository -RepositoryPath $script:ProjectRoot -Label "Projektový"
+        Write-Host ""
+        Write-Host "DDDA projektový Miro dry-run: PASS"
+        return
+    }
+
+    Write-Host ""
+    Write-Host "=== Render cílového boardu ==="
+    $firstRender = Invoke-ProjectMiroCli -CommandArguments $renderArguments
+    $boardId = [string](Get-DDDAObjectPropertyValue -InputObject $firstRender -Name "board_id")
+    if ([string]::IsNullOrWhiteSpace($boardId)) {
+        throw "Renderer nevrátil board_id."
+    }
+
+    $onlineDoctor = Invoke-ProjectMiroCli -CommandArguments @("doctor", "--online")
+    if (-not (Get-DDDAObjectPropertyValue -InputObject $onlineDoctor -Name "board")) {
+        throw "Online doctor nevrátil board."
+    }
+
+    $firstSnapshot = Get-DDDAMiroMapSnapshot -ProjectPath $script:ProjectRoot
+    if ($firstSnapshot.BoardId -ne $boardId) {
+        throw "Board ID v miro-map.yaml neodpovídá rendereru. Renderer: $boardId; mapping: $($firstSnapshot.BoardId)"
+    }
+    if (@($firstSnapshot.ItemIds).Count -eq 0) {
+        throw "miro-map.yaml neobsahuje žádné Miro item ID."
+    }
+
+    Write-Host ""
+    Write-Host "=== Idempotentní kontrolní render ==="
+    $secondRender = Invoke-ProjectMiroCli -CommandArguments @("render")
+    $secondBoardId = [string](Get-DDDAObjectPropertyValue -InputObject $secondRender -Name "board_id")
+    if ($secondBoardId -ne $boardId) {
+        throw "Kontrolní render změnil board ID. Původní: $boardId; nové: $secondBoardId"
+    }
+
+    $createBoardOperations = @(
+        (Get-DDDAObjectPropertyValue -InputObject $secondRender -Name "operations" -DefaultValue @()) |
+            Where-Object { (Get-DDDAObjectPropertyValue -InputObject $_ -Name "action") -eq "create_board" }
+    ).Count
+    if ($createBoardOperations -ne 0) {
+        throw "Kontrolní render se pokusil vytvořit další board."
+    }
+
+    $secondSnapshot = Get-DDDAMiroMapSnapshot -ProjectPath $script:ProjectRoot
+    $mappingDifference = Compare-Object -ReferenceObject @($firstSnapshot.ItemIds) -DifferenceObject @($secondSnapshot.ItemIds)
+    if ($mappingDifference) {
+        throw "Kontrolní render změnil množinu Miro item ID; hrozí duplikace scaffoldu."
+    }
+
+    Assert-DDDACleanGitRepository -RepositoryPath $script:PlatformRoot -Label "Platformní"
+
+    $projectChanges = Invoke-DDDAGit -RepositoryPath $script:ProjectRoot -Arguments @("status", "--porcelain")
+    $unexpectedChanges = @()
+    foreach ($line in @($projectChanges -split "`r?`n")) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+        $changedPath = $line.Substring([Math]::Min(3, $line.Length)).Trim().Replace('\', '/')
+        if ($changedPath -match ' -> ') {
+            $changedPath = ($changedPath -split ' -> ')[-1]
+        }
+        if (-not $changedPath.StartsWith("miro/")) {
+            $unexpectedChanges += $line
+        }
+    }
+    if ($unexpectedChanges.Count -gt 0) {
+        throw "Inicializace změnila neočekávané projektové soubory:`n$($unexpectedChanges -join "`n")"
+    }
+
+    Write-Host ""
+    Write-Host "DDDA projektový Miro board: PASS"
+    Write-Host "Board ID: $boardId"
+    Write-Host "Board URL: https://miro.com/app/board/$boardId/"
+    Write-Host ""
+    Write-Host "Projektové změny k review:"
+    if ([string]::IsNullOrWhiteSpace($projectChanges)) {
+        Write-Host "  žádné"
+    }
+    else {
+        Write-Host $projectChanges
+        Write-Host ""
+        Write-Host "Zkontroluj diff a commitni změnu v projektovém repozitáři, typicky:"
+        Write-Host "  git -C `"$($script:ProjectRoot)`" diff -- miro/miro-map.yaml"
+        Write-Host "  git -C `"$($script:ProjectRoot)`" add miro/miro-map.yaml"
+        Write-Host "  git -C `"$($script:ProjectRoot)`" commit -m `"chore: initialize project Miro board`""
+    }
+}
+finally {
+    if ($originalTokenExists) {
+        $env:MIRO_ACCESS_TOKEN = $originalToken
+    }
+    else {
+        Remove-Item Env:\MIRO_ACCESS_TOKEN -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/Invoke-DDDAMiroSmokeTest.ps1
+++ b/scripts/Invoke-DDDAMiroSmokeTest.ps1
@@ -1,0 +1,430 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+    [switch]$ResetToken,
+    [switch]$KeepArtifacts,
+    [switch]$CleanupOnFailure,
+    [switch]$Full,
+    [switch]$NonInteractive,
+    [switch]$SkipRuntimeInstall,
+    [string]$ReportDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+try {
+    [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
+    $OutputEncoding = [Console]::OutputEncoding
+}
+catch {
+}
+
+. (Join-Path $PSScriptRoot "private/DDDAMiroSupport.ps1")
+
+function Write-Step {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    $script:CurrentStep = $Name
+    Write-Host ""
+    Write-Host ("=== {0} ===" -f $Name)
+}
+
+function Add-TestResult {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Status,
+        [string]$Detail = ""
+    )
+
+    $script:TestResults += [pscustomobject]@{ name = $Name; status = $Status; detail = $Detail }
+    Write-Host ("{0}: {1}" -f $Name, $Status)
+    if (-not [string]::IsNullOrWhiteSpace($Detail)) {
+        Write-Host ("  {0}" -f $Detail)
+    }
+}
+
+function Invoke-MiroCli {
+    param([Parameter(Mandatory = $true)][string[]]$CommandArguments)
+
+    $raw = & $script:MiroPython -m ddda_miro --project $script:ProjectRoot --platform $script:PlatformRoot @CommandArguments 2>&1
+    $exitCode = $LASTEXITCODE
+    $text = ($raw | Out-String).Trim()
+
+    if ($exitCode -ne 0) {
+        throw ("DDDA Miro CLI selhalo: {0}`n{1}" -f ($CommandArguments -join " "), $text)
+    }
+
+    try {
+        return ($text | ConvertFrom-Json)
+    }
+    catch {
+        throw ("DDDA Miro CLI nevrátilo platný JSON.`nPříkaz: {0}`nVýstup:`n{1}" -f ($CommandArguments -join " "), $text)
+    }
+}
+
+$originalTokenExists = Test-Path Env:\MIRO_ACCESS_TOKEN
+$originalToken = $null
+if ($originalTokenExists) {
+    $originalToken = $env:MIRO_ACCESS_TOKEN
+}
+
+$runId = Get-Date -Format "yyyyMMdd-HHmmss"
+$runShort = [Guid]::NewGuid().ToString("N").Substring(0, 8)
+$script:TestResults = @()
+$script:BoardId = $null
+$script:WorkspaceRoot = $null
+$script:ProjectRoot = $null
+$script:PlatformRoot = $null
+$script:MiroPython = $null
+$script:AccessToken = $null
+$script:CurrentStep = "Inicializace"
+$success = $false
+$failureMessage = $null
+$failureStep = $null
+$cleanupFailure = $null
+
+$stateRoot = Get-DDDAStateRoot
+if ([string]::IsNullOrWhiteSpace($ReportDirectory)) {
+    $reportRoot = Join-Path $stateRoot ("smoke-reports/{0}-{1}" -f $runId, $runShort)
+}
+else {
+    $reportRoot = [System.IO.Path]::GetFullPath($ReportDirectory)
+}
+$reportPath = Join-Path $reportRoot "result.json"
+
+try {
+    Write-Step "Platformní preflight"
+    $script:PlatformRoot = (Resolve-Path $PlatformPath).Path
+    $env:PYTHONUTF8 = "1"
+    $env:PYTHONIOENCODING = "utf-8"
+
+    $gitRoot = Invoke-DDDAGit -RepositoryPath $script:PlatformRoot -Arguments @("rev-parse", "--show-toplevel")
+    if ([System.IO.Path]::GetFullPath($gitRoot).TrimEnd('\', '/') -ne [System.IO.Path]::GetFullPath($script:PlatformRoot).TrimEnd('\', '/')) {
+        throw "PlatformPath není Git root DDDA. Zadaná cesta: $($script:PlatformRoot); Git root: $gitRoot"
+    }
+
+    Assert-DDDACleanGitRepository -RepositoryPath $script:PlatformRoot -Label "Platformní"
+    $branch = Invoke-DDDAGit -RepositoryPath $script:PlatformRoot -Arguments @("branch", "--show-current")
+    if ([string]::IsNullOrWhiteSpace($branch)) {
+        $branch = "detached"
+    }
+    Add-TestResult -Name "platform-preflight" -Status "PASS" -Detail ("branch={0}" -f $branch)
+
+    Write-Step "Načtení nebo registrace Miro tokenu"
+    $script:AccessToken = Get-DDDAMiroAccessToken -ResetToken:$ResetToken -NonInteractive:$NonInteractive
+    $env:MIRO_ACCESS_TOKEN = $script:AccessToken
+    $null = Assert-DDDAMiroTokenScopes -AccessToken $script:AccessToken
+    Add-TestResult -Name "token-context" -Status "PASS" -Detail "scopes boards:read + boards:write"
+
+    Write-Step "Vytvoření izolovaného workspace"
+    $script:WorkspaceRoot = Join-Path $env:TEMP ("DDDA/smoke/{0}-{1}" -f $runId, $runShort)
+    $projectId = "miro-smoke-$runShort"
+    $projectName = "DDDA Miro Smoke $runShort"
+    $script:ProjectRoot = Join-Path $script:WorkspaceRoot ("projects/{0}" -f $projectId)
+
+    Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $script:PlatformRoot "scripts/Initialize-DDDAWorkspace.ps1") -Arguments @(
+        "-WorkspaceRoot", $script:WorkspaceRoot,
+        "-WorkspaceId", ("smoke-{0}" -f $runShort),
+        "-WorkspaceName", ("DDDA Miro Smoke {0}" -f $runShort)
+    )
+
+    Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $script:PlatformRoot "scripts/New-DDDAProject.ps1") -Arguments @(
+        "-WorkspaceRoot", $script:WorkspaceRoot,
+        "-ProjectId", $projectId,
+        "-Name", $projectName,
+        "-Type", "domain-discovery",
+        "-NoInitialCommit"
+    )
+    Add-TestResult -Name "workspace-bootstrap" -Status "PASS" -Detail $script:ProjectRoot
+
+    Write-Step "Diagnostika instalace"
+    Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $script:PlatformRoot "scripts/Test-DDDAInstallation.ps1") -Arguments @(
+        "-PlatformPath", $script:PlatformRoot,
+        "-WorkspaceRoot", $script:WorkspaceRoot,
+        "-ProjectPath", $script:ProjectRoot
+    )
+    Add-TestResult -Name "installation-doctor" -Status "PASS"
+
+    Write-Step "Instalace Miro runtime"
+    $pythonCommand = Resolve-DDDAPythonCommand
+    if (-not $SkipRuntimeInstall) {
+        Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $script:PlatformRoot "scripts/Install-DDDAMiroRuntime.ps1") -Arguments @(
+            "-PlatformPath", $script:PlatformRoot,
+            "-PythonCommand", $pythonCommand
+        )
+    }
+
+    $script:MiroPython = Join-Path $script:PlatformRoot ".ddda/runtime/miro-venv/Scripts/python.exe"
+    if (-not (Test-Path $script:MiroPython)) {
+        throw "Miro Python runtime nebyl vytvořen: $($script:MiroPython)"
+    }
+    Add-TestResult -Name "runtime-installation" -Status "PASS" -Detail $script:MiroPython
+
+    Write-Step "Offline doctor"
+    $doctor = Invoke-MiroCli -CommandArguments @("doctor")
+    if (-not (Get-DDDAObjectPropertyValue -InputObject $doctor -Name "scaffold_exists" -DefaultValue $false)) {
+        throw "Offline doctor nenašel Miro scaffold."
+    }
+    if (-not (Get-DDDAObjectPropertyValue -InputObject $doctor -Name "token_present" -DefaultValue $false)) {
+        throw "Offline doctor nevidí Miro token."
+    }
+    Add-TestResult -Name "offline-doctor" -Status "PASS"
+
+    Write-Step "Renderer dry-run"
+    $renderDry = Invoke-MiroCli -CommandArguments @("render", "--create-board", "--dry-run")
+    $createBoardOps = @(
+        (Get-DDDAObjectPropertyValue -InputObject $renderDry -Name "operations" -DefaultValue @()) |
+            Where-Object { (Get-DDDAObjectPropertyValue -InputObject $_ -Name "action") -eq "create_board" }
+    ).Count
+    if ($createBoardOps -ne 1) {
+        throw "Renderer dry-run neočekával přesně jednu create_board operaci. Počet: $createBoardOps"
+    }
+    Add-TestResult -Name "render-dry-run" -Status "PASS" -Detail ("operations={0}" -f (Get-DDDAObjectPropertyValue -InputObject $renderDry -Name "operation_count" -DefaultValue 0))
+
+    Write-Step "Vytvoření Miro boardu"
+    $render = Invoke-MiroCli -CommandArguments @("render", "--create-board")
+    $script:BoardId = [string](Get-DDDAObjectPropertyValue -InputObject $render -Name "board_id")
+    if ([string]::IsNullOrWhiteSpace($script:BoardId)) {
+        throw "Renderer nevrátil board_id."
+    }
+    Add-TestResult -Name "render-board" -Status "PASS" -Detail ("board_id={0}" -f $script:BoardId)
+
+    Write-Step "Online doctor"
+    $onlineDoctor = Invoke-MiroCli -CommandArguments @("doctor", "--online")
+    if (-not (Get-DDDAObjectPropertyValue -InputObject $onlineDoctor -Name "board")) {
+        throw "Online doctor nevrátil board."
+    }
+    Add-TestResult -Name "online-doctor" -Status "PASS" -Detail ("board_id={0}" -f $script:BoardId)
+
+    Write-Step "YAML -> Miro"
+    $artifactDirectory = Join-Path $script:ProjectRoot "artifacts/discover/domain_event"
+    New-Item -ItemType Directory -Path $artifactDirectory -Force | Out-Null
+    $artifactPath = Join-Path $artifactDirectory "evt-smoke-policy-issued.yaml"
+    Set-Content -Path $artifactPath -Encoding UTF8 -Value @(
+        "artifact:",
+        "  id: evt-smoke-policy-issued",
+        "  type: domain_event",
+        "  name: Testovací pojistná smlouva byla vydána",
+        "  description: Automatický online smoke test.",
+        "  status: candidate",
+        "  stage: discover",
+        "  miro:",
+        "    item_type: sticky_note",
+        "    frame_id: discover-big-picture-es"
+    )
+
+    $pushDry = Invoke-MiroCli -CommandArguments @("sync", "--direction", "push", "--dry-run")
+    $pushCreateOps = @(
+        (Get-DDDAObjectPropertyValue -InputObject $pushDry -Name "operations" -DefaultValue @()) |
+            Where-Object {
+                (Get-DDDAObjectPropertyValue -InputObject $_ -Name "action") -eq "push_create_miro" -and
+                (Get-DDDAObjectPropertyValue -InputObject $_ -Name "artifact_id") -eq "evt-smoke-policy-issued"
+            }
+    ).Count
+    if ($pushCreateOps -ne 1) {
+        throw "Push dry-run neočekával jednu push_create_miro operaci. Počet: $pushCreateOps"
+    }
+
+    $push = Invoke-MiroCli -CommandArguments @("sync", "--direction", "push")
+    if ((Get-DDDAObjectPropertyValue -InputObject $push -Name "conflict_count" -DefaultValue 0) -ne 0) {
+        throw "Push vytvořil konflikt."
+    }
+
+    $eventMarker = "DDDA:${projectId}:evt-smoke-policy-issued"
+    $eventItem = Find-DDDAMiroItemByMarker -BoardId $script:BoardId -Marker $eventMarker -AccessToken $script:AccessToken
+    if (-not $eventItem) {
+        throw "Na boardu nebyla nalezena sticky note s markerem $eventMarker"
+    }
+    Add-TestResult -Name "yaml-to-miro" -Status "PASS" -Detail ("item_id={0}" -f (Get-DDDAObjectPropertyValue -InputObject $eventItem -Name "id"))
+
+    Write-Step "Miro -> YAML"
+    $updatedContent = "<p><strong>Testovací pojistná smlouva byla úspěšně vydána</strong></p><p>Automatický online smoke test.</p><p>Typ: domain_event</p><p>Stav: candidate</p><p>Fáze: discover</p><p>$eventMarker</p>"
+    $boardSegment = [Uri]::EscapeDataString([string]$script:BoardId)
+    $eventItemId = [string](Get-DDDAObjectPropertyValue -InputObject $eventItem -Name "id")
+    $eventItemSegment = [Uri]::EscapeDataString($eventItemId)
+    $updateUri = "https://api.miro.com/v2/boards/$boardSegment/sticky_notes/$eventItemSegment"
+    $null = Invoke-DDDAMiroApi -Method PATCH -Uri $updateUri -AccessToken $script:AccessToken -Body @{ data = @{ content = $updatedContent } }
+
+    $pullDry = Invoke-MiroCli -CommandArguments @("sync", "--direction", "pull", "--dry-run")
+    $pullUpdateOps = @(
+        (Get-DDDAObjectPropertyValue -InputObject $pullDry -Name "operations" -DefaultValue @()) |
+            Where-Object {
+                (Get-DDDAObjectPropertyValue -InputObject $_ -Name "action") -eq "pull_update_yaml" -and
+                (Get-DDDAObjectPropertyValue -InputObject $_ -Name "artifact_id") -eq "evt-smoke-policy-issued"
+            }
+    ).Count
+    if ($pullUpdateOps -ne 1) {
+        throw "Pull dry-run neočekával jednu pull_update_yaml operaci. Počet: $pullUpdateOps"
+    }
+
+    $pull = Invoke-MiroCli -CommandArguments @("sync", "--direction", "pull")
+    if ((Get-DDDAObjectPropertyValue -InputObject $pull -Name "conflict_count" -DefaultValue 0) -ne 0) {
+        throw "Pull vytvořil konflikt."
+    }
+
+    $artifactText = Get-Content $artifactPath -Raw -Encoding UTF8
+    if ($artifactText -notmatch "Testovací pojistná smlouva byla úspěšně vydána") {
+        throw "Změna z Mira se nepromítla do YAML."
+    }
+    Add-TestResult -Name "miro-to-yaml" -Status "PASS"
+
+    Write-Step "PromoteNew"
+    $hotspotMarker = "DDDA:${projectId}:hotspot-medical-evidence"
+    $hotspotContent = "<p><strong>Nejasnost v underwriting procesu</strong></p><p>Je nutné vyjasnit, kdo schvaluje chybějící zdravotní podklady.</p><p>Typ: hotspot</p><p>Stav: candidate</p><p>Fáze: discover</p><p>$hotspotMarker</p>"
+    $createStickyUri = "https://api.miro.com/v2/boards/$boardSegment/sticky_notes"
+    $hotspotItem = Invoke-DDDAMiroApi -Method POST -Uri $createStickyUri -AccessToken $script:AccessToken -Body @{
+        data = @{ content = $hotspotContent; shape = "rectangle" }
+        style = @{ fillColor = "red" }
+    }
+    if (-not (Get-DDDAObjectPropertyValue -InputObject $hotspotItem -Name "id")) {
+        throw "Miro API nevytvořilo promotion sticky note."
+    }
+
+    $promoteDry = Invoke-MiroCli -CommandArguments @("sync", "--direction", "pull", "--promote-new", "--dry-run")
+    $promoteOps = @(
+        (Get-DDDAObjectPropertyValue -InputObject $promoteDry -Name "operations" -DefaultValue @()) |
+            Where-Object {
+                (Get-DDDAObjectPropertyValue -InputObject $_ -Name "action") -eq "pull_promote_yaml" -and
+                (Get-DDDAObjectPropertyValue -InputObject $_ -Name "artifact_id") -eq "hotspot-medical-evidence"
+            }
+    ).Count
+    if ($promoteOps -ne 1) {
+        throw "Promotion dry-run neočekával jednu pull_promote_yaml operaci. Počet: $promoteOps"
+    }
+
+    $promote = Invoke-MiroCli -CommandArguments @("sync", "--direction", "pull", "--promote-new")
+    if ((Get-DDDAObjectPropertyValue -InputObject $promote -Name "conflict_count" -DefaultValue 0) -ne 0) {
+        throw "PromoteNew vytvořil konflikt."
+    }
+
+    $promotedPath = Join-Path $script:ProjectRoot "artifacts/discover/hotspot/hotspot-medical-evidence.yaml"
+    if (-not (Test-Path $promotedPath)) {
+        throw "PromoteNew nevytvořil očekávaný YAML: $promotedPath"
+    }
+    Add-TestResult -Name "promote-new" -Status "PASS" -Detail $promotedPath
+
+    if ($Full) {
+        Write-Step "Polling worker"
+        $watchRaw = & $script:MiroPython -m ddda_miro --project $script:ProjectRoot --platform $script:PlatformRoot watch --interval-seconds 30 --max-cycles 2 2>&1
+        $watchText = ($watchRaw | Out-String).Trim()
+        if ($LASTEXITCODE -ne 0) {
+            throw "Polling worker selhal.`n$watchText"
+        }
+        Add-TestResult -Name "polling-worker" -Status "PASS" -Detail "2 cycles"
+    }
+
+    Write-Step "Idempotence"
+    $idempotence = Invoke-MiroCli -CommandArguments @("sync", "--direction", "both", "--dry-run")
+    $operationCount = Get-DDDAObjectPropertyValue -InputObject $idempotence -Name "operation_count" -DefaultValue 0
+    $conflictCount = Get-DDDAObjectPropertyValue -InputObject $idempotence -Name "conflict_count" -DefaultValue 0
+    if ($operationCount -ne 0) {
+        throw "Idempotence selhala. operation_count=$operationCount"
+    }
+    if ($conflictCount -ne 0) {
+        throw "Idempotence vytvořila konflikty. conflict_count=$conflictCount"
+    }
+    Add-TestResult -Name "idempotence" -Status "PASS" -Detail "operation_count=0; conflict_count=0"
+
+    Write-Step "Kontrola platformního repozitáře"
+    Assert-DDDACleanGitRepository -RepositoryPath $script:PlatformRoot -Label "Platformní"
+    Add-TestResult -Name "platform-clean" -Status "PASS"
+    $success = $true
+}
+catch {
+    $failureStep = $script:CurrentStep
+    $failureMessage = ("Krok '{0}' selhal. {1}" -f $failureStep, $_.Exception.Message)
+    Add-TestResult -Name "smoke-test" -Status "FAIL" -Detail $failureMessage
+}
+finally {
+    $script:CurrentStep = "Cleanup"
+    Write-Host ""
+    Write-Host "=== Cleanup ==="
+
+    $shouldCleanup = (-not $KeepArtifacts) -and ($success -or $CleanupOnFailure)
+    if ($shouldCleanup) {
+        try {
+            if ($script:BoardId -and $script:AccessToken) {
+                $boardSegment = [Uri]::EscapeDataString([string]$script:BoardId)
+                $deleteBoardUri = "https://api.miro.com/v2/boards/$boardSegment"
+                $null = Invoke-DDDAMiroApi -Method DELETE -Uri $deleteBoardUri -AccessToken $script:AccessToken
+                Write-Host "Testovací board byl odstraněn: $($script:BoardId)"
+            }
+
+            if ($script:WorkspaceRoot -and (Test-Path $script:WorkspaceRoot)) {
+                Remove-Item $script:WorkspaceRoot -Recurse -Force
+                Write-Host "Dočasný workspace byl odstraněn: $($script:WorkspaceRoot)"
+            }
+            Add-TestResult -Name "cleanup" -Status "PASS"
+        }
+        catch {
+            $cleanupFailure = $_.Exception.Message
+            if ($success) {
+                $failureStep = "Cleanup"
+                $failureMessage = "Cleanup selhal. $cleanupFailure"
+            }
+            $success = $false
+            Add-TestResult -Name "cleanup" -Status "FAIL" -Detail $cleanupFailure
+        }
+    }
+    elseif ($KeepArtifacts) {
+        Write-Host "KeepArtifacts: board a workspace byly ponechány."
+    }
+    elseif (-not $success) {
+        Write-Host "Test selhal; board a workspace byly ponechány pro diagnostiku."
+    }
+
+    New-Item -ItemType Directory -Path $reportRoot -Force | Out-Null
+    $commit = $null
+    if ($script:PlatformRoot) {
+        try { $commit = Invoke-DDDAGit -RepositoryPath $script:PlatformRoot -Arguments @("rev-parse", "HEAD") } catch {}
+    }
+
+    $report = [ordered]@{
+        schema_version = 1
+        run_id = "$runId-$runShort"
+        result = $(if ($success) { "passed" } else { "failed" })
+        platform_path = $script:PlatformRoot
+        platform_commit = $commit
+        workspace_path = $script:WorkspaceRoot
+        project_path = $script:ProjectRoot
+        board_id = $script:BoardId
+        keep_artifacts = [bool]$KeepArtifacts
+        cleanup_on_failure = [bool]$CleanupOnFailure
+        full = [bool]$Full
+        failure_step = $failureStep
+        failure = $failureMessage
+        cleanup_failure = $cleanupFailure
+        tests = $script:TestResults
+        completed_at = (Get-Date).ToUniversalTime().ToString("o")
+    }
+    $report | ConvertTo-Json -Depth 20 | Set-Content -Path $reportPath -Encoding UTF8
+
+    if ($originalTokenExists) {
+        $env:MIRO_ACCESS_TOKEN = $originalToken
+    }
+    else {
+        Remove-Item Env:\MIRO_ACCESS_TOKEN -ErrorAction SilentlyContinue
+    }
+
+    Write-Host ""
+    Write-Host "Report: $reportPath"
+
+    if ($success) {
+        Write-Host ""
+        Write-Host "DDDA Miro smoke test: PASS"
+    }
+    else {
+        Write-Host ""
+        Write-Host "DDDA Miro smoke test: FAIL"
+        if ($script:BoardId -and -not $shouldCleanup) {
+            Write-Host "Board ponechán: $($script:BoardId)"
+        }
+        if ($script:WorkspaceRoot -and -not $shouldCleanup) {
+            Write-Host "Workspace ponechán: $($script:WorkspaceRoot)"
+        }
+        if ([string]::IsNullOrWhiteSpace($failureMessage)) {
+            $failureMessage = "DDDA Miro smoke test selhal bez detailu."
+        }
+        throw $failureMessage
+    }
+}

--- a/scripts/Test-DDDAInstallation.ps1
+++ b/scripts/Test-DDDAInstallation.ps1
@@ -18,6 +18,7 @@ try {
 $requiredFiles = @(
     "README.md", "USAGE.md", "docs/README.md",
     "docs/cookbooks/README.md", "docs/cookbooks/11-chat-first-pracovni-rezim.md", "docs/cookbooks/12-miro-troubleshooting.md",
+    "docs/cookbooks/13-inicializace-po-clone.md", "docs/cookbooks/14-inicializace-ciloveho-miro-boardu.md",
     "docs/methodology/01-metodicky-tok-a-gates.md", "docs/methodology/02-typy-projektu-toky-use-cases.md",
     "docs/product/01-architektura-ddda.md", "docs/product/04-synchronizace.md", "docs/product/06-migrace-a-kompatibilita.md",
     "examples/life-insurance-greenfield/README.md", "examples/life-insurance-greenfield/project.yaml",
@@ -29,7 +30,9 @@ $requiredFiles = @(
     "runtime/miro/pyproject.toml", "runtime/miro/ddda_miro/client.py", "runtime/miro/ddda_miro/sync.py",
     "scripts/Initialize-DDDAWorkspace.ps1", "scripts/New-DDDAProject.ps1", "scripts/Test-DDDARepositoryScope.ps1",
     "scripts/Update-DDDAProject.ps1", "scripts/Install-DDDAMiroRuntime.ps1", "scripts/Initialize-DDDAMiroBoard.ps1",
-    "scripts/Invoke-DDDAMiroSync.ps1", "scripts/Start-DDDAMiroSyncWorker.ps1", "scripts/Test-DDDAMiroConfiguration.ps1"
+    "scripts/Invoke-DDDAMiroSync.ps1", "scripts/Start-DDDAMiroSyncWorker.ps1", "scripts/Test-DDDAMiroConfiguration.ps1",
+    "scripts/Initialize-DDDAAfterClone.ps1", "scripts/Invoke-DDDAMiroSmokeTest.ps1", "scripts/Initialize-DDDAProjectMiro.ps1",
+    "scripts/private/DDDAMiroSupport.ps1", "tests/powershell/Test-DDDAMiroAutomation.ps1"
 )
 foreach ($relativePath in $requiredFiles) {
     $fullPath = Join-Path $platformFull $relativePath
@@ -43,14 +46,15 @@ Get-ChildItem -Path (Join-Path $platformFull "schemas") -Filter "*.json" -File -
     try { Get-Content $_.FullName -Raw -Encoding UTF8 | ConvertFrom-Json | Out-Null; Add-Success "JSON je syntakticky validní: $($_.Name)" }
     catch { Add-Failure "Neplatný JSON $($_.FullName): $($_.Exception.Message)" }
 }
-Get-ChildItem -Path (Join-Path $platformFull "scripts") -Filter "*.ps1" -File -ErrorAction SilentlyContinue | ForEach-Object {
+Get-ChildItem -Path (Join-Path $platformFull "scripts") -Filter "*.ps1" -File -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
     $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
     $hasUtf8Bom = $bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF
-    if ($hasUtf8Bom) { Add-Success "UTF-8 BOM: $($_.Name)" } else { Add-Failure "PowerShell skript nemá UTF-8 BOM: $($_.Name)" }
+    $relativeScript = $_.FullName.Substring($platformFull.Length).TrimStart('\', '/')
+    if ($hasUtf8Bom) { Add-Success "UTF-8 BOM: $relativeScript" } else { Add-Failure "PowerShell skript nemá UTF-8 BOM: $relativeScript" }
     $tokens = $null; $parseErrors = $null
     [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$parseErrors) | Out-Null
-    if ($parseErrors.Count -eq 0) { Add-Success "PowerShell parser: $($_.Name)" }
-    else { foreach ($parseError in $parseErrors) { Add-Failure "PowerShell chyba $($_.Name): $($parseError.Message)" } }
+    if ($parseErrors.Count -eq 0) { Add-Success "PowerShell parser: $relativeScript" }
+    else { foreach ($parseError in $parseErrors) { Add-Failure "PowerShell chyba $relativeScript: $($parseError.Message)" } }
 }
 if (-not [string]::IsNullOrWhiteSpace($WorkspaceRoot)) {
     $workspaceFull = [System.IO.Path]::GetFullPath($WorkspaceRoot)

--- a/scripts/Test-DDDAInstallation.ps1
+++ b/scripts/Test-DDDAInstallation.ps1
@@ -4,17 +4,24 @@ param(
     [string]$WorkspaceRoot,
     [string]$ProjectPath
 )
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
 $failures = [System.Collections.Generic.List[string]]::new()
 function Add-Failure { param([string]$Message) $script:failures.Add($Message); Write-Host "[FAIL] $Message" -ForegroundColor Red }
 function Add-Success { param([string]$Message) Write-Host "[ OK ] $Message" -ForegroundColor Green }
+
 $platformFull = [System.IO.Path]::GetFullPath($PlatformPath)
 try {
     $gitRoot = (& git -C $platformFull rev-parse --show-toplevel 2>&1 | Out-String).Trim()
     if ($LASTEXITCODE -ne 0) { throw $gitRoot }
     Add-Success "Platformní Git repozitář: $gitRoot"
-} catch { Add-Failure "PlatformPath není dostupný Git repozitář: $($_.Exception.Message)" }
+}
+catch {
+    Add-Failure "PlatformPath není dostupný Git repozitář: $($_.Exception.Message)"
+}
+
 $requiredFiles = @(
     "README.md", "USAGE.md", "docs/README.md",
     "docs/cookbooks/README.md", "docs/cookbooks/11-chat-first-pracovni-rezim.md", "docs/cookbooks/12-miro-troubleshooting.md",
@@ -34,43 +41,89 @@ $requiredFiles = @(
     "scripts/Initialize-DDDAAfterClone.ps1", "scripts/Invoke-DDDAMiroSmokeTest.ps1", "scripts/Initialize-DDDAProjectMiro.ps1",
     "scripts/private/DDDAMiroSupport.ps1", "tests/powershell/Test-DDDAMiroAutomation.ps1"
 )
+
+$missingRequiredFiles = @()
 foreach ($relativePath in $requiredFiles) {
-    $fullPath = Join-Path $platformFull $relativePath
-    if (Test-Path $fullPath) { Add-Success "Soubor existuje: $relativePath" }
-    else { Add-Failure "Chybí povinný soubor: $relativePath" }
+    if (-not (Test-Path (Join-Path $platformFull $relativePath))) {
+        $missingRequiredFiles += $relativePath
+    }
 }
-$rootDocs = @(Get-ChildItem -Path (Join-Path $platformFull "docs") -Filter "*.md" -File -ErrorAction SilentlyContinue)
-if ($rootDocs.Count -eq 1 -and $rootDocs[0].Name -eq "README.md") { Add-Success "Kořen docs obsahuje pouze index README.md" }
-else { Add-Failure "Kořen docs smí obsahovat pouze README.md; nalezeno: $($rootDocs.Name -join ', ')" }
-Get-ChildItem -Path (Join-Path $platformFull "schemas") -Filter "*.json" -File -ErrorAction SilentlyContinue | ForEach-Object {
-    try { Get-Content $_.FullName -Raw -Encoding UTF8 | ConvertFrom-Json | Out-Null; Add-Success "JSON je syntakticky validní: $($_.Name)" }
-    catch { Add-Failure "Neplatný JSON $($_.FullName): $($_.Exception.Message)" }
+if ($missingRequiredFiles.Count -eq 0) {
+    Add-Success "Povinné soubory: $($requiredFiles.Count)"
 }
-Get-ChildItem -Path (Join-Path $platformFull "scripts") -Filter "*.ps1" -File -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
-    $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
+else {
+    foreach ($relativePath in $missingRequiredFiles) {
+        Add-Failure "Chybí povinný soubor: $relativePath"
+    }
+}
+
+$scriptFiles = @(Get-ChildItem -Path (Join-Path $platformFull "scripts") -Filter "*.ps1" -File -Recurse -ErrorAction SilentlyContinue)
+$scriptFiles += @(Get-ChildItem -Path (Join-Path $platformFull "tests/powershell") -Filter "*.ps1" -File -Recurse -ErrorAction SilentlyContinue)
+$scriptFiles = @($scriptFiles | Sort-Object FullName -Unique)
+$scriptValidationFailuresBefore = $failures.Count
+foreach ($scriptFile in $scriptFiles) {
+    $relativeScript = $scriptFile.FullName.Substring($platformFull.Length).TrimStart('\', '/')
+    $bytes = [System.IO.File]::ReadAllBytes($scriptFile.FullName)
     $hasUtf8Bom = $bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF
-    $relativeScript = $_.FullName.Substring($platformFull.Length).TrimStart('\', '/')
-    if ($hasUtf8Bom) { Add-Success "UTF-8 BOM: $relativeScript" } else { Add-Failure "PowerShell skript nemá UTF-8 BOM: $relativeScript" }
-    $tokens = $null; $parseErrors = $null
-    [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$parseErrors) | Out-Null
-    if ($parseErrors.Count -eq 0) { Add-Success "PowerShell parser: $relativeScript" }
-    else { foreach ($parseError in $parseErrors) { Add-Failure "PowerShell chyba $relativeScript: $($parseError.Message)" } }
+    if (-not $hasUtf8Bom) {
+        Add-Failure "PowerShell skript nemá UTF-8 BOM: $relativeScript"
+    }
+
+    $tokens = $null
+    $parseErrors = $null
+    [System.Management.Automation.Language.Parser]::ParseFile($scriptFile.FullName, [ref]$tokens, [ref]$parseErrors) | Out-Null
+    foreach ($parseError in @($parseErrors)) {
+        Add-Failure "PowerShell chyba $relativeScript na řádku $($parseError.Extent.StartLineNumber): $($parseError.Message)"
+    }
 }
+if ($failures.Count -eq $scriptValidationFailuresBefore) {
+    Add-Success "PowerShell parser a UTF-8 BOM: $($scriptFiles.Count) skriptů"
+}
+
+$rootDocs = @(Get-ChildItem -Path (Join-Path $platformFull "docs") -Filter "*.md" -File -ErrorAction SilentlyContinue)
+if ($rootDocs.Count -eq 1 -and $rootDocs[0].Name -eq "README.md") {
+    Add-Success "Kořen docs obsahuje pouze index README.md"
+}
+else {
+    Add-Failure "Kořen docs smí obsahovat pouze README.md; nalezeno: $($rootDocs.Name -join ', ')"
+}
+
+$schemaFiles = @(Get-ChildItem -Path (Join-Path $platformFull "schemas") -Filter "*.json" -File -ErrorAction SilentlyContinue)
+$schemaFailuresBefore = $failures.Count
+foreach ($schemaFile in $schemaFiles) {
+    try {
+        Get-Content $schemaFile.FullName -Raw -Encoding UTF8 | ConvertFrom-Json | Out-Null
+    }
+    catch {
+        Add-Failure "Neplatný JSON $($schemaFile.FullName): $($_.Exception.Message)"
+    }
+}
+if ($failures.Count -eq $schemaFailuresBefore) {
+    Add-Success "JSON schémata: $($schemaFiles.Count)"
+}
+
 if (-not [string]::IsNullOrWhiteSpace($WorkspaceRoot)) {
     $workspaceFull = [System.IO.Path]::GetFullPath($WorkspaceRoot)
     foreach ($name in @("workspace.yaml", "DDDA.code-workspace", "projects")) {
         $path = Join-Path $workspaceFull $name
-        if (Test-Path $path) { Add-Success "Workspace položka existuje: $path" } else { Add-Failure "Workspace položka chybí: $path" }
+        if (Test-Path $path) { Add-Success "Workspace položka existuje: $path" }
+        else { Add-Failure "Workspace položka chybí: $path" }
     }
 }
+
 if (-not [string]::IsNullOrWhiteSpace($ProjectPath)) {
     $projectFull = [System.IO.Path]::GetFullPath($ProjectPath)
     foreach ($name in @(".git", "project.yaml", "ddda.lock.yaml", "artifacts", "ingestion", "decisions", "workshops", "workshops/prompts", "miro", "miro/miro-map.yaml", "miro/sync-state.yaml", "miro/conflicts", "reports", "reports/miro-sync", "exports")) {
         $path = Join-Path $projectFull $name
-        if (Test-Path $path) { Add-Success "Projektová položka existuje: $path" } else { Add-Failure "Projektová položka chybí: $path" }
+        if (Test-Path $path) { Add-Success "Projektová položka existuje: $path" }
+        else { Add-Failure "Projektová položka chybí: $path" }
     }
 }
+
 Write-Host ""
-if ($failures.Count -gt 0) { Write-Host "DDDA diagnostika selhala: $($failures.Count) problémů." -ForegroundColor Red; exit 1 }
+if ($failures.Count -gt 0) {
+    Write-Host "DDDA diagnostika selhala: $($failures.Count) problémů." -ForegroundColor Red
+    exit 1
+}
 Write-Host "DDDA diagnostika proběhla úspěšně." -ForegroundColor Green
 exit 0

--- a/scripts/private/DDDAMiroSupport.ps1
+++ b/scripts/private/DDDAMiroSupport.ps1
@@ -1,0 +1,391 @@
+﻿Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Test-DDDAIsWindows {
+    return ($env:OS -eq "Windows_NT" -or $PSVersionTable.PSEdition -eq "Desktop")
+}
+
+function Get-DDDAStateRoot {
+    if (Test-DDDAIsWindows) {
+        if ([string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+            throw "LOCALAPPDATA není dostupné; nelze určit lokální DDDA state adresář."
+        }
+        return (Join-Path $env:LOCALAPPDATA "DDDA")
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:XDG_STATE_HOME)) {
+        return (Join-Path $env:XDG_STATE_HOME "ddda")
+    }
+
+    $homePath = [Environment]::GetFolderPath("UserProfile")
+    if ([string]::IsNullOrWhiteSpace($homePath)) {
+        throw "Nelze určit domovský adresář pro DDDA state."
+    }
+    return (Join-Path $homePath ".local/state/ddda")
+}
+
+function Get-DDDAMiroSecretPath {
+    return (Join-Path (Get-DDDAStateRoot) "secrets/miro-access-token.xml")
+}
+
+function ConvertFrom-DDDASecureString {
+    param([Parameter(Mandatory = $true)][Security.SecureString]$SecureValue)
+
+    $pointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureValue)
+    try {
+        return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($pointer)
+    }
+    finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($pointer)
+    }
+}
+
+function Clear-DDDAMiroAccessToken {
+    $secretPath = Get-DDDAMiroSecretPath
+    if (Test-Path $secretPath) {
+        Remove-Item -Path $secretPath -Force
+    }
+}
+
+function Get-DDDAMiroAccessToken {
+    param(
+        [switch]$ResetToken,
+        [switch]$NonInteractive
+    )
+
+    $secretPath = Get-DDDAMiroSecretPath
+    $secretRoot = Split-Path -Parent $secretPath
+
+    if ($ResetToken) {
+        Clear-DDDAMiroAccessToken
+    }
+
+    if (Test-Path Env:\MIRO_ACCESS_TOKEN) {
+        $token = [string]$env:MIRO_ACCESS_TOKEN
+        if ([string]::IsNullOrWhiteSpace($token)) {
+            throw "MIRO_ACCESS_TOKEN je nastaven, ale je prázdný."
+        }
+
+        if (Test-DDDAIsWindows) {
+            New-Item -ItemType Directory -Path $secretRoot -Force | Out-Null
+            $secureToken = ConvertTo-SecureString $token -AsPlainText -Force
+            $secureToken | Export-Clixml -Path $secretPath
+        }
+        return $token
+    }
+
+    if ((Test-DDDAIsWindows) -and (Test-Path $secretPath)) {
+        $secureToken = Import-Clixml -Path $secretPath
+        $token = ConvertFrom-DDDASecureString -SecureValue $secureToken
+        if ([string]::IsNullOrWhiteSpace($token)) {
+            throw "Uložený Miro token je prázdný. Použij -ResetToken."
+        }
+        return $token
+    }
+
+    if ($NonInteractive) {
+        throw "Miro token není dostupný. Nastav MIRO_ACCESS_TOKEN nebo spusť interaktivně bez -NonInteractive."
+    }
+
+    $secureToken = Read-Host "Vlož Miro access token" -AsSecureString
+    $token = ConvertFrom-DDDASecureString -SecureValue $secureToken
+    if ([string]::IsNullOrWhiteSpace($token)) {
+        throw "Miro token je prázdný."
+    }
+
+    if (Test-DDDAIsWindows) {
+        New-Item -ItemType Directory -Path $secretRoot -Force | Out-Null
+        $secureToken | Export-Clixml -Path $secretPath
+    }
+    else {
+        Write-Warning "Na tomto systému se token nepersistuje. Pro další běh nastav MIRO_ACCESS_TOKEN."
+    }
+
+    return $token
+}
+
+function ConvertTo-DDDAJsonUtf8Bytes {
+    param([Parameter(Mandatory = $true)][object]$Body)
+
+    $json = $Body | ConvertTo-Json -Depth 20 -Compress
+    return [pscustomobject]@{
+        Json = $json
+        Bytes = [System.Text.Encoding]::UTF8.GetBytes($json)
+    }
+}
+
+function Invoke-DDDAMiroApi {
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet("GET", "POST", "PATCH", "DELETE")][string]$Method,
+        [Parameter(Mandatory = $true)][string]$Uri,
+        [Parameter(Mandatory = $true)][string]$AccessToken,
+        [object]$Body
+    )
+
+    $headers = @{ Authorization = "Bearer $AccessToken"; Accept = "application/json" }
+    $json = $null
+
+    try {
+        if ($PSBoundParameters.ContainsKey("Body")) {
+            $encoded = ConvertTo-DDDAJsonUtf8Bytes -Body $Body
+            $json = $encoded.Json
+            return Invoke-RestMethod -Method $Method -Uri $Uri -Headers $headers -ContentType "application/json; charset=utf-8" -Body $encoded.Bytes
+        }
+
+        return Invoke-RestMethod -Method $Method -Uri $Uri -Headers $headers
+    }
+    catch {
+        $statusCode = $null
+        $responseBody = $null
+
+        try {
+            $response = $_.Exception.Response
+            if ($null -ne $response) {
+                try { $statusCode = [int]$response.StatusCode } catch {}
+
+                if ($response.PSObject.Properties["Content"] -and $null -ne $response.Content) {
+                    try { $responseBody = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult() } catch {}
+                }
+
+                if ([string]::IsNullOrWhiteSpace([string]$responseBody) -and $response.PSObject.Methods["GetResponseStream"]) {
+                    $stream = $response.GetResponseStream()
+                    if ($null -ne $stream) {
+                        $reader = New-Object System.IO.StreamReader($stream)
+                        try { $responseBody = $reader.ReadToEnd() }
+                        finally { $reader.Dispose() }
+                    }
+                }
+            }
+        }
+        catch {
+        }
+
+        if ([string]::IsNullOrWhiteSpace([string]$responseBody)) {
+            $responseBody = $_.Exception.Message
+        }
+
+        $requestInfo = ""
+        if (-not [string]::IsNullOrWhiteSpace([string]$json)) {
+            $requestInfo = "`nRequest body: $json"
+        }
+
+        throw ("Miro API {0} {1} selhalo. HTTP {2}. Response: {3}{4}" -f $Method, $Uri, $statusCode, $responseBody, $requestInfo)
+    }
+}
+
+function Assert-DDDAMiroTokenScopes {
+    param([Parameter(Mandatory = $true)][string]$AccessToken)
+
+    $context = Invoke-DDDAMiroApi -Method GET -Uri "https://api.miro.com/v1/oauth-token" -AccessToken $AccessToken
+    $contextJson = $context | ConvertTo-Json -Depth 20
+    if (($contextJson -notmatch "boards:read") -or ($contextJson -notmatch "boards:write")) {
+        throw "Miro token nemá požadované scopes boards:read a boards:write."
+    }
+    return $context
+}
+
+function Get-DDDAObjectPropertyValue {
+    param(
+        [object]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [object]$DefaultValue = $null
+    )
+
+    if ($null -eq $InputObject) {
+        return $DefaultValue
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        if ($InputObject.Contains($Name)) {
+            return $InputObject[$Name]
+        }
+        return $DefaultValue
+    }
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $DefaultValue
+    }
+
+    return $property.Value
+}
+
+function Get-DDDAAllMiroItems {
+    param(
+        [Parameter(Mandatory = $true)][string]$BoardId,
+        [Parameter(Mandatory = $true)][string]$AccessToken
+    )
+
+    $items = @()
+    $cursor = $null
+    $boardSegment = [Uri]::EscapeDataString($BoardId)
+
+    do {
+        $uri = "https://api.miro.com/v2/boards/$boardSegment/items?limit=50"
+        if ($cursor) {
+            $uri += "&cursor=" + [Uri]::EscapeDataString([string]$cursor)
+        }
+
+        $page = Invoke-DDDAMiroApi -Method GET -Uri $uri -AccessToken $AccessToken
+        $pageData = Get-DDDAObjectPropertyValue -InputObject $page -Name "data" -DefaultValue @()
+        if ($pageData) {
+            $items += @($pageData)
+        }
+        $cursor = Get-DDDAObjectPropertyValue -InputObject $page -Name "cursor"
+    }
+    while ($cursor)
+
+    return $items
+}
+
+function Find-DDDAMiroItemByMarker {
+    param(
+        [Parameter(Mandatory = $true)][string]$BoardId,
+        [Parameter(Mandatory = $true)][string]$Marker,
+        [Parameter(Mandatory = $true)][string]$AccessToken
+    )
+
+    foreach ($item in @(Get-DDDAAllMiroItems -BoardId $BoardId -AccessToken $AccessToken)) {
+        $data = Get-DDDAObjectPropertyValue -InputObject $item -Name "data"
+        $content = Get-DDDAObjectPropertyValue -InputObject $data -Name "content" -DefaultValue ""
+        if ([string]::IsNullOrWhiteSpace([string]$content)) {
+            $content = Get-DDDAObjectPropertyValue -InputObject $data -Name "title" -DefaultValue ""
+        }
+
+        if ([string]$content -match [regex]::Escape($Marker)) {
+            return $item
+        }
+    }
+
+    return $null
+}
+
+function Assert-DDDALastExitCode {
+    param([Parameter(Mandatory = $true)][string]$Operation)
+
+    if ($LASTEXITCODE -ne 0) {
+        throw ("{0} selhalo. Exit code: {1}" -f $Operation, $LASTEXITCODE)
+    }
+}
+
+function Invoke-DDDAChildPowerShell {
+    param(
+        [Parameter(Mandatory = $true)][string]$ScriptPath,
+        [string[]]$Arguments = @()
+    )
+
+    $hostExe = (Get-Process -Id $PID).Path
+    $hostArguments = @("-NoProfile")
+    if (Test-DDDAIsWindows) {
+        $hostArguments += @("-ExecutionPolicy", "Bypass")
+    }
+    $hostArguments += @("-File", $ScriptPath)
+    $hostArguments += $Arguments
+
+    & $hostExe @hostArguments
+    Assert-DDDALastExitCode -Operation ("PowerShell skript {0}" -f $ScriptPath)
+}
+
+function Resolve-DDDAPythonCommand {
+    foreach ($candidate in @("python", "py")) {
+        if (-not (Get-Command $candidate -ErrorAction SilentlyContinue)) {
+            continue
+        }
+
+        & $candidate --version *> $null
+        if ($LASTEXITCODE -eq 0) {
+            return $candidate
+        }
+    }
+
+    throw "Nebyl nalezen funkční příkaz python ani py. DDDA vyžaduje Python 3.11 nebo novější."
+}
+
+function Invoke-DDDAGit {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryPath,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $output = & git -C $RepositoryPath @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Git selhal v '$RepositoryPath': git $($Arguments -join ' ')`n$output"
+    }
+    return ($output | Out-String).Trim()
+}
+
+function Assert-DDDACleanGitRepository {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryPath,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    $changes = Invoke-DDDAGit -RepositoryPath $RepositoryPath -Arguments @("status", "--porcelain")
+    if (-not [string]::IsNullOrWhiteSpace($changes)) {
+        throw "$Label repozitář není čistý:`n$changes"
+    }
+}
+
+function Get-DDDAWorkspaceProjectPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkspaceRoot,
+        [Parameter(Mandatory = $true)][string]$ProjectId
+    )
+
+    $workspaceFull = [System.IO.Path]::GetFullPath($WorkspaceRoot)
+    $workspaceFile = Join-Path $workspaceFull "workspace.yaml"
+    if (-not (Test-Path $workspaceFile)) {
+        throw "Nenalezen workspace.yaml: $workspaceFile"
+    }
+
+    $currentId = $null
+    foreach ($line in Get-Content -Path $workspaceFile -Encoding UTF8) {
+        if ($line -match '^\s*-\s+id:\s*(?<value>.+?)\s*$') {
+            $currentId = $Matches["value"].Trim().Trim('"').Trim("'")
+            continue
+        }
+
+        if ($currentId -eq $ProjectId -and $line -match '^\s+path:\s*(?<value>.+?)\s*$') {
+            $relativePath = $Matches["value"].Trim().Trim('"').Trim("'")
+            $projectPath = [System.IO.Path]::GetFullPath((Join-Path $workspaceFull $relativePath))
+            if (-not (Test-Path $projectPath)) {
+                throw "Projekt '$ProjectId' je registrován, ale cesta neexistuje: $projectPath"
+            }
+            return $projectPath
+        }
+    }
+
+    throw "Projekt '$ProjectId' nebyl nalezen ve workspace.yaml."
+}
+
+function Get-DDDAMiroMapSnapshot {
+    param([Parameter(Mandatory = $true)][string]$ProjectPath)
+
+    $mapPath = Join-Path $ProjectPath "miro/miro-map.yaml"
+    if (-not (Test-Path $mapPath)) {
+        throw "Nenalezen Miro mapping: $mapPath"
+    }
+
+    $boardId = $null
+    $itemIds = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($line in Get-Content -Path $mapPath -Encoding UTF8) {
+        if ($line -match '^board_id:\s*(?<value>.*?)\s*$') {
+            $value = $Matches["value"].Trim().Trim('"').Trim("'")
+            if ($value -and $value -ne "null") {
+                $boardId = $value
+            }
+        }
+        elseif ($line -match '^\s+miro_item_id:\s*(?<value>.*?)\s*$') {
+            $value = $Matches["value"].Trim().Trim('"').Trim("'")
+            if ($value -and $value -ne "null") {
+                $itemIds.Add($value)
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        BoardId = $boardId
+        ItemIds = @($itemIds | Sort-Object -Unique)
+    }
+}

--- a/tests/powershell/Test-DDDAMiroAutomation.ps1
+++ b/tests/powershell/Test-DDDAMiroAutomation.ps1
@@ -1,0 +1,105 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PlatformPath "scripts/private/DDDAMiroSupport.ps1")
+
+function Assert-Equal {
+    param(
+        [object]$Expected,
+        [object]$Actual,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    if ($Expected -ne $Actual) {
+        throw "$Message Očekáváno: '$Expected'; skutečnost: '$Actual'."
+    }
+}
+
+function Assert-True {
+    param(
+        [bool]$Condition,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+$frame = [pscustomobject]@{ data = [pscustomobject]@{ title = "Discover" } }
+$frameData = Get-DDDAObjectPropertyValue -InputObject $frame -Name "data"
+Assert-Equal -Expected "" -Actual (Get-DDDAObjectPropertyValue -InputObject $frameData -Name "content" -DefaultValue "") -Message "Chybějící data.content musí být bezpečné."
+Assert-Equal -Expected "Discover" -Actual (Get-DDDAObjectPropertyValue -InputObject $frameData -Name "title" -DefaultValue "") -Message "Frame title nebyl načten."
+
+$projectId = "miro-smoke-1234"
+$marker = "DDDA:${projectId}:evt-test"
+Assert-Equal -Expected "DDDA:miro-smoke-1234:evt-test" -Actual $marker -Message "PowerShell marker interpolace je chybná."
+
+$encoded = ConvertTo-DDDAJsonUtf8Bytes -Body @{ data = @{ content = "Pojistná smlouva byla vydána" } }
+$decoded = [System.Text.Encoding]::UTF8.GetString($encoded.Bytes)
+Assert-True -Condition ($decoded -match "Pojistná smlouva byla vydána") -Message "JSON request body není UTF-8."
+Assert-True -Condition ($encoded.Json -eq $decoded) -Message "JSON text a UTF-8 bytes se liší."
+
+$encodedBoardId = [Uri]::EscapeDataString("uXjVH4yfs6Y=")
+Assert-True -Condition ($encodedBoardId.EndsWith("%3D")) -Message "Board ID není bezpečně URL encoded."
+
+$platformFull = [System.IO.Path]::GetFullPath($PlatformPath).TrimEnd('\', '/')
+$secretFull = [System.IO.Path]::GetFullPath((Get-DDDAMiroSecretPath))
+Assert-True -Condition (-not $secretFull.StartsWith($platformFull, [System.StringComparison]::OrdinalIgnoreCase)) -Message "Secret store nesmí být uvnitř platformního Git rootu."
+
+$tempRoot = Join-Path $env:TEMP ("ddda-automation-test-" + [Guid]::NewGuid().ToString("N"))
+try {
+    New-Item -ItemType Directory -Path (Join-Path $tempRoot "projects/sample/miro") -Force | Out-Null
+    Set-Content -Path (Join-Path $tempRoot "workspace.yaml") -Encoding UTF8 -Value @(
+        "workspace:",
+        "  id: test",
+        "projects:",
+        "  - id: sample",
+        "    path: projects/sample",
+        "    repository: null",
+        "    status: active"
+    )
+    Set-Content -Path (Join-Path $tempRoot "projects/sample/miro/miro-map.yaml") -Encoding UTF8 -Value @(
+        "project_id: sample",
+        "board_id: 'board-1'",
+        "items:",
+        "  item-1:",
+        "    miro_item_id: 'item-1'",
+        "frames:",
+        "  frame-1:",
+        "    miro_item_id: 'frame-1'"
+    )
+
+    $projectPath = Get-DDDAWorkspaceProjectPath -WorkspaceRoot $tempRoot -ProjectId "sample"
+    Assert-Equal -Expected ([System.IO.Path]::GetFullPath((Join-Path $tempRoot "projects/sample"))) -Actual $projectPath -Message "Projekt nebyl nalezen ve workspace registru."
+
+    $snapshot = Get-DDDAMiroMapSnapshot -ProjectPath $projectPath
+    Assert-Equal -Expected "board-1" -Actual $snapshot.BoardId -Message "Board ID nebylo načteno z mappingu."
+    Assert-Equal -Expected 2 -Actual @($snapshot.ItemIds).Count -Message "Miro item ID nebyla načtena z mappingu."
+}
+finally {
+    if (Test-Path $tempRoot) {
+        Remove-Item $tempRoot -Recurse -Force
+    }
+}
+
+$smokeCommand = Get-Command (Join-Path $PlatformPath "scripts/Invoke-DDDAMiroSmokeTest.ps1")
+foreach ($parameterName in @("ResetToken", "KeepArtifacts", "CleanupOnFailure", "Full", "NonInteractive")) {
+    Assert-True -Condition $smokeCommand.Parameters.ContainsKey($parameterName) -Message "Smoke runner nemá parametr $parameterName."
+}
+
+$projectCommand = Get-Command (Join-Path $PlatformPath "scripts/Initialize-DDDAProjectMiro.ps1")
+foreach ($parameterName in @("WorkspaceRoot", "ProjectId", "CreateBoard", "DryRun", "ResetToken")) {
+    Assert-True -Condition $projectCommand.Parameters.ContainsKey($parameterName) -Message "Project Miro initializer nemá parametr $parameterName."
+}
+
+$smokeText = Get-Content (Join-Path $PlatformPath "scripts/Invoke-DDDAMiroSmokeTest.ps1") -Raw -Encoding UTF8
+Assert-True -Condition ($smokeText -notmatch "romanhlavac/ddd-accelerator") -Message "Smoke runner nesmí být svázán s konkrétním origin remote."
+Assert-True -Condition ($smokeText -match 'DDDA:\$\{projectId\}:evt-smoke-policy-issued') -Message "Smoke runner nepoužívá bezpečnou interpolaci markeru."
+
+Write-Host "DDDA Miro automation tests: PASS"


### PR DESCRIPTION
## Scope

`platform` — rutinní inicializace po clone, opakovatelný online Miro smoke test a bezpečná inicializace projektového Miro boardu.

## Co se implementuje

### Inicializace po clone

- nový orchestrátor `Initialize-DDDAAfterClone.ps1`,
- kontrola čistého Git rootu a povinných souborů,
- detekce funkčního Pythonu,
- instalace Miro runtime,
- offline provozní kontrola jedním příkazem,
- volitelný navazující online smoke test přes `-WithMiro`.

### Opakovatelný online Miro smoke test

- produkční `Invoke-DDDAMiroSmokeTest.ps1`,
- jednorázové skryté zadání access tokenu,
- bezpečné uložení tokenu pomocí DPAPI mimo Git root na Windows,
- ověření scopes `boards:read` a `boards:write`,
- izolovaný workspace, projekt a testovací board pro každý běh,
- renderer dry-run a skutečný render,
- YAML → Miro a Miro → YAML,
- explicitní `PromoteNew`,
- volitelný dvoucyklový polling worker,
- závěrečná idempotence bez operací a konfliktů,
- automatický cleanup po úspěchu,
- zachování diagnostického boardu a workspace po chybě,
- auditní JSON report mimo repozitář.

### Inicializace cílového projektového boardu

- nový `Initialize-DDDAProjectMiro.ps1`,
- projekt se vyhledá přes `workspace.yaml`,
- board vlastní konkrétní projektový repozitář, nikoli workspace,
- povinný dry-run před write operací,
- vytvoření nebo aktualizace boardu,
- online doctor,
- druhý kontrolní render,
- kontrola stejného board ID a stabilní množiny mapped item ID,
- změny jsou omezené na projektové `miro/`,
- žádný automatický Git commit nebo push.

### Testy a dokumentace

- PowerShell regresní testy pro chybějící `data.content`, frame `data.title`, bezpečnou interpolaci markerů, UTF-8 JSON, URL encoding a secret-store boundary,
- CI kontrola v PowerShellu 7 a Windows PowerShellu 5.1,
- cookbook 13 pro rutinní inicializaci po clone,
- cookbook 14 pro cílový projektový Miro board,
- aktualizovaný quick start a dokumentační index,
- ignorování `*.egg-info/` vytvářeného editable instalací.

## Bezpečnostní hranice

- token není zapisován do Gitu, reportu ani příkazové historie,
- token se neposílá do chybového výpisu,
- online smoke test nepoužívá klientský projektový board,
- při chybě se prostředky standardně nemažou, aby zůstala diagnostika,
- skripty neprovádějí Git commit, push, merge ani release,
- `board_id` je integrační identita a může být verzováno v projektovém mappingu; access token je secret.

## Validace

CI ověřuje:

- strukturu dokumentace a schémata,
- existenci a PowerShell syntaxi všech nových skriptů včetně private helperu,
- UTF-8 BOM pro Windows PowerShell 5.1,
- regresní testy Miro automation helperů,
- offline `Initialize-DDDAAfterClone.ps1`,
- bootstrap workspace/projektu a offline Miro doctor.

Lokálně je před označením PR jako ready potřeba provést:

```powershell
.\scripts\Initialize-DDDAAfterClone.ps1 -WithMiro -Full
```

a následně inicializaci cílového boardu na testovacím projektu přes `Initialize-DDDAProjectMiro.ps1 -CreateBoard`.
