### PR TITLE
Automatizovat první spuštění workspace a referenčního example projektu

### DIFF
--- a/.github/workflows/validate-ddda.yml
+++ b/.github/workflows/validate-ddda.yml
@@ -104,10 +104,10 @@ jobs:
       - name: Test Miro automation helpers
         shell: pwsh
         run: ./tests/powershell/Test-DDDAMiroAutomation.ps1 -PlatformPath $PWD
-      - name: Initialize platform after clone
+      - name: Test complete offline first run
         shell: pwsh
-        run: ./scripts/Initialize-DDDAAfterClone.ps1 -PlatformPath $PWD -NonInteractive
-      - name: Bootstrap workspace, project and run offline doctor
+        run: ./tests/powershell/Test-DDDAFirstRun.ps1 -PlatformPath $PWD
+      - name: Bootstrap generic workspace, project and run offline doctor
         shell: pwsh
         run: |
           $workspace = Join-Path $env:RUNNER_TEMP "ddda-smoke-pwsh"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ DDDA je chat-first, Miro-first a Git-verzované pracovní prostředí pro domén
 - dry-run, explicitní konflikty, tombstone delete, auditní sync reporty a idempotentní mapping,
 - řízený polling worker pro průběžnou synchronizaci,
 - automatizovaná inicializace po clone a opakovatelný online Miro smoke test,
+- automatizované vytvoření workspace a materializace referenčního example projektu,
 - idempotentní inicializace cílového Miro boardu pro konkrétní projekt,
 - Mermaid jako odvozená textová projekce,
 - česká metodika, kuchařky, typové workflow a referenční projekt životní pojišťovny.
@@ -27,9 +28,11 @@ DDDA je chat-first, Miro-first a Git-verzované pracovní prostředí pro domén
 
 Sémantický konflikt se nikdy neřeší implicitním last-write-wins. Runtime vytvoří conflict record a vyžádá rozhodnutí.
 
-## Rychlý start
+## Kanonický první start
 
-Před spuštěním se přesuň do **parent adresáře**, ve kterém má vzniknout `DDDA-Workspace`.
+Toto je doporučený postup pro nového uživatele. Po `git clone` se workspace, referenční example projekt i oba Miro smoke testy spouštějí jedním orchestrátorem.
+
+Z parent adresáře, ve kterém má vzniknout `DDDA-Workspace`:
 
 ```powershell
 New-Item -ItemType Directory -Force .\DDDA-Workspace\platform | Out-Null
@@ -38,54 +41,79 @@ git clone `
   https://github.com/romanhlavac/ddd-accelerator.git `
   .\DDDA-Workspace\platform\ddd-accelerator
 
-$WorkspaceRoot = (Resolve-Path .\DDDA-Workspace).Path
-$PlatformRoot = (Resolve-Path .\DDDA-Workspace\platform\ddd-accelerator).Path
+Set-Location .\DDDA-Workspace\platform\ddd-accelerator
 
-& (Join-Path $PlatformRoot 'scripts\Initialize-DDDAAfterClone.ps1') `
-  -PlatformPath $PlatformRoot `
-  -WithMiro `
-  -Full
+.\scripts\Initialize-DDDAFirstRun.ps1 -WithMiro -Full
+```
 
-& (Join-Path $PlatformRoot 'scripts\Initialize-DDDAWorkspace.ps1') `
-  -WorkspaceRoot $WorkspaceRoot
+Jediný příkaz po clone automaticky provede:
 
-& (Join-Path $PlatformRoot 'scripts\New-DDDAProject.ps1') `
-  -WorkspaceRoot $WorkspaceRoot `
-  -ProjectId life-insurance-greenfield `
-  -Name 'Nová životní pojišťovna' `
-  -Type portfolio-program `
-  -TypeAlias greenfield-portfolio
+1. kontrolu platformy, Pythonu a PowerShell skriptů;
+2. instalaci Miro runtime;
+3. izolovaný online platformní Miro smoke test;
+4. vytvoření `DDDA-Workspace`;
+5. materializaci skutečného referenčního projektu `life-insurance-greenfield` včetně artifacts, ingestion a workshop prompts;
+6. kontrolu workspace a projektu;
+7. vytvoření cílového Miro boardu example projektu;
+8. online doctor a idempotentní kontrolní render projektového boardu.
 
-& (Join-Path $PlatformRoot 'scripts\Initialize-DDDAProjectMiro.ps1') `
-  -WorkspaceRoot $WorkspaceRoot `
-  -ProjectId life-insurance-greenfield `
+První online běh si vyžádá Miro access token se scopes `boards:read` a `boards:write`. Na Windows jej uloží pomocí DPAPI mimo Git root. Skript neprovádí automatický push, merge ani commit projektového Miro mappingu.
+
+Detailní iniciační postup a očekávané výstupy jsou v [kuchařce 15 — První spuštění a referenční example projekt](docs/cookbooks/15-prvni-spusteni-a-example-projekt.md).
+
+## Offline první start
+
+Bez Miro API:
+
+```powershell
+.\scripts\Initialize-DDDAFirstRun.ps1
+```
+
+Tím vznikne a projde kontrolou workspace i referenční example projekt. Projektový board lze doplnit později:
+
+```powershell
+.\scripts\Initialize-DDDAProjectMiro.ps1 `
+  -WorkspaceRoot '..\..' `
+  -ProjectId 'life-insurance-greenfield' `
   -CreateBoard
 ```
 
-První online běh si vyžádá Miro access token se scopes `boards:read` a `boards:write`. Na Windows jej uloží pomocí DPAPI mimo Git root. Další smoke testy a inicializace projektových boardů stejný token znovu použijí.
+## Samostatné provozní příkazy
 
-Pouze offline inicializace bez Miro API:
-
-```powershell
-& (Join-Path $PlatformRoot 'scripts\Initialize-DDDAAfterClone.ps1') `
-  -PlatformPath $PlatformRoot
-```
-
-## Samostatný online Miro smoke test
+Pouze platformní inicializace po clone:
 
 ```powershell
-& (Join-Path $PlatformRoot 'scripts\Invoke-DDDAMiroSmokeTest.ps1') `
-  -PlatformPath $PlatformRoot `
-  -Full
+.\scripts\Initialize-DDDAAfterClone.ps1 -WithMiro -Full
 ```
 
-Test vytvoří izolovaný workspace, projekt a board, ověří YAML ↔ Miro, `PromoteNew`, polling worker a idempotenci. Po úspěchu board a workspace odstraní; při chybě je ponechá pro diagnostiku.
+Pouze opakovaný online Miro smoke test platformy:
+
+```powershell
+.\scripts\Invoke-DDDAMiroSmokeTest.ps1 -Full
+```
+
+Pouze materializace referenčního example projektu v existujícím workspace:
+
+```powershell
+.\scripts\New-DDDAExampleProject.ps1 -WorkspaceRoot '..\..'
+```
+
+Pouze vytvoření nebo kontrolní render projektového boardu:
+
+```powershell
+.\scripts\Initialize-DDDAProjectMiro.ps1 `
+  -WorkspaceRoot '..\..' `
+  -ProjectId 'life-insurance-greenfield' `
+  -CreateBoard
+```
 
 ## Řízený synchronizační worker
 
 Pro průběžnou spolupráci lze spustit polling worker. Worker nejméně jednou za 30 sekund provede kontrolovaný režim `Both`, zapisuje auditní report a při prvním konfliktu se ukončí s exit code `2`, aby se konflikt nešířil dál.
 
 ```powershell
+$WorkspaceRoot = (Resolve-Path '..\..').Path
+$PlatformRoot = (Resolve-Path '.').Path
 $ProjectRoot = Join-Path $WorkspaceRoot 'projects\life-insurance-greenfield'
 
 & (Join-Path $PlatformRoot 'scripts\Start-DDDAMiroSyncWorker.ps1') `
@@ -103,4 +131,4 @@ Typický prompt:
 
 ## Dokumentace
 
-Začni v [indexu dokumentace](docs/README.md), pokračuj [hlavním návodem](USAGE.md), [inicializací po clone](docs/cookbooks/13-inicializace-po-clone.md), [inicializací cílového Miro boardu](docs/cookbooks/14-inicializace-ciloveho-miro-boardu.md) a referenčním [greenfield příkladem životní pojišťovny](examples/life-insurance-greenfield/README.md).
+Začni [kuchařkou prvního spuštění](docs/cookbooks/15-prvni-spusteni-a-example-projekt.md), pokračuj [indexem dokumentace](docs/README.md), [hlavním návodem](USAGE.md), [inicializací po clone](docs/cookbooks/13-inicializace-po-clone.md), [inicializací cílového Miro boardu](docs/cookbooks/14-inicializace-ciloveho-miro-boardu.md) a referenčním [greenfield příkladem životní pojišťovny](examples/life-insurance-greenfield/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,14 @@
 
 ## Začít zde
 
-1. [README platformy](../README.md)
-2. [Praktický provozní návod](../USAGE.md)
-3. [Inicializace po clone](cookbooks/13-inicializace-po-clone.md)
-4. [Založení projektu](cookbooks/01-zalozeni-projektu.md)
+1. [První spuštění a referenční example projekt](cookbooks/15-prvni-spusteni-a-example-projekt.md)
+2. [README platformy](../README.md)
+3. [Praktický provozní návod](../USAGE.md)
+4. [Inicializace po clone](cookbooks/13-inicializace-po-clone.md)
 5. [Inicializace cílového Miro boardu](cookbooks/14-inicializace-ciloveho-miro-boardu.md)
-6. [Miro board a synchronizace](cookbooks/02-priprava-miro-boardu.md)
-7. [Referenční projekt životní pojišťovny](../examples/life-insurance-greenfield/README.md)
+6. [Založení vlastního projektu](cookbooks/01-zalozeni-projektu.md)
+7. [Miro board a synchronizace](cookbooks/02-priprava-miro-boardu.md)
+8. [Referenční projekt životní pojišťovny](../examples/life-insurance-greenfield/README.md)
 
 ## Metodika
 
@@ -43,6 +44,7 @@
 - [12 Miro troubleshooting](cookbooks/12-miro-troubleshooting.md)
 - [13 Inicializace po clone](cookbooks/13-inicializace-po-clone.md)
 - [14 Inicializace cílového Miro boardu](cookbooks/14-inicializace-ciloveho-miro-boardu.md)
+- [15 První spuštění a referenční example projekt](cookbooks/15-prvni-spusteni-a-example-projekt.md)
 
 ## Strukturní pravidlo
 

--- a/docs/cookbooks/15-prvni-spusteni-a-example-projekt.md
+++ b/docs/cookbooks/15-prvni-spusteni-a-example-projekt.md
@@ -1,0 +1,200 @@
+# 15 První spuštění a referenční example projekt
+
+## Účel
+
+Toto je **kanonický iniciační postup pro nového uživatele DDDA**. Po `git clone` automatizuje celý řetězec:
+
+1. kontrolu platformy a instalaci runtime;
+2. izolovaný online smoke test proti Miro API;
+3. vytvoření workspace;
+4. materializaci referenčního projektu životní pojišťovny jako samostatného Git repozitáře;
+5. kontrolu workspace a projektu;
+6. vytvoření cílového Miro boardu example projektu;
+7. online doctor a idempotentní kontrolní render projektového boardu.
+
+Nižší úrovně postupu jsou popsány v kuchařkách [13 Inicializace po clone](13-inicializace-po-clone.md) a [14 Inicializace cílového Miro boardu](14-inicializace-ciloveho-miro-boardu.md). Pro první spuštění se jednotlivé příkazy ručně neskládají; používá se orchestrátor níže.
+
+## Předpoklady
+
+- Git;
+- Windows PowerShell 5.1 nebo PowerShell 7;
+- Python 3.11+ dostupný jako `python` nebo `py`;
+- Miro Developer team a aplikace se scopes `boards:read` a `boards:write`;
+- access token aplikace;
+- nastavené `git config user.name` a `git config user.email`, protože example projekt dostane vlastní iniciační commit.
+
+## Standardní clone
+
+Z parent adresáře, ve kterém má vzniknout `DDDA-Workspace`:
+
+```powershell
+New-Item -ItemType Directory -Force .\DDDA-Workspace\platform | Out-Null
+
+git clone `
+  https://github.com/romanhlavac/ddd-accelerator.git `
+  .\DDDA-Workspace\platform\ddd-accelerator
+
+Set-Location .\DDDA-Workspace\platform\ddd-accelerator
+```
+
+## Jediný příkaz po clone
+
+```powershell
+.\scripts\Initialize-DDDAFirstRun.ps1 -WithMiro -Full
+```
+
+Při standardní topologii skript automaticky odvodí `WorkspaceRoot` jako adresář `DDDA-Workspace`. Při jiné topologii jej lze zadat explicitně:
+
+```powershell
+.\scripts\Initialize-DDDAFirstRun.ps1 `
+  -WorkspaceRoot 'C:\path\to\DDDA-Workspace' `
+  -WithMiro `
+  -Full
+```
+
+## Co proběhne automaticky
+
+### 1. Platforma po clone
+
+Orchestrátor spustí `Initialize-DDDAAfterClone.ps1`:
+
+- ověří čistý platformní Git root;
+- zkontroluje povinné soubory a PowerShell syntaxi;
+- nainstaluje Miro runtime do ignorovaného `.ddda/runtime/miro-venv`;
+- spustí izolovaný online Miro smoke test;
+- ověří YAML → Miro, Miro → YAML, `PromoteNew`, polling worker a idempotenci;
+- po úspěchu odstraní dočasný testovací board a workspace.
+
+Při prvním online běhu se token zadává skrytě. Na Windows se uloží pomocí DPAPI mimo Git root a další kroky jej znovu použijí.
+
+### 2. Workspace
+
+Vznikne:
+
+```text
+DDDA-Workspace/
+├── platform/ddd-accelerator/
+├── projects/
+├── workspace.yaml
+└── DDDA.code-workspace
+```
+
+Existující kompatibilní workspace se znovu použije.
+
+### 3. Referenční example projekt
+
+`New-DDDAExampleProject.ps1` vytvoří samostatný Git repozitář:
+
+```text
+DDDA-Workspace/projects/life-insurance-greenfield/
+```
+
+Do něj materializuje skutečný obsah z `examples/life-insurance-greenfield/`:
+
+- bohatý `project.yaml`;
+- ingestion katalog a interview placeholder;
+- project charter;
+- domain event `policy-issued`;
+- context map;
+- workshopové prompty;
+- prázdný Miro mapping připravený pro první board;
+- aktuální `ddda.lock.yaml` vůči klonované platformě.
+
+Nejde tedy o prázdný projekt pouze pojmenovaný jako example.
+
+### 4. Projektový Miro smoke test
+
+`Initialize-DDDAProjectMiro.ps1 -CreateBoard`:
+
+- provede povinný dry-run;
+- vytvoří cílový board projektu;
+- vyrenderuje metodický scaffold;
+- spustí online doctor;
+- provede druhý kontrolní render;
+- ověří stejné `board_id` a stabilní množinu `miro_item_id`;
+- nevytvoří druhý board ani duplicitní frames.
+
+Toto je první smoke test proti Miro **pro skutečný example projekt**, nikoli pouze platformní dočasný test.
+
+## Očekávaný konec
+
+```text
+DDDA první spuštění: PASS
+Workspace: ...\DDDA-Workspace
+Projekt:   ...\DDDA-Workspace\projects\life-insurance-greenfield
+```
+
+Workspace otevři:
+
+```powershell
+cursor .\DDDA-Workspace\DDDA.code-workspace
+```
+
+Při standardní topologii a práci z platformního rootu:
+
+```powershell
+cursor ..\..\DDDA.code-workspace
+```
+
+## Jediné ruční kroky
+
+Po clone zůstávají záměrně ruční pouze:
+
+1. první skryté zadání Miro access tokenu;
+2. kontrola změny `projects/life-insurance-greenfield/miro/miro-map.yaml`;
+3. projektový commit mappingu po review.
+
+Skript neprovádí automatický push, merge ani commit Miro mappingu.
+
+Kontrola mappingu:
+
+```powershell
+git -C '..\..\projects\life-insurance-greenfield' diff -- miro/miro-map.yaml
+```
+
+Commit po review:
+
+```powershell
+git -C '..\..\projects\life-insurance-greenfield' add miro/miro-map.yaml
+
+git -C '..\..\projects\life-insurance-greenfield' commit -m 'chore: initialize example Miro board'
+```
+
+## Offline varianta
+
+Bez Miro API:
+
+```powershell
+.\scripts\Initialize-DDDAFirstRun.ps1
+```
+
+Vytvoří a ověří workspace i referenční example projekt, ale nevytvoří projektový board. Online část lze doplnit později:
+
+```powershell
+.\scripts\Initialize-DDDAProjectMiro.ps1 `
+  -WorkspaceRoot '..\..' `
+  -ProjectId 'life-insurance-greenfield' `
+  -CreateBoard
+```
+
+## Opakované spuštění a obnova
+
+Orchestrátor je resumable:
+
+- existující workspace znovu použije;
+- existující validní example projekt znovu použije;
+- existující `board_id` z `miro/miro-map.yaml` použije místo vytvoření dalšího boardu;
+- při nečistém projektovém repozitáři se zastaví před Miro write operací.
+
+Při selhání platformního smoke testu zůstává dočasný board a workspace pro diagnostiku. Detaily jsou v kuchařce 13.
+
+## Definition of Done
+
+- výstup končí `DDDA první spuštění: PASS`;
+- platformní Git root je čistý;
+- `workspace.yaml` registruje `life-insurance-greenfield`;
+- example projekt je samostatný Git repozitář;
+- example obsahuje referenční artifacts, ingestion a workshop prompts;
+- projektový Miro board prošel online doctor a idempotentním druhým renderem;
+- projektový diff po online inicializaci je omezen na `miro/`;
+- token není v repozitáři ani reportu.

--- a/docs/cookbooks/15-prvni-spusteni-a-example-projekt.md
+++ b/docs/cookbooks/15-prvni-spusteni-a-example-projekt.md
@@ -184,9 +184,11 @@ Orchestrátor je resumable:
 - existující workspace znovu použije;
 - existující validní example projekt znovu použije;
 - existující `board_id` z `miro/miro-map.yaml` použije místo vytvoření dalšího boardu;
-- při nečistém projektovém repozitáři se zastaví před Miro write operací.
+- po přerušeném projektovém Miro bootstrapu automaticky použije bezpečný `-Resume` režim;
+- `-Resume` připustí pouze necommitnuté změny pod `miro/`; změny v `project.yaml`, artifacts, ingestion nebo jiných projektových souborech běh zastaví;
+- druhý běh znovu provede dry-run, online doctor a idempotentní render bez vytvoření dalšího boardu.
 
-Při selhání platformního smoke testu zůstává dočasný board a workspace pro diagnostiku. Detaily jsou v kuchařce 13.
+Při selhání platformního smoke testu zůstává dočasný board a workspace pro diagnostiku. Detaily jsou v kuchařce 13. Při selhání po vytvoření projektového boardu neupravuj ani nemaž `miro/miro-map.yaml`; po opravě platformy spusť stejný first-run příkaz znovu.
 
 ## Definition of Done
 

--- a/docs/cookbooks/README.md
+++ b/docs/cookbooks/README.md
@@ -28,4 +28,4 @@ Kuchařka je opakovatelný pracovní postup pro chat, workshop, Miro, YAML a Git
 
 ## Doporučené pořadí
 
-Po novém clone začni kuchařkou 13. Potom obvykle následuje 01 → 14 → 02 → 03 → 04 → 06 → 08. Po stabilizaci hranic následuje 05 pro konkrétní BC. Kuchařky 07, 11 a 12 jsou průřezové. Kuchařka 10 rozšiřuje tok legacy modernizace.
+Nový uživatel začíná kuchařkou 15, která automatizuje clone → platformní testy → workspace → referenční example projekt → projektový Miro smoke test. Kuchařky 13 a 14 popisují nižší provozní kroky samostatně. Pro vlastní projekt potom obvykle následuje 01 → 02 → 03 → 04 → 06 → 08. Po stabilizaci hranic následuje 05 pro konkrétní BC. Kuchařky 07, 11 a 12 jsou průřezové. Kuchařka 10 rozšiřuje tok legacy modernizace.

--- a/scripts/Initialize-DDDAFirstRun.ps1
+++ b/scripts/Initialize-DDDAFirstRun.ps1
@@ -47,6 +47,7 @@ $workspaceFull = Resolve-DDDAFirstRunWorkspaceRoot -PlatformRoot $platformRoot -
 $projectId = "life-insurance-greenfield"
 $projectRoot = Join-Path (Join-Path $workspaceFull "projects") $projectId
 $workspaceFile = Join-Path $workspaceFull "workspace.yaml"
+$projectAlreadyExisted = Test-Path $projectRoot
 
 if ($WithMiro -and $NoInitialCommit) {
     throw "-NoInitialCommit nelze kombinovat s -WithMiro. Projektový Miro bootstrap vyžaduje čistý projektový Git repozitář."
@@ -122,6 +123,7 @@ if ($WithMiro) {
         "-ProjectId", $projectId,
         "-CreateBoard"
     )
+    if ($projectAlreadyExisted) { $projectMiroArguments += "-Resume" }
     if ($NonInteractive) { $projectMiroArguments += "-NonInteractive" }
 
     Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/Initialize-DDDAProjectMiro.ps1") -Arguments $projectMiroArguments

--- a/scripts/Initialize-DDDAFirstRun.ps1
+++ b/scripts/Initialize-DDDAFirstRun.ps1
@@ -1,0 +1,143 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+    [string]$WorkspaceRoot,
+    [switch]$WithMiro,
+    [switch]$Full,
+    [switch]$ResetToken,
+    [switch]$KeepArtifacts,
+    [switch]$CleanupOnFailure,
+    [switch]$ForceRecreateRuntime,
+    [switch]$NonInteractive,
+    [switch]$NoInitialCommit
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+try {
+    [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
+    $OutputEncoding = [Console]::OutputEncoding
+}
+catch {
+}
+
+. (Join-Path $PSScriptRoot "private/DDDAMiroSupport.ps1")
+
+function Resolve-DDDAFirstRunWorkspaceRoot {
+    param(
+        [Parameter(Mandatory = $true)][string]$PlatformRoot,
+        [string]$RequestedWorkspaceRoot
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedWorkspaceRoot)) {
+        return [System.IO.Path]::GetFullPath($RequestedWorkspaceRoot)
+    }
+
+    $platformParent = Split-Path -Parent $PlatformRoot
+    if ((Split-Path -Leaf $platformParent) -ieq "platform") {
+        return [System.IO.Path]::GetFullPath((Split-Path -Parent $platformParent))
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path (Split-Path -Parent $PlatformRoot) "DDDA-Workspace"))
+}
+
+$platformRoot = (Resolve-Path $PlatformPath).Path
+$workspaceFull = Resolve-DDDAFirstRunWorkspaceRoot -PlatformRoot $platformRoot -RequestedWorkspaceRoot $WorkspaceRoot
+$projectId = "life-insurance-greenfield"
+$projectRoot = Join-Path (Join-Path $workspaceFull "projects") $projectId
+$workspaceFile = Join-Path $workspaceFull "workspace.yaml"
+
+if ($WithMiro -and $NoInitialCommit) {
+    throw "-NoInitialCommit nelze kombinovat s -WithMiro. Projektový Miro bootstrap vyžaduje čistý projektový Git repozitář."
+}
+
+Write-Host "=== DDDA první spuštění ==="
+Write-Host "Platforma: $platformRoot"
+Write-Host "Workspace: $workspaceFull"
+Write-Host "Example:   $projectId"
+
+$afterCloneArguments = @("-PlatformPath", $platformRoot)
+if ($WithMiro) { $afterCloneArguments += "-WithMiro" }
+if ($Full) { $afterCloneArguments += "-Full" }
+if ($ResetToken) { $afterCloneArguments += "-ResetToken" }
+if ($KeepArtifacts) { $afterCloneArguments += "-KeepArtifacts" }
+if ($CleanupOnFailure) { $afterCloneArguments += "-CleanupOnFailure" }
+if ($ForceRecreateRuntime) { $afterCloneArguments += "-ForceRecreateRuntime" }
+if ($NonInteractive) { $afterCloneArguments += "-NonInteractive" }
+
+Write-Host ""
+Write-Host "=== 1/5 Platforma po clone ==="
+Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/Initialize-DDDAAfterClone.ps1") -Arguments $afterCloneArguments
+
+Write-Host ""
+Write-Host "=== 2/5 Workspace ==="
+if (-not (Test-Path $workspaceFile)) {
+    Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/Initialize-DDDAWorkspace.ps1") -Arguments @(
+        "-WorkspaceRoot", $workspaceFull,
+        "-WorkspaceId", "ddda-example-workspace",
+        "-WorkspaceName", "DDDA Example Workspace"
+    )
+}
+else {
+    Write-Host "Existující workspace bude znovu použit: $workspaceFull"
+}
+
+Write-Host ""
+Write-Host "=== 3/5 Referenční example projekt ==="
+if (-not (Test-Path $projectRoot)) {
+    $exampleArguments = @(
+        "-WorkspaceRoot", $workspaceFull,
+        "-PlatformPath", $platformRoot
+    )
+    if ($NoInitialCommit) { $exampleArguments += "-NoInitialCommit" }
+
+    Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/New-DDDAExampleProject.ps1") -Arguments $exampleArguments
+}
+else {
+    $workspaceText = Get-Content $workspaceFile -Raw -Encoding UTF8
+    if ($workspaceText -notmatch "(?m)^\s*-\s+id:\s*$([regex]::Escape($projectId))\s*$") {
+        throw "Projektový adresář existuje, ale projekt '$projectId' není registrován ve workspace.yaml: $projectRoot"
+    }
+    if (-not (Test-Path (Join-Path $projectRoot "artifacts/align/project-charter.yaml"))) {
+        throw "Existující projekt není materializovaný referenční example: $projectRoot"
+    }
+    Write-Host "Existující referenční example projekt bude znovu použit: $projectRoot"
+}
+
+Write-Host ""
+Write-Host "=== 4/5 Workspace a projektové kontroly ==="
+Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/Test-DDDAInstallation.ps1") -Arguments @(
+    "-PlatformPath", $platformRoot,
+    "-WorkspaceRoot", $workspaceFull,
+    "-ProjectPath", $projectRoot
+)
+
+if ($WithMiro) {
+    Write-Host ""
+    Write-Host "=== 5/5 Projektový Miro board a online smoke test ==="
+    $projectMiroArguments = @(
+        "-PlatformPath", $platformRoot,
+        "-WorkspaceRoot", $workspaceFull,
+        "-ProjectId", $projectId,
+        "-CreateBoard"
+    )
+    if ($NonInteractive) { $projectMiroArguments += "-NonInteractive" }
+
+    Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/Initialize-DDDAProjectMiro.ps1") -Arguments $projectMiroArguments
+}
+else {
+    Write-Host ""
+    Write-Host "=== 5/5 Projektový Miro board ==="
+    Write-Host "Přeskočeno. Pro online první spuštění použij -WithMiro."
+}
+
+Write-Host ""
+Write-Host "DDDA první spuštění: PASS"
+Write-Host "Workspace: $workspaceFull"
+Write-Host "Projekt:   $projectRoot"
+Write-Host "Otevření:  cursor `"$(Join-Path $workspaceFull 'DDDA.code-workspace')`""
+if ($WithMiro) {
+    Write-Host "Miro map:  $(Join-Path $projectRoot 'miro/miro-map.yaml')"
+    Write-Host "Projektový mapping zkontroluj a commituj samostatně; skript commit ani push neprovádí."
+}

--- a/scripts/Initialize-DDDAProjectMiro.ps1
+++ b/scripts/Initialize-DDDAProjectMiro.ps1
@@ -7,7 +7,8 @@ param(
     [switch]$DryRun,
     [switch]$ResetToken,
     [switch]$ForceRecreateRuntime,
-    [switch]$NonInteractive
+    [switch]$NonInteractive,
+    [switch]$Resume
 )
 
 Set-StrictMode -Version Latest
@@ -21,6 +22,7 @@ catch {
 }
 
 . (Join-Path $PSScriptRoot "private/DDDAMiroSupport.ps1")
+. (Join-Path $PSScriptRoot "private/DDDAGitStatus.ps1")
 
 function Invoke-ProjectMiroCli {
     param([Parameter(Mandatory = $true)][string[]]$CommandArguments)
@@ -63,7 +65,17 @@ try {
     }
 
     Assert-DDDACleanGitRepository -RepositoryPath $script:PlatformRoot -Label "Platformní"
-    Assert-DDDACleanGitRepository -RepositoryPath $script:ProjectRoot -Label "Projektový"
+
+    $initialProjectChanges = Invoke-DDDAGit -RepositoryPath $script:ProjectRoot -Arguments @("status", "--porcelain")
+    if ($Resume) {
+        $null = Assert-DDDAGitChangesWithinPath -PorcelainText $initialProjectChanges -AllowedPrefix "miro/" -Label "Projektový repozitář v resume režimu"
+        if (-not [string]::IsNullOrWhiteSpace($initialProjectChanges)) {
+            Write-Host "Resume: používají se existující necommitnuté změny omezené na miro/."
+        }
+    }
+    else {
+        Assert-DDDACleanGitRepository -RepositoryPath $script:ProjectRoot -Label "Projektový"
+    }
 
     $accessToken = Get-DDDAMiroAccessToken -ResetToken:$ResetToken -NonInteractive:$NonInteractive
     $env:MIRO_ACCESS_TOKEN = $accessToken
@@ -102,7 +114,13 @@ try {
 
     if ($DryRun) {
         Assert-DDDACleanGitRepository -RepositoryPath $script:PlatformRoot -Label "Platformní"
-        Assert-DDDACleanGitRepository -RepositoryPath $script:ProjectRoot -Label "Projektový"
+        if ($Resume) {
+            $dryRunProjectChanges = Invoke-DDDAGit -RepositoryPath $script:ProjectRoot -Arguments @("status", "--porcelain")
+            $null = Assert-DDDAGitChangesWithinPath -PorcelainText $dryRunProjectChanges -AllowedPrefix "miro/" -Label "Projektový repozitář po resume dry-run"
+        }
+        else {
+            Assert-DDDACleanGitRepository -RepositoryPath $script:ProjectRoot -Label "Projektový"
+        }
         Write-Host ""
         Write-Host "DDDA projektový Miro dry-run: PASS"
         return
@@ -154,21 +172,13 @@ try {
     Assert-DDDACleanGitRepository -RepositoryPath $script:PlatformRoot -Label "Platformní"
 
     $projectChanges = Invoke-DDDAGit -RepositoryPath $script:ProjectRoot -Arguments @("status", "--porcelain")
-    $unexpectedChanges = @()
-    foreach ($line in @($projectChanges -split "`r?`n")) {
-        if ([string]::IsNullOrWhiteSpace($line)) {
-            continue
-        }
-        $changedPath = $line.Substring([Math]::Min(3, $line.Length)).Trim().Replace('\', '/')
-        if ($changedPath -match ' -> ') {
-            $changedPath = ($changedPath -split ' -> ')[-1]
-        }
-        if (-not $changedPath.StartsWith("miro/")) {
-            $unexpectedChanges += $line
-        }
-    }
+    $projectEntries = @(ConvertFrom-DDDAGitPorcelain -PorcelainText $projectChanges)
+    $unexpectedChanges = @(
+        $projectEntries |
+            Where-Object { -not $_.Path.StartsWith("miro/", [System.StringComparison]::OrdinalIgnoreCase) }
+    )
     if ($unexpectedChanges.Count -gt 0) {
-        throw "Inicializace změnila neočekávané projektové soubory:`n$($unexpectedChanges -join "`n")"
+        throw "Inicializace změnila neočekávané projektové soubory:`n$($unexpectedChanges.Line -join "`n")"
     }
 
     Write-Host ""

--- a/scripts/New-DDDAExampleProject.ps1
+++ b/scripts/New-DDDAExampleProject.ps1
@@ -1,0 +1,99 @@
+﻿[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$WorkspaceRoot,
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+    [string]$RemoteUrl,
+    [switch]$NoInitialCommit
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+try {
+    [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
+    $OutputEncoding = [Console]::OutputEncoding
+}
+catch {
+}
+
+. (Join-Path $PSScriptRoot "private/DDDAMiroSupport.ps1")
+
+$projectId = "life-insurance-greenfield"
+$projectName = "Greenfield životní pojišťovna"
+$platformRoot = (Resolve-Path $PlatformPath).Path
+$workspaceFull = [System.IO.Path]::GetFullPath($WorkspaceRoot)
+$workspaceFile = Join-Path $workspaceFull "workspace.yaml"
+$exampleRoot = Join-Path $platformRoot "examples/life-insurance-greenfield"
+$projectRoot = Join-Path (Join-Path $workspaceFull "projects") $projectId
+
+if (-not (Test-Path $workspaceFile)) {
+    throw "Workspace není inicializován: $workspaceFile"
+}
+if (-not (Test-Path (Join-Path $exampleRoot "project.yaml"))) {
+    throw "Referenční example nebyl nalezen: $exampleRoot"
+}
+if (Test-Path $projectRoot) {
+    throw "Cílový example projekt již existuje: $projectRoot"
+}
+
+Assert-DDDACleanGitRepository -RepositoryPath $platformRoot -Label "Platformní"
+
+$exampleManifest = Get-Content (Join-Path $exampleRoot "project.yaml") -Raw -Encoding UTF8
+if ($exampleManifest -notmatch "(?m)^\s*id:\s*$([regex]::Escape($projectId))\s*$") {
+    throw "Referenční example nemá očekávané project.id '$projectId'."
+}
+
+$newProjectArguments = @(
+    "-WorkspaceRoot", $workspaceFull,
+    "-ProjectId", $projectId,
+    "-Name", $projectName,
+    "-Type", "portfolio-program",
+    "-TypeAlias", "greenfield-portfolio",
+    "-NoInitialCommit"
+)
+if (-not [string]::IsNullOrWhiteSpace($RemoteUrl)) {
+    $newProjectArguments += @("-RemoteUrl", $RemoteUrl)
+}
+
+Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/New-DDDAProject.ps1") -Arguments $newProjectArguments
+
+try {
+    Copy-Item -Path (Join-Path $exampleRoot "*") -Destination $projectRoot -Recurse -Force
+
+    $mapPath = Join-Path $projectRoot "miro/miro-map.yaml"
+    $mapText = Get-Content $mapPath -Raw -Encoding UTF8
+    if ($mapText -notmatch "(?m)^board_id:\s*null\s*$") {
+        throw "Referenční Miro mapping musí před prvním během obsahovat board_id: null."
+    }
+
+    Invoke-DDDAChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/Test-DDDAInstallation.ps1") -Arguments @(
+        "-PlatformPath", $platformRoot,
+        "-WorkspaceRoot", $workspaceFull,
+        "-ProjectPath", $projectRoot
+    )
+
+    if (-not $NoInitialCommit) {
+        Invoke-DDDAGit -RepositoryPath $projectRoot -Arguments @("add", ".") | Out-Null
+        try {
+            Invoke-DDDAGit -RepositoryPath $projectRoot -Arguments @("commit", "-m", "chore: initialize DDDA reference example") | Out-Null
+        }
+        catch {
+            throw "Example projekt byl vytvořen, ale první commit selhal. Ověř git config user.name a user.email. $($_.Exception.Message)"
+        }
+    }
+}
+catch {
+    throw "Materializace referenčního example projektu selhala. Projekt zůstal pro diagnostiku v '$projectRoot'. $($_.Exception.Message)"
+}
+
+Write-Host ""
+Write-Host "Referenční example projekt je připraven."
+Write-Host "Project ID: $projectId"
+Write-Host "Projekt:    $projectRoot"
+Write-Host "Workspace:  $workspaceFull"
+if ($NoInitialCommit) {
+    Write-Host "Initial commit: přeskočen"
+}
+else {
+    Write-Host "Initial commit: vytvořen"
+}

--- a/scripts/Test-DDDAInstallation.ps1
+++ b/scripts/Test-DDDAInstallation.ps1
@@ -26,6 +26,7 @@ $requiredFiles = @(
     "README.md", "USAGE.md", "docs/README.md",
     "docs/cookbooks/README.md", "docs/cookbooks/11-chat-first-pracovni-rezim.md", "docs/cookbooks/12-miro-troubleshooting.md",
     "docs/cookbooks/13-inicializace-po-clone.md", "docs/cookbooks/14-inicializace-ciloveho-miro-boardu.md",
+    "docs/cookbooks/15-prvni-spusteni-a-example-projekt.md",
     "docs/methodology/01-metodicky-tok-a-gates.md", "docs/methodology/02-typy-projektu-toky-use-cases.md",
     "docs/product/01-architektura-ddda.md", "docs/product/04-synchronizace.md", "docs/product/06-migrace-a-kompatibilita.md",
     "examples/life-insurance-greenfield/README.md", "examples/life-insurance-greenfield/project.yaml",
@@ -39,7 +40,8 @@ $requiredFiles = @(
     "scripts/Update-DDDAProject.ps1", "scripts/Install-DDDAMiroRuntime.ps1", "scripts/Initialize-DDDAMiroBoard.ps1",
     "scripts/Invoke-DDDAMiroSync.ps1", "scripts/Start-DDDAMiroSyncWorker.ps1", "scripts/Test-DDDAMiroConfiguration.ps1",
     "scripts/Initialize-DDDAAfterClone.ps1", "scripts/Invoke-DDDAMiroSmokeTest.ps1", "scripts/Initialize-DDDAProjectMiro.ps1",
-    "scripts/private/DDDAMiroSupport.ps1", "tests/powershell/Test-DDDAMiroAutomation.ps1"
+    "scripts/New-DDDAExampleProject.ps1", "scripts/Initialize-DDDAFirstRun.ps1",
+    "scripts/private/DDDAMiroSupport.ps1", "tests/powershell/Test-DDDAMiroAutomation.ps1", "tests/powershell/Test-DDDAFirstRun.ps1"
 )
 
 $missingRequiredFiles = @()

--- a/scripts/Test-DDDAInstallation.ps1
+++ b/scripts/Test-DDDAInstallation.ps1
@@ -41,7 +41,8 @@ $requiredFiles = @(
     "scripts/Invoke-DDDAMiroSync.ps1", "scripts/Start-DDDAMiroSyncWorker.ps1", "scripts/Test-DDDAMiroConfiguration.ps1",
     "scripts/Initialize-DDDAAfterClone.ps1", "scripts/Invoke-DDDAMiroSmokeTest.ps1", "scripts/Initialize-DDDAProjectMiro.ps1",
     "scripts/New-DDDAExampleProject.ps1", "scripts/Initialize-DDDAFirstRun.ps1",
-    "scripts/private/DDDAMiroSupport.ps1", "tests/powershell/Test-DDDAMiroAutomation.ps1", "tests/powershell/Test-DDDAFirstRun.ps1"
+    "scripts/private/DDDAMiroSupport.ps1", "scripts/private/DDDAGitStatus.ps1",
+    "tests/powershell/Test-DDDAMiroAutomation.ps1", "tests/powershell/Test-DDDAFirstRun.ps1"
 )
 
 $missingRequiredFiles = @()

--- a/scripts/private/DDDAGitStatus.ps1
+++ b/scripts/private/DDDAGitStatus.ps1
@@ -1,0 +1,70 @@
+﻿Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-DDDAGitPorcelainPath {
+    param([Parameter(Mandatory = $true)][string]$Line)
+
+    if ([string]::IsNullOrWhiteSpace($Line)) {
+        return $null
+    }
+
+    $candidate = $Line.TrimEnd()
+    $path = $null
+
+    # Standard porcelain v1 má dva status znaky a mezeru. Invoke-DDDAGit však
+    # trimuje celý výstup, takže první řádek může ztratit počáteční mezeru
+    # pracovního stromu (např. " M file" se změní na "M file").
+    if ($candidate.Length -ge 3 -and $candidate[2] -eq ' ') {
+        $path = $candidate.Substring(3)
+    }
+    elseif ($candidate -match '^[MADRCU?!]{1,2}\s+(?<path>.+)$') {
+        $path = $Matches["path"]
+    }
+    else {
+        throw "Nelze rozpoznat Git porcelain řádek: '$Line'"
+    }
+
+    if ($path -match ' -> ') {
+        $path = ($path -split ' -> ')[-1]
+    }
+
+    return $path.Trim().Replace('\', '/')
+}
+
+function ConvertFrom-DDDAGitPorcelain {
+    param([string]$PorcelainText)
+
+    $entries = [System.Collections.Generic.List[object]]::new()
+    foreach ($line in @($PorcelainText -split "`r?`n")) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        $entries.Add([pscustomobject]@{
+            Line = $line
+            Path = Get-DDDAGitPorcelainPath -Line $line
+        })
+    }
+
+    return @($entries)
+}
+
+function Assert-DDDAGitChangesWithinPath {
+    param(
+        [string]$PorcelainText,
+        [Parameter(Mandatory = $true)][string]$AllowedPrefix,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    $normalizedPrefix = $AllowedPrefix.Replace('\', '/').TrimStart('/')
+    $unexpected = @(
+        ConvertFrom-DDDAGitPorcelain -PorcelainText $PorcelainText |
+            Where-Object { -not $_.Path.StartsWith($normalizedPrefix, [System.StringComparison]::OrdinalIgnoreCase) }
+    )
+
+    if ($unexpected.Count -gt 0) {
+        throw "$Label obsahuje změny mimo '$normalizedPrefix':`n$($unexpected.Line -join "`n")"
+    }
+
+    return @(ConvertFrom-DDDAGitPorcelain -PorcelainText $PorcelainText)
+}

--- a/tests/powershell/Test-DDDAFirstRun.ps1
+++ b/tests/powershell/Test-DDDAFirstRun.ps1
@@ -1,0 +1,66 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+try {
+    [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
+    $OutputEncoding = [Console]::OutputEncoding
+}
+catch {
+}
+
+$platformRoot = (Resolve-Path $PlatformPath).Path
+$workspaceRoot = Join-Path $env:TEMP ("ddda-first-run-test-" + [Guid]::NewGuid().ToString("N"))
+$projectRoot = Join-Path $workspaceRoot "projects/life-insurance-greenfield"
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)][bool]$Condition,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+try {
+    & (Join-Path $platformRoot "scripts/Initialize-DDDAFirstRun.ps1") -PlatformPath $platformRoot -WorkspaceRoot $workspaceRoot -NoInitialCommit -NonInteractive
+    if ($LASTEXITCODE -ne 0) {
+        throw "Initialize-DDDAFirstRun.ps1 selhal s exit code $LASTEXITCODE."
+    }
+
+    Assert-True -Condition (Test-Path (Join-Path $workspaceRoot "workspace.yaml")) -Message "Chybí workspace.yaml."
+    Assert-True -Condition (Test-Path (Join-Path $workspaceRoot "DDDA.code-workspace")) -Message "Chybí DDDA.code-workspace."
+    Assert-True -Condition (Test-Path (Join-Path $projectRoot ".git")) -Message "Example projekt není samostatný Git repozitář."
+    Assert-True -Condition (Test-Path (Join-Path $projectRoot "ddda.lock.yaml")) -Message "Chybí ddda.lock.yaml."
+    Assert-True -Condition (Test-Path (Join-Path $projectRoot "artifacts/align/project-charter.yaml")) -Message "Nebyl materializován project charter example."
+    Assert-True -Condition (Test-Path (Join-Path $projectRoot "artifacts/connect/context-map.yaml")) -Message "Nebyl materializován context map example."
+    Assert-True -Condition (Test-Path (Join-Path $projectRoot "artifacts/discover/events/policy-issued.yaml")) -Message "Nebyl materializován domain event example."
+    Assert-True -Condition (Test-Path (Join-Path $projectRoot "ingestion/catalog.yaml")) -Message "Nebyl materializován ingestion katalog."
+    Assert-True -Condition (Test-Path (Join-Path $projectRoot "workshops/prompts/01-intake.md")) -Message "Nebyl materializován intake prompt."
+
+    $workspaceText = Get-Content (Join-Path $workspaceRoot "workspace.yaml") -Raw -Encoding UTF8
+    Assert-True -Condition ($workspaceText -match "(?m)^\s*-\s+id:\s*life-insurance-greenfield\s*$") -Message "Example projekt není registrován ve workspace.yaml."
+
+    $projectText = Get-Content (Join-Path $projectRoot "project.yaml") -Raw -Encoding UTF8
+    Assert-True -Condition ($projectText -match "(?m)^\s*id:\s*life-insurance-greenfield\s*$") -Message "Example project.yaml má nesprávné project.id."
+    Assert-True -Condition ($projectText -match "(?m)^\s*type:\s*portfolio-program\s*$") -Message "Example project.yaml má nesprávný typ."
+
+    $mapText = Get-Content (Join-Path $projectRoot "miro/miro-map.yaml") -Raw -Encoding UTF8
+    Assert-True -Condition ($mapText -match "(?m)^board_id:\s*null\s*$") -Message "Offline first run nesmí inicializovat Miro board."
+
+    $platformStatus = (& git -C $platformRoot status --short | Out-String).Trim()
+    Assert-True -Condition ([string]::IsNullOrWhiteSpace($platformStatus)) -Message "Platformní repozitář po first-run testu není čistý:`n$platformStatus"
+
+    Write-Host "DDDA first-run automation test: PASS"
+}
+finally {
+    if (Test-Path $workspaceRoot) {
+        Remove-Item -Path $workspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/tests/powershell/Test-DDDAMiroAutomation.ps1
+++ b/tests/powershell/Test-DDDAMiroAutomation.ps1
@@ -7,6 +7,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 . (Join-Path $PlatformPath "scripts/private/DDDAMiroSupport.ps1")
+. (Join-Path $PlatformPath "scripts/private/DDDAGitStatus.ps1")
 
 function Assert-Equal {
     param(
@@ -47,6 +48,22 @@ Assert-True -Condition ($encoded.Json -eq $decoded) -Message "JSON text a UTF-8 
 
 $encodedBoardId = [Uri]::EscapeDataString("uXjVH4yfs6Y=")
 Assert-True -Condition ($encodedBoardId.EndsWith("%3D")) -Message "Board ID není bezpečně URL encoded."
+
+Assert-Equal -Expected "miro/miro-map.yaml" -Actual (Get-DDDAGitPorcelainPath -Line " M miro/miro-map.yaml") -Message "Standardní Git porcelain řádek nebyl rozpoznán."
+Assert-Equal -Expected "miro/miro-map.yaml" -Actual (Get-DDDAGitPorcelainPath -Line "M miro/miro-map.yaml") -Message "Trimovaný první Git porcelain řádek nebyl rozpoznán."
+Assert-Equal -Expected "miro/new-map.yaml" -Actual (Get-DDDAGitPorcelainPath -Line "R  miro/old-map.yaml -> miro/new-map.yaml") -Message "Git rename porcelain řádek nebyl rozpoznán."
+
+$allowedEntries = @(Assert-DDDAGitChangesWithinPath -PorcelainText "M miro/miro-map.yaml`n?? miro/report.yaml" -AllowedPrefix "miro/" -Label "Test")
+Assert-Equal -Expected 2 -Actual $allowedEntries.Count -Message "Povolené Miro změny nebyly správně rozpoznány."
+
+$outsideRejected = $false
+try {
+    $null = Assert-DDDAGitChangesWithinPath -PorcelainText "M project.yaml" -AllowedPrefix "miro/" -Label "Test"
+}
+catch {
+    $outsideRejected = $true
+}
+Assert-True -Condition $outsideRejected -Message "Změna mimo miro/ musí být v resume režimu odmítnuta."
 
 $platformFull = [System.IO.Path]::GetFullPath($PlatformPath).TrimEnd('\', '/')
 $secretFull = [System.IO.Path]::GetFullPath((Get-DDDAMiroSecretPath))
@@ -94,7 +111,7 @@ foreach ($parameterName in @("ResetToken", "KeepArtifacts", "CleanupOnFailure", 
 }
 
 $projectCommand = Get-Command (Join-Path $PlatformPath "scripts/Initialize-DDDAProjectMiro.ps1")
-foreach ($parameterName in @("WorkspaceRoot", "ProjectId", "CreateBoard", "DryRun", "ResetToken")) {
+foreach ($parameterName in @("WorkspaceRoot", "ProjectId", "CreateBoard", "DryRun", "ResetToken", "Resume")) {
     Assert-True -Condition $projectCommand.Parameters.ContainsKey($parameterName) -Message "Project Miro initializer nemá parametr $parameterName."
 }
 


### PR DESCRIPTION
## Scope

`platform` — jeden kanonický a resumable onboardingový tok pro nového uživatele po `git clone`.

## Problém

Dosavadní dokumentace měla jednotlivé dílčí postupy pro platformní post-clone test, workspace, obecný projekt a projektový Miro board, ale neexistoval jeden automatizovaný tok. Rychlý start navíc vytvářel prázdný projekt pouze pojmenovaný `life-insurance-greenfield`; nematerializoval skutečný obsah z `examples/life-insurance-greenfield`.

## Řešení

### Jeden příkaz po clone

```powershell
.\scripts\Initialize-DDDAFirstRun.ps1 -WithMiro -Full
```

Orchestrátor automaticky provede:

1. kontrolu platformy a instalaci runtime,
2. izolovaný online platformní Miro smoke test,
3. vytvoření nebo reuse workspace,
4. materializaci referenčního example projektu jako samostatného Git repozitáře,
5. kontrolu workspace a projektu,
6. vytvoření cílového Miro boardu example projektu,
7. online doctor a idempotentní druhý render projektového boardu.

### Skutečný example projekt

Nový `New-DDDAExampleProject.ps1` používá `New-DDDAProject.ps1 -NoInitialCommit`, potom do projektového repozitáře kopíruje skutečný obsah z `examples/life-insurance-greenfield/` a vytvoří vlastní iniciační commit. Projekt tak obsahuje referenční artifacts, ingestion katalog, workshop prompts, project manifest a prázdný Miro mapping.

### Dokumentace

- README nyní uvádí kanonický první start jedním příkazem,
- nový cookbook 15 popisuje celý tok, očekávané výstupy, offline variantu, obnovu po chybě a jediné záměrně ruční kroky,
- dokumentační index začíná onboardingovou kuchařkou,
- cookbooks 13 a 14 zůstávají nižšími provozními postupy.

### Validace

- nový offline regresní test materializuje workspace a example projekt v dočasném adresáři,
- ověřuje samostatný Git root, `ddda.lock.yaml`, artifacts, ingestion, workshop prompts, registraci ve `workspace.yaml` a prázdný Miro mapping,
- CI zachovává samostatný test generického projektu a Miro runtime.

## Bezpečnostní a Git hranice

- token zůstává mimo Git a zadává se skrytě pouze při prvním online běhu,
- platformní smoke test nepoužívá projektový board,
- projektový board vlastní example projekt,
- Miro mapping se po online inicializaci automaticky necommituje ani nepushuje,
- `-NoInitialCommit` je podporován pro offline CI, ale nelze jej kombinovat s `-WithMiro`.

## Lokální online validace před merge

Po stažení větve spustit ze standardního clone:

```powershell
.\scripts\Initialize-DDDAFirstRun.ps1 -WithMiro -Full
```

Očekávaný konec:

```text
DDDA první spuštění: PASS
```
