### PR TITLE
[0.1.1][#70] Preserve exact-SHA ancestry for governed platform merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,20 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 
 - machine-readable `human-release-decision.schema.json`, `review-pr` scaffold a fail-closed Release Scope Gate pro exact release-candidate SHA / candidate package / release-version identity;
 - governed implementation command `merge-pr` a machine-readable Human Review marker `ddda:human-pr-review:v1`, vázané na exact PR SHA a candidate package hash;
-- ADR 0008 a developer runbook oddělující Human Review/implementation merge, Human Release Decision a mechanickou release-scope completeness.
+- ADR 0008 a developer runbook oddělující Human Review/implementation merge, Human Release Decision a mechanickou release-scope completeness;
+- ADR 0009 a versioned merge-strategy contract zachovávající exact validated SHA ancestry pro HIGH/BREAKING změny a explicitní human squash exception pro LOW/MEDIUM.
 
 ### Changed
 
 - platform lifecycle nyní explicitně odděluje governed merge implementačních PR od skutečného release/promotion; implementation merge nevyžaduje HRDR ani Release Scope Gate a nesmí vytvořit release package, release validation nebo tag;
-- public `promote-pr` zůstává strict release-candidate command: před interním release executorem vyžaduje validní human HRDR a read-only Release Scope Gate PASS nad Milestone, native blockers a GitHub Project V2 projekcí.
+- public `promote-pr` zůstává strict release-candidate command: před interním release executorem vyžaduje validní human HRDR a read-only Release Scope Gate PASS nad Milestone, native blockers a GitHub Project V2 projekcí;
+- governed implementation merge používá po aktivaci #70 merge commit jako canonical default; HIGH/BREAKING a neklasifikované PR nesmějí squash/rebase, LOW/MEDIUM squash vyžaduje explicitní human exception a canonical merge ověřuje validated PR HEAD server-side jako parent/ancestor výsledného main state.
 
 ### Fixed
 
-- promotion dry-run wrapper nyní používá operation-local výsledek a explicitní post-read-back side-effect assertions; očekávaná `404` absence tagu/GitHub Release je PASS assertion, zatímco auth/network/API chyby zůstávají FAIL, takže PR8-class `semantic PASS / wrapper FAIL` false-negative se nemůže opakovat přes stale `$LASTEXITCODE`.
-- annotated release tag nyní používá deterministic non-secret Git identity pouze v izolovaném release-source clone; clean runner proto nezávisí na ambientním `user.name`/`user.email` a bounded recovery po post-validation tag failure je explicitně zdokumentována.
+- promotion dry-run wrapper nyní používá operation-local výsledek a explicitní post-read-back side-effect assertions; očekávaná `404` absence tagu/GitHub Release je PASS assertion, zatímco auth/network/API chyby zůstávají FAIL, takže PR8-class `semantic PASS / wrapper FAIL` false-negative se nemůže opakovat přes stale `$LASTEXITCODE`;
+- annotated release tag nyní používá deterministic non-secret Git identity pouze v izolovaném release-source clone; clean runner proto nezávisí na ambientním `user.name`/`user.email` a bounded recovery po post-validation tag failure je explicitně zdokumentována;
+- Miro acceptance evidence zachová exact board ID/URL i při child failure po vytvoření boardu, ale před child reportem; konfliktní handoff identity nebo mismatch s reportem failují closed a cleanup může cílit na skutečně vytvořený board.
 
 Změny pro další verzi se během vývoje zapisují sem. Před promotion se všechny položky přesunou do jediné verze `X.Y.Z` s ISO datem a tato sekce zůstane bez release položek.
 

--- a/config/platform/development-policy.yaml
+++ b/config/platform/development-policy.yaml
@@ -1,7 +1,55 @@
 {
   "schema_version": 1,
   "base_branch": "main",
-  "merge_method": "squash",
+  "merge_method": "merge",
+  "merge_strategy": {
+    "schema_version": 1,
+    "classification_marker": "<!-- ddda:change-classification:v1 -->",
+    "squash_exception_marker": "<!-- ddda:squash-exception:v1 -->",
+    "default_method": "merge",
+    "unknown_impact_allowed_methods": [
+      "merge"
+    ],
+    "impacts": {
+      "LOW": {
+        "default_method": "merge",
+        "allowed_methods": [
+          "merge",
+          "squash"
+        ],
+        "squash_requires_human_exception": true
+      },
+      "MEDIUM": {
+        "default_method": "merge",
+        "allowed_methods": [
+          "merge",
+          "squash"
+        ],
+        "squash_requires_human_exception": true
+      },
+      "HIGH": {
+        "default_method": "merge",
+        "allowed_methods": [
+          "merge"
+        ],
+        "squash_requires_human_exception": false
+      },
+      "BREAKING": {
+        "default_method": "merge",
+        "allowed_methods": [
+          "merge"
+        ],
+        "squash_requires_human_exception": false
+      }
+    },
+    "bootstrap_transition": {
+      "change_issue": 70,
+      "legacy_base_sha": "297f61f6012f180e70805999df2ac1abe9616a05",
+      "legacy_merge_method": "squash",
+      "prospective_after_integration": true,
+      "reason": "Issue #70 changes the merge contract itself. Its own integration remains governed by the pre-existing main policy; the new merge-commit contract applies only after #70 is integrated into main."
+    }
+  },
   "minimum_approvals": 0,
   "require_explicit_confirmation": true,
   "execution_interfaces": {
@@ -101,7 +149,9 @@
     "docs/adr/0005-chat-work-only-development-operating-model.md",
     "docs/adr/0006-chat-atomic-platform-implementation.md",
     "docs/adr/0007-miro-execution-profiles-and-persistent-validation-boards.md",
+    "docs/adr/0009-exact-sha-merge-strategy.md",
     "docs/developer-guide/chat-work-operating-model.md",
+    "docs/developer-guide/merge-strategy.md",
     "docs/developer-guide/miro-execution-profiles.md",
     "docs/migration/pr8-non-breaking-steering-extension.md"
   ],

--- a/ddda.ps1
+++ b/ddda.ps1
@@ -1,4 +1,4 @@
-﻿[CmdletBinding()]
+[CmdletBinding()]
 param(
     [Parameter(Mandatory = $true, Position = 0)]
     [ValidateSet("doctor", "test", "validate-pr", "merge-pr", "review-pr", "promote-pr")]
@@ -12,6 +12,7 @@ param(
     [string]$PackagePath,
     [string]$Reviewer,
     [string]$DecisionOwner,
+    [ValidateSet("merge", "squash")][string]$MergeMethod,
     [switch]$PublishScaffold,
     [switch]$WithMiro,
     [switch]$Full,
@@ -100,6 +101,7 @@ switch ($Command) {
             throw "Příkaz merge-pr vyžaduje kladné -Pr."
         }
         $arguments = @("-PlatformPath", $platformRoot, "-Pr", [string]$Pr)
+        if (-not [string]::IsNullOrWhiteSpace($MergeMethod)) { $arguments += @("-MergeMethod", $MergeMethod) }
         if ($ConfirmMerge) { $arguments += "-ConfirmMerge" }
         if ($DryRun) { $arguments += "-DryRun" }
         Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAGovernedMergePr.ps1" -Arguments $arguments

--- a/docs/adr/0001-platform-development-lifecycle.md
+++ b/docs/adr/0001-platform-development-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR: Reprodukovatelný lifecycle vývoje DDDA platformy
 
-Status: Accepted — amended 2026-08-18 by ADR 0008
+Status: Accepted — amended 2026-08-18 by ADR 0008; amended 2026-08-20 by ADR 0009
 
 Date: 2026-07-26
 
@@ -72,6 +72,25 @@ Release Scope Gate vyžaduje kompletní/konzistentní release scope, ale **není
 
 Human Review, implementation merge authorization, Human Release Decision a release/promotion authorization jsou odlišné lidské boundaries. Automation nesmí žádnou z nich inferovat z technického PASS ani z jiné authorization.
 
+### Amendment 2026-08-20 — exact-SHA ancestry a merge strategy
+
+ADR 0009 prospektivně zpřesňuje způsob samotného implementation merge:
+
+```text
+HIGH / BREAKING → merge commit REQUIRED
+LOW / MEDIUM    → merge commit DEFAULT; squash jen explicitní human exception
+UNKNOWN impact  → merge commit only
+rebase           → forbidden
+```
+
+Důvodem je zachování exact validated PR HEAD jako přímo dohledatelného ancestor výsledného `main` state. Čitelnost hlavní historie se řeší first-parent pohledem, nikoli ztrátou reviewované ancestry.
+
+LOW/MEDIUM squash exception je samostatný human-governed record vázaný na stejné PR/SHA/candidate package/impact a musí po merge vytvořit explicitní source→result mapping. Automation ji nesmí vytvořit ani inferovat.
+
+Pro canonical merge provádí `merge-pr` server-side post-read-back a ověřuje validated PR HEAD jako parent/ancestor výsledného merge commit.
+
+#70 mění merge policy samotnou; jeho vlastní integraci proto řídí pre-existing policy z exact base `297f61f6012f180e70805999df2ac1abe9616a05`. Nový contract je účinný až po integraci #70 do `main`. Transition je exact-base-bound a není precedentem pro budoucí HIGH/BREAKING squash. Historie PR #8 / `v0.1.0` ani dalších již mergovaných PR se nepřepisuje.
+
 Veřejným entry pointem je `ddda.ps1`. Specializované skripty zůstávají interními stavebními bloky a compatibility entry points.
 
 ## Options considered
@@ -122,6 +141,10 @@ Cons:
 
 Zamítnuto dodatkem 2026-08-18. Se strict Release Scope Gate může vytvořit kruhovou závislost u multi-PR releasu a směšuje integration a release authority.
 
+### E. Globální squash jako merge default
+
+Zamítnuto dodatkem 2026-08-20 pro HIGH/BREAKING. Squash zachová výsledný obsah, ale exact reviewed PR HEAD není ancestor výsledného main state a audit závisí na externím mappingu. Detail trade-offu a LOW/MEDIUM exception popisuje ADR 0009.
+
 ## Consequences
 
 Positive:
@@ -131,14 +154,18 @@ Positive:
 - běžné testy nemohou samy mergovat nebo tagovat;
 - implementation PR lze bezpečně integrovat bez vytvoření release;
 - strict Release Scope Gate se aplikuje až na skutečný release candidate;
-- merge a release authorization zůstávají oddělené.
+- merge a release authorization zůstávají oddělené;
+- HIGH/BREAKING validated SHA zůstává po merge v ancestry;
+- first-parent history zachovává čitelnost bez ztráty auditability.
 
 Negative:
 
 - lifecycle má explicitně dva orchestration commands/boundaries (`merge-pr`, `promote-pr`);
 - před release je potřeba explicitní release candidate;
 - E2E a online Miro acceptance jsou pomalejší než unit testy;
-- release proces má explicitní nároky na nástroje, evidence a oprávnění.
+- release proces má explicitní nároky na nástroje, evidence a oprávnění;
+- historie obsahuje více merge commits;
+- LOW/MEDIUM squash vyžaduje explicitní human exception evidence.
 
 New obligations:
 
@@ -148,7 +175,9 @@ New obligations:
 - udržovat minimal example a invariant-based regression;
 - zachovat fail-closed implementation merge i release promotion;
 - Human Review evidence vázat na exact implementation SHA/package;
-- HRDR + Release Scope Gate vázat na exact release candidate.
+- HRDR + Release Scope Gate vázat na exact release candidate;
+- wrong merge method odmítnout před irreversible merge;
+- canonical merge ověřit post-merge ancestry read-backem.
 
 ## Impact
 
@@ -179,12 +208,14 @@ Migration:
 - offline acceptance;
 - volitelný online Miro acceptance;
 - governed `merge-pr` dry-run bez side effects;
+- impact → merge-method matrix a wrong-method negative regression;
+- canonical merge ancestry invariant a LOW/MEDIUM squash exception contract;
 - multi-PR anti-deadlock regression;
 - strict release-scope regression;
 - promotion dry-run bez release side effects.
 
 ## Follow-up actions
 
-- [ ] Používat oddělený implementation merge / release candidate lifecycle pro post-0.1.0 stabilization.
+- [x] Používat oddělený implementation merge / release candidate lifecycle pro post-0.1.0 stabilization.
 - [ ] Po maintenance release zpřesnit časové limity a retention reportů.
-- [ ] Podle repository policy upravit počet požadovaných approvals a merge strategy (#70).
+- [x] Verzovat risk-based merge strategy a exact-SHA ancestry contract v ADR 0009 / #70; activation zůstává podmíněna HVR a samostatnou merge authorization #70.

--- a/docs/adr/0009-exact-sha-merge-strategy.md
+++ b/docs/adr/0009-exact-sha-merge-strategy.md
@@ -1,0 +1,208 @@
+# ADR 0009: Exact-SHA ancestry a merge strategy řízených platformních PR
+
+Status: Accepted candidate — pending Human Review of PR implementing #70
+
+Date: 2026-08-20
+
+## Context
+
+DDDA používá exact PR HEAD SHA a candidate-package SHA-256 jako základ auditovatelné technické evidence. Dosavadní repository policy používala `squash`, takže výsledný commit na `main` obsahoval reviewovaný obsah, ale reviewovaný PR HEAD nebyl součástí ancestry výsledného main state. Audit proto závisel na odděleném source→result mappingu.
+
+Pro běžný produkt to může být přijatelný trade-off. Pro DDDA platformu ale mají `HIGH` a `BREAKING` změny silnější požadavek na auditability: commit, který prošel exact-SHA CI, `validate-pr` a Human Review, má zůstat přímo dohledatelný v Git historii po merge.
+
+Prioritní quality attributes jsou:
+
+- auditability;
+- traceability;
+- safety / fail-closed governance;
+- reproducibility;
+- readability historie;
+- jednoduchost provozu.
+
+## Decision
+
+Po integraci změny #70 platí prospektivně tento contract:
+
+```text
+HIGH / BREAKING
+  → merge commit REQUIRED
+  → squash/rebase forbidden
+  → validated PR HEAD musí být ancestor výsledného main state
+
+LOW / MEDIUM
+  → merge commit DEFAULT
+  → squash pouze jako explicitní human-governed exception
+  → rebase forbidden
+
+UNKNOWN impact
+  → merge commit only (fail-safe default)
+```
+
+`merge-pr` načte impact z jednoho autoritativního PR-body markeru:
+
+```text
+<!-- ddda:change-classification:v1 -->
+```
+
+s fenced JSON objektem `schema_version=1` a `impact=LOW|MEDIUM|HIGH|BREAKING`. Chybějící marker je `UNKNOWN`; malformed nebo duplicitní marker failuje closed.
+
+### Proč merge commit
+
+Merge commit zachová reviewovaný PR HEAD jako parent/ancestor výsledného main state. Tím je vazba:
+
+```text
+validated source SHA
+→ Human Review stejného SHA/package
+→ explicit merge authorization
+→ resulting main state
+```
+
+ověřitelná přímo z Gitu a není závislá pouze na externím komentáři nebo reportu.
+
+### Readability
+
+Čitelnost hlavní historie se řeší pohledem first-parent (`git log --first-parent`), nikoli ztrátou auditní ancestry. Merge commits tvoří přehlednou delivery páteř, zatímco detailní commit historie zůstává dostupná podle potřeby.
+
+## LOW/MEDIUM squash exception
+
+Squash je legitimní pouze pro LOW/MEDIUM změnu a pouze po explicitním lidském rozhodnutí. Automatizace nesmí exception vytvořit ani inferovat.
+
+Autoritativní PR comment obsahuje marker:
+
+```text
+<!-- ddda:squash-exception:v1 -->
+```
+
+a machine-readable record minimálně s:
+
+```text
+repository
+pr
+validated_source_head_sha
+candidate_package_sha256
+impact
+reason
+reviewer
+approved_at
+```
+
+Comment musí mít lidskou GitHub provenance a reviewer musí odpovídat autorovi komentáře. SHA/package/impact musí přesně odpovídat aktuálnímu candidate. Změna identity exception invaliduje.
+
+Po squash merge se evidence uloží jako explicitní source→result mapping:
+
+```text
+validated_source_head_sha
+candidate_package_sha256
+resulting_merge_sha
+source_to_result_relation = explicit_squash_mapping
+human exception metadata
+```
+
+Squash exception nemění Human Review ani explicitní merge authorization.
+
+## Post-merge read-back
+
+Pro canonical `merge` musí `merge-pr` po irreversible operaci ověřit server-side:
+
+1. výsledný merge commit obsahuje validated PR HEAD mezi parenty;
+2. GitHub compare read-back potvrzuje validated PR HEAD jako merge base / ancestor výsledného merge commit;
+3. evidence zaznamená `source_to_result_relation=ancestor` a `ancestry_verified=true`.
+
+Nesoulad je governance failure a musí být zachován jako diagnostika; shared history se automaticky nepřepisuje.
+
+## Vztah k candidate package, HRDR a release
+
+Merge strategy nemění exact-SHA CI, `validate-pr`, candidate-package hash ani Human Review. Implementační merge je stále oddělen od release.
+
+HRDR, Release Scope Gate a Human Release Decision vznikají až pro skutečný release candidate po integraci zamýšlených implementation PR. Release tag ukazuje na validovaný release state; merge ancestry poskytuje auditní trasu od release state zpět k reviewovaným implementation SHA.
+
+Squash exception nikdy neoslabuje HRDR, Release Scope Gate, release authorization nebo tag governance.
+
+## Bootstrap / prospective activation
+
+#70 mění právě merge policy, podle které by měl být sám integrován. Proto se nesmí sám retroaktivně prohlásit za již účinnou autoritu.
+
+Explicitní transition contract je:
+
+```text
+legacy governing base: 297f61f6012f180e70805999df2ac1abe9616a05
+legacy merge method: squash
+change issue: #70
+new policy effective: až po integraci #70 do main
+```
+
+Pokud bude PR implementující #70 po exact-SHA PASS, Human Review a samostatné merge autorizaci skutečně mergován, jeho vlastní merge se řídí pre-existing policy z uvedeného base. Tento jediný transition případ je versioned a exact-base-bound; po posunu `main` už podmínku nelze splnit.
+
+Tento bootstrap není precedent pro HIGH/BREAKING squash po aktivaci nové policy.
+
+## Historical scope
+
+Rozhodnutí je výhradně prospektivní. Nemění a nepřepisuje historii:
+
+- PR #8 / `v0.1.0`;
+- PR #74;
+- PR #77;
+- PR #78;
+- PR #79;
+- jiné již sdílené branche nebo tagy.
+
+Historické squash merges zůstávají auditovatelné prostřednictvím existujících source→result evidence. Žádný force push, rebase nebo retag není součástí tohoto rozhodnutí.
+
+## Options considered
+
+### A. Zachovat globální squash
+
+Výhoda: velmi kompaktní historie.
+
+Nevýhoda: exact reviewed SHA se ztrácí z ancestry; audit musí spoléhat na externí mapping. Pro HIGH/BREAKING zamítnuto.
+
+### B. Globální merge commit bez výjimek
+
+Výhoda: nejjednodušší a nejsilnější ancestry invariant.
+
+Nevýhoda: zbytečně rigidní pro triviální LOW/MEDIUM změny. Použito jako default, ale s úzkou human squash exception.
+
+### C. Rebase merge
+
+Výhoda: lineární historie.
+
+Nevýhoda: přepisuje commit identity, takže exact validated PR HEAD není zachován. Zamítnuto pro canonical DDDA merge path.
+
+### D. Risk-based merge commit + LOW/MEDIUM squash exception
+
+Přijato. Zachovává auditní invariant tam, kde je nejdůležitější, a dovoluje explicitní, auditovatelnou výjimku pro nízké riziko.
+
+## Consequences
+
+Positive:
+
+- HIGH/BREAKING reviewed SHA zůstává přímo v ancestry;
+- wrong merge method failuje před irreversible side effect;
+- first-parent history zachovává čitelnost;
+- LOW/MEDIUM squash je explicitní lidské rozhodnutí, nikoli automation default;
+- release traceability se zjednodušuje.
+
+Negative:
+
+- historie obsahuje více merge commits;
+- impact classification se stává součástí merge preflightu;
+- LOW/MEDIUM squash vyžaduje další auditní record;
+- jeden exact-base-bound bootstrap je nutný pro samotnou aktivaci #70.
+
+## Validation
+
+Povinné regresní scénáře:
+
+- HIGH + merge → PASS;
+- HIGH/BREAKING + squash → FAIL před merge;
+- UNKNOWN + squash → FAIL;
+- LOW/MEDIUM default → merge;
+- LOW/MEDIUM squash bez human exception → FAIL;
+- validní human squash exception → PASS preflight;
+- bot/identity/package drift exception → FAIL;
+- canonical merge post-read-back → validated SHA je parent/ancestor;
+- #70 bootstrap funguje pouze pro exact legacy base a nelze jej znovu použít.
+
+## Decision ownership
+
+Technická validace tohoto ADR neznamená jeho Human Review. Judgment-heavy trade-off — auditní ancestry versus kompaktnost historie a jednorázový bootstrap #70 — musí být explicitně schválen při HVR implementačního PR.

--- a/docs/developer-guide/merge-strategy.md
+++ b/docs/developer-guide/merge-strategy.md
@@ -1,0 +1,141 @@
+# Merge strategy řízených DDDA platformních PR
+
+## Účel
+
+Tento runbook konkretizuje ADR 0009 a `config/platform/development-policy.yaml`. Řeší pouze způsob integrace implementačního PR do `main`; nemění Human Review, HRDR, Release Scope Gate ani release/tag authorization.
+
+## Kanonická pravidla
+
+```text
+HIGH / BREAKING
+  merge commit REQUIRED
+  squash forbidden
+  rebase forbidden
+
+LOW / MEDIUM
+  merge commit DEFAULT
+  squash jen s explicitní human squash exception
+  rebase forbidden
+
+UNKNOWN impact
+  merge commit only
+```
+
+Důvodem není preference „hezčího Gitu“, ale auditability exact-SHA evidence. Commit, který prošel CI, `validate-pr` a Human Review, má u HIGH/BREAKING zůstat ancestor výsledného main state.
+
+## Impact classification
+
+Governed PR může nést právě jeden marker `<!-- ddda:change-classification:v1 -->`, bezprostředně následovaný fenced JSON objektem například:
+
+```json
+{"schema_version":1,"impact":"HIGH"}
+```
+
+Povolené hodnoty jsou `LOW`, `MEDIUM`, `HIGH`, `BREAKING`. Pokud marker chybí, merge preflight použije `UNKNOWN` a dovolí pouze merge commit. Duplicitní, malformed nebo nepodporovaný marker failuje closed.
+
+Impact je judgment-heavy governance vstup. Automatizace smí marker validovat, ale nesmí sama změnit risk classification jen proto, aby povolila jiný merge method.
+
+## Dry-run
+
+Default:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr <PR> -DryRun
+```
+
+Explicitní metoda pro kontrolu policy:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr <PR> -MergeMethod merge -DryRun
+```
+
+Pro LOW/MEDIUM lze vyžádat squash pouze po existenci platné human exception:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr <PR> -MergeMethod squash -DryRun
+```
+
+Dry-run musí skončit před `Merge-DDDAGitHubPullRequest`; wrong method, chybějící exception nebo identity drift tedy nemohou vytvořit irreversible side effect.
+
+## Human squash exception
+
+Squash je výjimka, nikoli default. Je povolen pouze pro LOW/MEDIUM a vyžaduje právě jeden PR Conversation comment s markerem `<!-- ddda:squash-exception:v1 -->` a fenced JSON recordem:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "squash_exception",
+  "repository": "romanhlavac/ddd-accelerator",
+  "pr": 123,
+  "validated_source_head_sha": "<40-char-sha>",
+  "candidate_package_sha256": "<64-char-sha256>",
+  "impact": "LOW",
+  "reason": "Proč je ztráta ancestry v tomto nízkorizikovém případě přijatelná.",
+  "reviewer": "<human-login>",
+  "approved_at": "<ISO-8601>"
+}
+```
+
+Marker musí mít lidskou GitHub provenance. `reviewer` musí odpovídat autorovi komentáře. SHA, package hash a impact musí přesně odpovídat current PR candidate. Bot/automation marker, stale SHA nebo prázdný reason znamenají FAIL.
+
+Human squash exception nenahrazuje HVR ani samostatnou merge authorization.
+
+## Post-merge evidence
+
+Pro `merge` se po server-side merge ověřuje:
+
+- validated PR HEAD je parent výsledného merge commit;
+- compare read-back potvrzuje validated HEAD jako ancestor;
+- `result.json` obsahuje `source_to_result_relation=ancestor` a `ancestry_verified=true`.
+
+Pro povolený LOW/MEDIUM squash se ukládá explicitní source→result mapping:
+
+```text
+validated_source_head_sha
+candidate_package_sha256
+resulting_merge_sha
+source_to_result_relation = explicit_squash_mapping
+human squash exception metadata
+```
+
+Post-merge read-back failure se neopravuje force-pushem nebo přepisem shared history. Je to governance failure vyžadující diagnostiku a explicitní recovery rozhodnutí.
+
+## First-parent historie
+
+Pro běžné čtení delivery historie používej:
+
+```bash
+git log --first-parent
+```
+
+Tím zůstává hlavní tok kompaktní, aniž by se ztrácela reviewovaná commit ancestry.
+
+## Prospective bootstrap #70
+
+#70 mění samotný merge contract. Jeho vlastní integraci proto stále řídí pre-existing policy na exact base:
+
+```text
+297f61f6012f180e70805999df2ac1abe9616a05
+```
+
+Tato policy používala squash. Versioned `bootstrap_transition` dovoluje tento jediný exact-base-bound transition a po integraci #70 je neaktivní. Nový contract se aplikuje na následné PR. Historické PR/tagy se nepřepisují.
+
+HVR #70 musí explicitně posoudit a přijmout tento bootstrap trade-off. Technický PASS jej nemůže schválit.
+
+## Release boundary
+
+Merge strategy je implementation-integration concern. Po merge jednotlivých PR stále platí samostatný release-candidate tok:
+
+```text
+integrated work
+→ release candidate
+→ exact-SHA validation
+→ HRDR
+→ Release Scope Gate
+→ Human Release Decision
+→ separate release authorization
+→ release validation
+→ tag
+```
+
+Implementation merge ani squash exception nikdy neautorizují promotion, release nebo tag.

--- a/docs/developer-guide/platform-development-lifecycle.md
+++ b/docs/developer-guide/platform-development-lifecycle.md
@@ -146,6 +146,8 @@ INGESTION, CLI, WORKSPACE-GENERATOR, EXAMPLE,
 TESTING, RELEASE, SECURITY-GOVERNANCE
 ```
 
+Impact je `LOW`, `MEDIUM`, `HIGH` nebo `BREAKING`. Pro governed merge jej lze auditovatelně zapsat do PR body markeru `ddda:change-classification:v1`; chybějící marker se při merge považuje za `UNKNOWN` a používá fail-safe merge-commit-only policy.
+
 ## 2. Feature branch a implementace
 
 `main` se nemění přímo. Doporučené názvy:
@@ -231,6 +233,17 @@ Skutečný merge:
 
 `merge-pr` fail-closed ověřuje live PR state, exact head SHA, required CI, exact-SHA `validate-pr`, candidate package hash, Human Review PASS stejného SHA/package, required governance docs a repository merge policy.
 
+Po aktivaci ADR 0009 je merge strategy risk-based:
+
+```text
+HIGH / BREAKING → merge commit REQUIRED
+LOW / MEDIUM    → merge commit DEFAULT; squash jen explicitní human exception
+UNKNOWN         → merge commit only
+rebase           → forbidden
+```
+
+Wrong merge method musí failnout před irreversible merge. Pro canonical merge následuje server-side ancestry read-back: validated PR HEAD musí být parent/ancestor výsledného main state. LOW/MEDIUM squash exception je samostatný human record vázaný na stejné PR/SHA/package/impact; automation jej nesmí vytvořit. Detailní kontrakt je v ADR 0009 a `docs/developer-guide/merge-strategy.md`.
+
 `merge-pr`:
 
 - **nevyhodnocuje HRDR**;
@@ -241,6 +254,12 @@ Skutečný merge:
 - bez explicitního `-ConfirmMerge` nemerguje.
 
 To umožňuje bezpečně integrovat více implementačních PR před sestavením release candidate bez kruhové závislosti na release-scope completeness.
+
+### 6.2 Prospective transition #70
+
+#70 mění samotný merge contract. Jeho vlastní integraci proto stále řídí pre-existing `main` policy z exact base `297f61f6012f180e70805999df2ac1abe9616a05`, která používala squash. Nová merge-commit policy se stává autoritativní až po integraci #70 do `main`.
+
+Transition je versioned, exact-base-bound a single-purpose; není to HIGH/BREAKING squash exception pro budoucí PR. HVR #70 musí tento bootstrap trade-off explicitně posoudit. Historické PR/tagy se nepřepisují.
 
 ## 7. Release candidate a HRDR
 
@@ -283,6 +302,8 @@ Po canonical release-candidate merge vznikne release package; tag se vytvoří a
 
 Work musí rozlišit connector/access failure, implementation failure, CI/test failure, Human Review rejection, implementation merge failure, release-scope failure a release validation failure. Nedokončená práce se nesmí prezentovat jako PASS.
 
+Post-merge ancestry failure se nikdy neopravuje automatickým force-pushem nebo přepisem shared history; vyžaduje zachování diagnostiky a explicitní recovery rozhodnutí.
+
 ## 10. Definition of Done
 
 Implementační PR je připraven k merge pouze když:
@@ -294,6 +315,7 @@ Implementační PR je připraven k merge pouze když:
 - relevantní acceptance je PASS;
 - compatibility/ADR/changelog obligations jsou splněny;
 - mandatory Human Review je PASS pro stejné SHA/package;
+- impact/merge strategy preflight je PASS;
 - merge nebyl proveden bez explicitní human merge authorization.
 
 Release je připraven pouze když navíc existuje validní release candidate, HRDR, Release Scope Gate PASS, explicitní Human Release Decision a samostatná release/promotion authorization. Technický PASS ani implementační merge sám o sobě release neautorizuje.

--- a/docs/user-guide/validate-and-promote-pr.md
+++ b/docs/user-guide/validate-and-promote-pr.md
@@ -59,9 +59,33 @@ Dry-run fail-closed ověří:
 - existuje právě jeden authoritativní Human Review marker `ddda:human-pr-review:v1`;
 - Human Review má lidskou provenance, stejné PR/SHA/package a verdict `pass`;
 - required governance documents existují;
-- merge method odpovídá repository policy.
+- impact classification a merge method odpovídají repository merge-strategy policy.
 
 Dry-run neprovede merge, release, promotion ani tag.
+
+### Merge strategy a exact-SHA ancestry
+
+Po aktivaci ADR 0009 je canonical default `merge`:
+
+```text
+HIGH / BREAKING → merge commit REQUIRED
+LOW / MEDIUM    → merge commit DEFAULT
+UNKNOWN impact  → merge commit only
+rebase           → forbidden
+```
+
+LOW/MEDIUM může použít `squash` pouze s explicitním lidským `ddda:squash-exception:v1` recordem pro stejné PR/SHA/package/impact. Automation tuto exception nesmí vytvořit ani inferovat.
+
+Explicitní dry-run varianty:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr 74 -MergeMethod merge -DryRun
+.\ddda.ps1 merge-pr -Pr <LOW_OR_MEDIUM_PR> -MergeMethod squash -DryRun
+```
+
+Pro canonical merge se po skutečném merge server-side ověří, že validated PR HEAD je parent/ancestor výsledného main state. Evidence používá `source_to_result_relation=ancestor`. U schváleného LOW/MEDIUM squash se místo ancestry ukládá explicitní source→result mapping s human exception metadata.
+
+Detailní contract je v `docs/developer-guide/merge-strategy.md` a ADR 0009.
 
 Skutečný implementation merge:
 
@@ -189,5 +213,7 @@ release-reports/
 - běžné testy nikdy nemergují ani netagují;
 - Human Review PASS nevytváří automation;
 - merge authorization a release authorization jsou oddělené;
+- wrong merge method musí failnout před irreversible side effect;
+- LOW/MEDIUM squash exception musí mít lidskou provenance a exact candidate binding;
 - `merge-pr` nesmí být release bypass;
 - `promote-pr` nesmí být použit jako obecný mechanismus merge implementačních PR.

--- a/runtime/platform/tests/test_merge_strategy_contract.py
+++ b/runtime/platform/tests/test_merge_strategy_contract.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+POLICY = ROOT / "config/platform/development-policy.yaml"
+MERGE_SCRIPT = ROOT / "scripts/platform/Invoke-DDDAGovernedMergePr.ps1"
+SUPPORT = ROOT / "scripts/platform/DDDAMergeStrategySupport.ps1"
+
+
+def test_merge_policy_is_ancestry_preserving_by_default():
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    strategy = policy["merge_strategy"]
+    assert policy["merge_method"] == "merge"
+    assert strategy["default_method"] == "merge"
+    assert strategy["unknown_impact_allowed_methods"] == ["merge"]
+    assert strategy["impacts"]["HIGH"]["allowed_methods"] == ["merge"]
+    assert strategy["impacts"]["BREAKING"]["allowed_methods"] == ["merge"]
+    for impact in ("LOW", "MEDIUM"):
+        assert strategy["impacts"][impact]["default_method"] == "merge"
+        assert strategy["impacts"][impact]["allowed_methods"] == ["merge", "squash"]
+        assert strategy["impacts"][impact]["squash_requires_human_exception"] is True
+
+
+def test_bootstrap_transition_is_exact_and_prospective():
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    transition = policy["merge_strategy"]["bootstrap_transition"]
+    assert transition["change_issue"] == 70
+    assert transition["legacy_base_sha"] == "297f61f6012f180e70805999df2ac1abe9616a05"
+    assert transition["legacy_merge_method"] == "squash"
+    assert transition["prospective_after_integration"] is True
+
+
+def test_governed_merge_fails_strategy_before_irreversible_merge_and_reads_back_ancestry():
+    text = MERGE_SCRIPT.read_text(encoding="utf-8-sig")
+    strategy_pos = text.index("Resolve-DDDAMergeStrategy")
+    merge_pos = text.index("Merge-DDDAGitHubPullRequest")
+    ancestry_pos = text.index("Post-merge ancestry read-back")
+    assert strategy_pos < merge_pos < ancestry_pos
+    assert 'compare/$headSha...$mergeCommit' in text
+    assert 'source_to_result_relation = $sourceToResultRelation' in text
+    assert 'ancestry_verified = $ancestryVerified' in text
+    assert 'release_side_effects = $false' in text
+    assert 'tag_side_effects = $false' in text
+
+
+def test_rebase_is_not_canonical_and_human_exception_cannot_be_automated():
+    support = SUPPORT.read_text(encoding="utf-8-sig")
+    assert 'if ($method -notin @("merge", "squash"))' in support
+    assert "Rebase není povolen" in support
+    assert "Squash exception musí mít lidskou GitHub provenance" in support
+    assert 'CommentAuthorType -eq "Bot"' in support
+    assert "validated_source_head_sha" in support
+    assert "candidate_package_sha256" in support
+
+
+def test_behavioral_merge_strategy_contract():
+    executable = shutil.which("pwsh") or shutil.which("powershell")
+    if executable is None:
+        if os.name == "nt":
+            pytest.fail("Windows platform test runtime must expose PowerShell for merge-strategy regression")
+        pytest.skip("PowerShell is not installed on this non-Windows validation worker")
+    script = ROOT / "tests/powershell/Test-DDDAMergeStrategy.ps1"
+    completed = subprocess.run(
+        [executable, "-NoProfile", "-File", str(script), "-PlatformPath", str(ROOT)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+    assert completed.returncode == 0, completed.stdout + "\n" + completed.stderr
+    assert "DDDA merge strategy contract: PASS" in completed.stdout

--- a/scripts/platform/DDDAMergeStrategySupport.ps1
+++ b/scripts/platform/DDDAMergeStrategySupport.ps1
@@ -1,0 +1,212 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:DDDAChangeClassificationMarker = "<!-- ddda:change-classification:v1 -->"
+$script:DDDASquashExceptionMarker = "<!-- ddda:squash-exception:v1 -->"
+
+function Get-DDDAMarkedJsonRecord {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [Parameter(Mandatory = $true)][string]$Marker,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [switch]$AllowMissing
+    )
+
+    $escapedMarker = [regex]::Escape($Marker)
+    $pattern = "(?s)$escapedMarker\s*```json\s*(?<json>\{.*?\})\s*```"
+    $matches = [regex]::Matches($Text, $pattern, [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
+    if ($matches.Count -eq 0) {
+        if ($AllowMissing) { return $null }
+        throw "$Label marker chybí."
+    }
+    if ($matches.Count -ne 1) {
+        throw "$Label musí být právě jeden. Nalezeno: $($matches.Count)."
+    }
+
+    try {
+        return $matches[0].Groups["json"].Value | ConvertFrom-Json
+    }
+    catch {
+        throw "$Label JSON nelze parse: $($_.Exception.Message)"
+    }
+}
+
+function Get-DDDAChangeImpactFromPrBody {
+    param([AllowEmptyString()][string]$Body = "")
+
+    $record = Get-DDDAMarkedJsonRecord `
+        -Text $Body `
+        -Marker $script:DDDAChangeClassificationMarker `
+        -Label "Change classification" `
+        -AllowMissing
+    if ($null -eq $record) {
+        return "UNKNOWN"
+    }
+    if ([int]$record.schema_version -ne 1) {
+        throw "Change classification má nepodporovaný schema_version."
+    }
+    $impact = ([string]$record.impact).ToUpperInvariant()
+    if ($impact -notin @("LOW", "MEDIUM", "HIGH", "BREAKING")) {
+        throw "Change classification impact '$impact' není podporovaný."
+    }
+    return $impact
+}
+
+function Test-DDDABootstrapMergeTransition {
+    param(
+        [Parameter(Mandatory = $true)][object]$MergeStrategy,
+        [Parameter(Mandatory = $true)][int]$Pr,
+        [Parameter(Mandatory = $true)][string]$BaseSha,
+        [AllowEmptyString()][string]$PrBody = "",
+        [Parameter(Mandatory = $true)][string]$Impact,
+        [Parameter(Mandatory = $true)][string]$MergeMethod
+    )
+
+    $property = $MergeStrategy.PSObject.Properties["bootstrap_transition"]
+    if ($null -eq $property -or $null -eq $property.Value) {
+        return $false
+    }
+    $transition = $property.Value
+    if (-not [bool]$transition.prospective_after_integration) { return $false }
+    if ($Pr -ne [int]$transition.change_issue) { return $false }
+    if ($BaseSha -ne [string]$transition.legacy_base_sha) { return $false }
+    if ($MergeMethod -ne [string]$transition.legacy_merge_method) { return $false }
+    if ($Impact -notin @("HIGH", "BREAKING")) { return $false }
+    $issue = [int]$transition.change_issue
+    if ($PrBody -notmatch "(?im)\b(?:Implements|Closes)\s+#$issue\b") { return $false }
+    return $true
+}
+
+function Resolve-DDDAMergeStrategy {
+    param(
+        [Parameter(Mandatory = $true)][object]$Policy,
+        [Parameter(Mandatory = $true)][string]$Impact,
+        [AllowEmptyString()][string]$RequestedMethod = "",
+        [Parameter(Mandatory = $true)][int]$Pr,
+        [Parameter(Mandatory = $true)][string]$BaseSha,
+        [AllowEmptyString()][string]$PrBody = ""
+    )
+
+    $mergeStrategyProperty = $Policy.PSObject.Properties["merge_strategy"]
+    if ($null -eq $mergeStrategyProperty -or $null -eq $mergeStrategyProperty.Value) {
+        throw "Platform development policy neobsahuje merge_strategy contract."
+    }
+    $strategy = $mergeStrategyProperty.Value
+    if ([int]$strategy.schema_version -ne 1) {
+        throw "Nepodporovaný merge_strategy schema_version."
+    }
+
+    $impactValue = $Impact.ToUpperInvariant()
+    $method = if ([string]::IsNullOrWhiteSpace($RequestedMethod)) {
+        [string]$strategy.default_method
+    }
+    else {
+        $RequestedMethod.ToLowerInvariant()
+    }
+    if ($method -notin @("merge", "squash")) {
+        throw "Canonical DDDA merge method '$method' není podporovaný. Rebase není povolen, protože nezachovává exact validated PR HEAD identity."
+    }
+
+    if ($impactValue -eq "UNKNOWN") {
+        $allowed = @($strategy.unknown_impact_allowed_methods | ForEach-Object { ([string]$_).ToLowerInvariant() })
+        if ($method -notin $allowed) {
+            throw "PR bez autoritativní impact classification smí použít pouze: $($allowed -join ', ')."
+        }
+        return [pscustomobject][ordered]@{
+            impact = $impactValue
+            merge_method = $method
+            human_squash_exception_required = $false
+            bootstrap_transition = $false
+        }
+    }
+
+    $impactProperty = $strategy.impacts.PSObject.Properties[$impactValue]
+    if ($null -eq $impactProperty) {
+        throw "Merge strategy neobsahuje pravidlo pro impact '$impactValue'."
+    }
+    $rule = $impactProperty.Value
+    $allowedMethods = @($rule.allowed_methods | ForEach-Object { ([string]$_).ToLowerInvariant() })
+    if ($method -notin $allowedMethods) {
+        $bootstrap = Test-DDDABootstrapMergeTransition `
+            -MergeStrategy $strategy `
+            -Pr $Pr `
+            -BaseSha $BaseSha `
+            -PrBody $PrBody `
+            -Impact $impactValue `
+            -MergeMethod $method
+        if (-not $bootstrap) {
+            throw "Merge method '$method' není povolen pro impact '$impactValue'. Povolené: $($allowedMethods -join ', ')."
+        }
+        return [pscustomobject][ordered]@{
+            impact = $impactValue
+            merge_method = $method
+            human_squash_exception_required = $false
+            bootstrap_transition = $true
+        }
+    }
+
+    $requiresException = (
+        $method -eq "squash" -and
+        [bool]$rule.squash_requires_human_exception
+    )
+    return [pscustomobject][ordered]@{
+        impact = $impactValue
+        merge_method = $method
+        human_squash_exception_required = $requiresException
+        bootstrap_transition = $false
+    }
+}
+
+function ConvertFrom-DDDASquashExceptionComment {
+    param([Parameter(Mandatory = $true)][object]$Comment)
+
+    return Get-DDDAMarkedJsonRecord `
+        -Text ([string]$Comment.body) `
+        -Marker $script:DDDASquashExceptionMarker `
+        -Label "Squash exception"
+}
+
+function Assert-DDDASquashExceptionRecord {
+    param(
+        [Parameter(Mandatory = $true)][object]$Record,
+        [Parameter(Mandatory = $true)][string]$CommentAuthor,
+        [Parameter(Mandatory = $true)][string]$CommentAuthorType,
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][int]$Pr,
+        [Parameter(Mandatory = $true)][string]$HeadSha,
+        [Parameter(Mandatory = $true)][string]$CandidatePackageSha256,
+        [Parameter(Mandatory = $true)][string]$Impact
+    )
+
+    if ([string]::IsNullOrWhiteSpace($CommentAuthor) -or $CommentAuthorType -eq "Bot" -or $CommentAuthor -match '\[bot\]$') {
+        throw "Squash exception musí mít lidskou GitHub provenance."
+    }
+    if ([int]$Record.schema_version -ne 1 -or [string]$Record.kind -ne "squash_exception") {
+        throw "Squash exception má nepodporovaný contract."
+    }
+    if ([string]$Record.repository -ne $Repository -or [int]$Record.pr -ne $Pr) {
+        throw "Squash exception repository/PR identity neodpovídá aktuálnímu PR."
+    }
+    if ([string]$Record.validated_source_head_sha -ne $HeadSha) {
+        throw "Squash exception validated_source_head_sha neodpovídá current PR head."
+    }
+    if ([string]$Record.candidate_package_sha256 -ne $CandidatePackageSha256) {
+        throw "Squash exception candidate package hash neodpovídá validate-pr evidence."
+    }
+    if (([string]$Record.impact).ToUpperInvariant() -ne $Impact.ToUpperInvariant()) {
+        throw "Squash exception impact neodpovídá PR classification."
+    }
+    if ([string]$Record.reviewer -ne $CommentAuthor) {
+        throw "Squash exception reviewer neodpovídá human comment authorovi."
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$Record.reason)) {
+        throw "Squash exception vyžaduje neprázdný reason."
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$Record.approved_at)) {
+        throw "Squash exception vyžaduje approved_at."
+    }
+    $approvedAt = [DateTimeOffset]::MinValue
+    if (-not [DateTimeOffset]::TryParse([string]$Record.approved_at, [ref]$approvedAt)) {
+        throw "Squash exception approved_at není platný timestamp."
+    }
+}

--- a/scripts/platform/Invoke-DDDAGovernedMergePr.ps1
+++ b/scripts/platform/Invoke-DDDAGovernedMergePr.ps1
@@ -1,7 +1,8 @@
-﻿[CmdletBinding()]
+[CmdletBinding()]
 param(
     [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
     [Parameter(Mandatory = $true)][ValidateRange(1, 2147483647)][int]$Pr,
+    [ValidateSet("merge", "squash")][string]$MergeMethod,
     [switch]$ConfirmMerge,
     [switch]$DryRun
 )
@@ -11,6 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "DDDAPlatformSupport.ps1")
 . (Join-Path $PSScriptRoot "DDDAGitHubSupport.ps1")
 . (Join-Path $PSScriptRoot "DDDAReleaseGovernanceSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAMergeStrategySupport.ps1")
 
 $platformRoot = Get-DDDAPlatformGitRoot -Path $PlatformPath
 if ($platformRoot -ne [System.IO.Path]::GetFullPath($PlatformPath).TrimEnd('\', '/')) {
@@ -40,6 +42,10 @@ if ([bool]$prInfo.draft) {
 $baseRefName = [string]$prInfo.base.ref
 if ($baseRefName -ne [string]$policy.base_branch) {
     throw "PR #$Pr míří do '$baseRefName', očekáváno '$($policy.base_branch)'."
+}
+$baseSha = [string]$prInfo.base.sha
+if ($baseSha -notmatch '^[0-9a-f]{40}$') {
+    throw "GitHub nevrátil platný base SHA."
 }
 $mergeStateStatus = ([string]$prInfo.mergeable_state).ToUpperInvariant()
 if ($mergeStateStatus -notin @("CLEAN", "HAS_HOOKS", "UNSTABLE")) {
@@ -119,19 +125,56 @@ foreach ($relative in @($policy.required_documents)) {
     }
 }
 
-$mergeMethod = [string]$policy.merge_method
-if ($mergeMethod -notin @("squash", "merge", "rebase")) {
-    throw "Nepodporovaná merge_method v policy: $mergeMethod"
+$impact = Get-DDDAChangeImpactFromPrBody -Body ([string]$prInfo.body)
+$requestedMergeMethod = if ([string]::IsNullOrWhiteSpace($MergeMethod)) { "" } else { $MergeMethod }
+$strategyDecision = Resolve-DDDAMergeStrategy `
+    -Policy $policy `
+    -Impact $impact `
+    -RequestedMethod $requestedMergeMethod `
+    -Pr $Pr `
+    -BaseSha $baseSha `
+    -PrBody ([string]$prInfo.body)
+$effectiveMergeMethod = [string]$strategyDecision.merge_method
+
+$squashException = $null
+if ([bool]$strategyDecision.human_squash_exception_required) {
+    $exceptionComments = [System.Collections.Generic.List[object]]::new()
+    for ($page = 1; ; $page++) {
+        $batch = @(Invoke-DDDAGitHubApi -Method GET -Path "repos/$repositorySlug/issues/$Pr/comments?per_page=100&page=$page" -Token $githubAuth.Token)
+        foreach ($comment in $batch) {
+            if ([string]$comment.body -like "*$script:DDDASquashExceptionMarker*") {
+                $exceptionComments.Add($comment)
+            }
+        }
+        if ($batch.Count -lt 100) { break }
+    }
+    if ($exceptionComments.Count -ne 1) {
+        throw "LOW/MEDIUM squash vyžaduje právě jeden authoritativní human squash exception marker. Nalezeno: $($exceptionComments.Count)."
+    }
+    $exceptionComment = $exceptionComments[0]
+    $squashException = ConvertFrom-DDDASquashExceptionComment -Comment $exceptionComment
+    Assert-DDDASquashExceptionRecord `
+        -Record $squashException `
+        -CommentAuthor ([string]$exceptionComment.user.login) `
+        -CommentAuthorType ([string]$exceptionComment.user.type) `
+        -Repository $repositorySlug `
+        -Pr $Pr `
+        -HeadSha $headSha `
+        -CandidatePackageSha256 ([string]$validation.PackageSha256) `
+        -Impact $impact
 }
 
 Write-Host "=== DDDA governed implementation merge preflight ==="
 Write-Host "Repository:        $repositorySlug"
 Write-Host "PR:                $Pr"
 Write-Host "Head SHA:          $headSha"
+Write-Host "Base SHA:          $baseSha"
 Write-Host "Candidate SHA-256: $($validation.PackageSha256)"
 Write-Host "CI checks:         PASS ($($checkSummary.CheckRunCount) check runs)"
 Write-Host "Human Review:      PASS ($commentAuthor)"
-Write-Host "Merge method:      $mergeMethod"
+Write-Host "Impact:            $impact"
+Write-Host "Merge method:      $effectiveMergeMethod"
+Write-Host "Bootstrap transition: $([bool]$strategyDecision.bootstrap_transition)"
 Write-Host "Release Scope Gate: NOT APPLICABLE (implementation merge)"
 Write-Host "Release/tag side effects: DISABLED"
 
@@ -152,7 +195,7 @@ $mergeResult = Merge-DDDAGitHubPullRequest `
     -RepositorySlug $repositorySlug `
     -Pr $Pr `
     -HeadSha $headSha `
-    -MergeMethod $mergeMethod `
+    -MergeMethod $effectiveMergeMethod `
     -Token $githubAuth.Token
 
 $mergeCommit = [string]$mergeResult.sha
@@ -165,22 +208,67 @@ if (-not [bool]$postMerge.merged) {
     throw "GitHub nepotvrdil merge PR #$Pr."
 }
 
+$sourceToResultRelation = $null
+$ancestryVerified = $false
+if ($effectiveMergeMethod -eq "merge") {
+    $mergeCommitInfo = Invoke-DDDAGitHubApi -Method GET -Path "repos/$repositorySlug/commits/$mergeCommit" -Token $githubAuth.Token
+    $parentShas = @($mergeCommitInfo.parents | ForEach-Object { [string]$_.sha })
+    if ($headSha -notin $parentShas) {
+        throw "Post-merge ancestry read-back selhal: validated PR HEAD $headSha není parent výsledného merge commit $mergeCommit."
+    }
+    $compare = Invoke-DDDAGitHubApi -Method GET -Path "repos/$repositorySlug/compare/$headSha...$mergeCommit" -Token $githubAuth.Token
+    if ([string]$compare.merge_base_commit.sha -ne $headSha) {
+        throw "Post-merge ancestry read-back selhal: validated PR HEAD není ancestor výsledného main state."
+    }
+    $sourceToResultRelation = "ancestor"
+    $ancestryVerified = $true
+}
+elseif ($effectiveMergeMethod -eq "squash") {
+    $sourceToResultRelation = "explicit_squash_mapping"
+}
+else {
+    throw "Neočekávaný merge method po merge: $effectiveMergeMethod"
+}
+
+$exceptionEvidence = $null
+if ($null -ne $squashException) {
+    $exceptionEvidence = [ordered]@{
+        type = "human_low_medium_exception"
+        reason = [string]$squashException.reason
+        reviewer = [string]$squashException.reviewer
+        approved_at = [string]$squashException.approved_at
+    }
+}
+elseif ([bool]$strategyDecision.bootstrap_transition) {
+    $transition = $policy.merge_strategy.bootstrap_transition
+    $exceptionEvidence = [ordered]@{
+        type = "prospective_policy_bootstrap"
+        change_issue = [int]$transition.change_issue
+        legacy_base_sha = [string]$transition.legacy_base_sha
+        reason = [string]$transition.reason
+    }
+}
+
 $evidenceRoot = Join-Path (Get-DDDAPlatformStateRoot) ("merge-reports/pr-$Pr-$headSha")
 New-Item -ItemType Directory -Path $evidenceRoot -Force | Out-Null
 $evidencePath = Join-Path $evidenceRoot "result.json"
-Write-DDDAPlatformJson -Path $evidencePath -Depth 20 -Value ([ordered]@{
-    schema_version = 1
+Write-DDDAPlatformJson -Path $evidencePath -Depth 30 -Value ([ordered]@{
+    schema_version = 2
     repository = $repositorySlug
     pr = $Pr
-    source_sha = $headSha
+    impact = $impact
+    validated_source_head_sha = $headSha
     candidate_package_sha256 = [string]$validation.PackageSha256
     human_review = [ordered]@{
         reviewer = $commentAuthor
         reviewed_at = [string]$review.reviewed_at
         verdict = "pass"
     }
-    merge_method = $mergeMethod
-    merge_sha = $mergeCommit
+    merge_method = $effectiveMergeMethod
+    resulting_merge_sha = $mergeCommit
+    source_to_result_relation = $sourceToResultRelation
+    ancestry_verified = $ancestryVerified
+    squash_exception = $exceptionEvidence
     merged = $true
     release_scope_gate = "NOT_APPLICABLE"
     release_side_effects = $false
@@ -191,5 +279,6 @@ Write-DDDAPlatformJson -Path $evidencePath -Depth 20 -Value ([ordered]@{
 Write-Host ""
 Write-Host "DDDA merge-pr: PASS"
 Write-Host "PR #$Pr merged as $mergeCommit."
+Write-Host "Source→result: $sourceToResultRelation"
 Write-Host "Evidence: $evidencePath"
 Write-Host "Nebyl vytvořen release package, release validation ani tag."

--- a/tests/powershell/Test-DDDAMergeStrategy.ps1
+++ b/tests/powershell/Test-DDDAMergeStrategy.ps1
@@ -1,0 +1,106 @@
+[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PlatformPath "scripts/platform/DDDAMergeStrategySupport.ps1")
+
+function Assert-Equal {
+    param([AllowNull()]$Actual, [AllowNull()]$Expected, [Parameter(Mandatory = $true)][string]$Message)
+    if ([string]$Actual -ne [string]$Expected) {
+        throw "$Message Expected '$Expected', actual '$Actual'."
+    }
+}
+function Assert-True {
+    param([bool]$Condition, [Parameter(Mandatory = $true)][string]$Message)
+    if (-not $Condition) { throw $Message }
+}
+function Assert-Throws {
+    param([Parameter(Mandatory = $true)][scriptblock]$Action, [Parameter(Mandatory = $true)][string]$Message)
+    $thrown = $false
+    try { & $Action } catch { $thrown = $true }
+    if (-not $thrown) { throw $Message }
+}
+
+$policy = Get-Content -LiteralPath (Join-Path $PlatformPath "config/platform/development-policy.yaml") -Raw -Encoding UTF8 | ConvertFrom-Json
+$baseSha = "1111111111111111111111111111111111111111"
+$highBody = @'
+Implements #999
+<!-- ddda:change-classification:v1 -->
+```json
+{"schema_version":1,"impact":"HIGH"}
+```
+'@
+$lowBody = @'
+Implements #998
+<!-- ddda:change-classification:v1 -->
+```json
+{"schema_version":1,"impact":"LOW"}
+```
+'@
+
+Assert-Equal (Get-DDDAChangeImpactFromPrBody -Body $highBody) "HIGH" "Impact marker parsing failed."
+Assert-Equal (Get-DDDAChangeImpactFromPrBody -Body "Implements #1") "UNKNOWN" "Missing classification must be UNKNOWN."
+
+$highDefault = Resolve-DDDAMergeStrategy -Policy $policy -Impact "HIGH" -Pr 999 -BaseSha $baseSha -PrBody $highBody
+Assert-Equal $highDefault.merge_method "merge" "HIGH must default to merge commit."
+Assert-Throws -Action {
+    Resolve-DDDAMergeStrategy -Policy $policy -Impact "HIGH" -RequestedMethod "squash" -Pr 999 -BaseSha $baseSha -PrBody $highBody | Out-Null
+} -Message "HIGH squash must fail closed."
+Assert-Throws -Action {
+    Resolve-DDDAMergeStrategy -Policy $policy -Impact "BREAKING" -RequestedMethod "squash" -Pr 999 -BaseSha $baseSha -PrBody $highBody | Out-Null
+} -Message "BREAKING squash must fail closed."
+Assert-Throws -Action {
+    Resolve-DDDAMergeStrategy -Policy $policy -Impact "UNKNOWN" -RequestedMethod "squash" -Pr 999 -BaseSha $baseSha -PrBody "" | Out-Null
+} -Message "UNKNOWN impact squash must fail closed."
+
+$lowDefault = Resolve-DDDAMergeStrategy -Policy $policy -Impact "LOW" -Pr 998 -BaseSha $baseSha -PrBody $lowBody
+Assert-Equal $lowDefault.merge_method "merge" "LOW must default to merge commit."
+$lowSquash = Resolve-DDDAMergeStrategy -Policy $policy -Impact "LOW" -RequestedMethod "squash" -Pr 998 -BaseSha $baseSha -PrBody $lowBody
+Assert-True $lowSquash.human_squash_exception_required "LOW squash must require human exception."
+
+$transition = $policy.merge_strategy.bootstrap_transition
+$bootstrapBody = @'
+Implements #70
+<!-- ddda:change-classification:v1 -->
+```json
+{"schema_version":1,"impact":"HIGH"}
+```
+'@
+$bootstrap = Resolve-DDDAMergeStrategy `
+    -Policy $policy `
+    -Impact "HIGH" `
+    -RequestedMethod "squash" `
+    -Pr 70 `
+    -BaseSha ([string]$transition.legacy_base_sha) `
+    -PrBody $bootstrapBody
+Assert-True $bootstrap.bootstrap_transition "#70 prospective bootstrap must allow only its exact legacy-base squash transition."
+Assert-Throws -Action {
+    Resolve-DDDAMergeStrategy -Policy $policy -Impact "HIGH" -RequestedMethod "squash" -Pr 70 -BaseSha ("f" * 40) -PrBody $bootstrapBody | Out-Null
+} -Message "#70 bootstrap must not apply on another base SHA."
+
+$exceptionComment = [pscustomobject]@{
+    body = @'
+<!-- ddda:squash-exception:v1 -->
+```json
+{"schema_version":1,"kind":"squash_exception","repository":"romanhlavac/ddd-accelerator","pr":998,"validated_source_head_sha":"2222222222222222222222222222222222222222","candidate_package_sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","impact":"LOW","reason":"Explicit history-cleanliness exception for a low-risk change.","reviewer":"romanhlavac","approved_at":"2026-08-20T00:00:00Z"}
+```
+'@
+}
+$record = ConvertFrom-DDDASquashExceptionComment -Comment $exceptionComment
+Assert-DDDASquashExceptionRecord `
+    -Record $record `
+    -CommentAuthor "romanhlavac" `
+    -CommentAuthorType "User" `
+    -Repository "romanhlavac/ddd-accelerator" `
+    -Pr 998 `
+    -HeadSha "2222222222222222222222222222222222222222" `
+    -CandidatePackageSha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" `
+    -Impact "LOW"
+Assert-Throws -Action {
+    Assert-DDDASquashExceptionRecord -Record $record -CommentAuthor "automation[bot]" -CommentAuthorType "Bot" -Repository "romanhlavac/ddd-accelerator" -Pr 998 -HeadSha "2222222222222222222222222222222222222222" -CandidatePackageSha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" -Impact "LOW"
+} -Message "Bot must not authorize squash exception."
+
+Write-Host "DDDA merge strategy contract: PASS"


### PR DESCRIPTION
Implements #70

Part of approved DDDA 0.1.1 Stabilization plan #75.

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"impact":"HIGH"}
```

## Baseline / classification
- base: `main@297f61f6012f180e70805999df2ac1abe9616a05`
- implementation head: `f8284740bad1d94833fa91a526de652abdf7fe69`
- branch: `fix/70-exact-sha-merge-strategy`
- impact: **HIGH**
- areas: `SECURITY-GOVERNANCE`, `RELEASE`, `TESTING`, `DOC`, `CLI`
- compatibility: non-breaking, prospective governance tightening

## Problem
Current global `squash` policy preserves content but removes the exact reviewed PR HEAD from resulting `main` ancestry. That weakens direct Git auditability of the exact SHA/package that passed CI, `validate-pr` and Human Review.

## Implemented contract
- canonical default changes to **merge commit**;
- HIGH/BREAKING: merge commit required, squash/rebase fail closed before irreversible merge;
- LOW/MEDIUM: merge commit default; squash only with exactly one human `ddda:squash-exception:v1` record bound to repository/PR/SHA/package/impact;
- missing impact marker is `UNKNOWN` and safely permits only merge commit;
- `rebase` is removed from the canonical governed path because it does not preserve exact validated commit identity;
- canonical merge performs server-side post-read-back: validated source HEAD must be a parent and ancestor of the resulting merge commit;
- merge evidence schema records impact, source SHA, package hash, resulting merge SHA, source→result relation, ancestry verification and any squash exception metadata;
- first-parent history is the recommended compact operational view.

## Bootstrap transition for #70 itself
This PR changes the merge policy that would otherwise govern its own integration. It therefore does **not** retroactively self-activate the new rule.

The transition is versioned and exact-base-bound:
- legacy governing base: `297f61f6012f180e70805999df2ac1abe9616a05`;
- legacy policy merge method: `squash`;
- transition issue: `#70`;
- new merge-commit policy becomes authoritative only **after #70 is integrated into main**.

Accordingly, if this PR later passes exact-SHA technical evidence + HVR and receives a separate explicit merge authorization, its own integration remains governed by the pre-existing squash policy. This one-time prospective bootstrap is not a precedent for HIGH/BREAKING squash after #70 lands. No historical PR, tag or shared history is rewritten.

## Tests
- impact → merge-method matrix;
- HIGH/BREAKING squash rejection;
- UNKNOWN squash rejection;
- LOW/MEDIUM human squash-exception requirement;
- bot/stale-identity exception rejection;
- exact-base-only #70 bootstrap regression;
- static guard that strategy validation occurs before merge and ancestry read-back after merge;
- PowerShell behavioral contract executed from platform pytest.

## Documentation
- ADR 0009 records the decision and trade-offs;
- ADR 0001 is amended;
- platform lifecycle and validate/promote user guide are aligned;
- new merge-strategy runbook defines human exception and post-merge evidence;
- `CHANGELOG.md` records #70 and also captures already-integrated #12 stabilization fix under `Unreleased`.

## Authority boundary
Automation may validate impact markers, method policy, ancestry and human squash-exception identity. It must not create impact decisions, squash exceptions, Human Review PASS, merge authorization, HRDR, release decision or release authorization.

## Side-effect guard
This PR does not authorize its own merge. No promotion, release, tag, force update or history rewrite is authorized by #70 or by technical PASS.