### PR TITLE
[GOV] Repair remote remediation broker preflight

### DIFF
--- a/.github/workflows/assistant-command.yml
+++ b/.github/workflows/assistant-command.yml
@@ -139,6 +139,9 @@ jobs:
             throw 'Remediation checkout drifted before execution.'
           }
           $script = Join-Path $PWD.Path $env:REMEDIATION_SCRIPT
+          if (-not (Test-Path -LiteralPath $script -PathType Leaf)) {
+            throw "Authorized remediation script does not exist at exact PR head: $env:REMEDIATION_SCRIPT"
+          }
           & $script -RepositoryRoot $PWD.Path -NoPush
           if ($LASTEXITCODE -ne 0) {
             throw "Remediation script failed with exit code $LASTEXITCODE."
@@ -224,4 +227,4 @@ jobs:
 
           No merge, tag, release or promotion was performed.
           "@
-          gh pr comment $env:PR_NUMBER --repo $env:REPOSITORY --body $body
+          gh api --method POST "repos/$env:REPOSITORY/issues/$env:PR_NUMBER/comments" -f body="$body" | Out-Null

--- a/runtime/platform/tests/test_remote_execution_broker_contract.py
+++ b/runtime/platform/tests/test_remote_execution_broker_contract.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+REQUEST = ROOT / "scripts/platform/Test-DDDARemoteExecutionRequest.ps1"
+WORKFLOW = ROOT / ".github/workflows/assistant-command.yml"
+
+
+def test_remote_broker_tolerates_optional_miro_team_id():
+    text = REQUEST.read_text(encoding="utf-8-sig")
+    assert '$remote.PSObject.Properties.Name -contains "miro_team_id"' in text
+    assert 'miro_team_id = $miroTeamId' in text
+    assert 'miro_team_id = [string]$remote.miro_team_id' not in text
+
+
+def test_remediation_script_existence_is_checked_after_exact_pr_checkout():
+    request = REQUEST.read_text(encoding="utf-8-sig")
+    workflow = WORKFLOW.read_text(encoding="utf-8-sig")
+
+    assert 'Remediation script does not exist at the exact PR head' not in request
+    checkout = workflow.index('name: Checkout exact PR branch without write credentials')
+    run = workflow.index('name: Run guarded remediation without push')
+    existence = workflow.index('Authorized remediation script does not exist at exact PR head')
+    assert checkout < run < existence
+
+
+def test_broker_failure_comment_uses_issues_rest_api():
+    workflow = WORKFLOW.read_text(encoding="utf-8-sig")
+    assert 'gh api --method POST "repos/$env:REPOSITORY/issues/$env:PR_NUMBER/comments"' in workflow
+    assert 'gh pr comment $env:PR_NUMBER' not in workflow
+    assert 'issues: write' in workflow

--- a/scripts/platform/Test-DDDARemoteExecutionRequest.ps1
+++ b/scripts/platform/Test-DDDARemoteExecutionRequest.ps1
@@ -26,6 +26,11 @@ if ([bool]$remote.same_repository_only -and $HeadRepository -ne $Repository) {
     throw "Remote execution is allowed only for same-repository pull requests."
 }
 
+$miroTeamId = ""
+if ($remote.PSObject.Properties.Name -contains "miro_team_id") {
+    $miroTeamId = [string]$remote.miro_team_id
+}
+
 $normalized = $CommandText.Trim()
 $result = [ordered]@{
     status = "PASS"
@@ -36,7 +41,7 @@ $result = [ordered]@{
     head_repository = $HeadRepository
     action = $null
     remediation_script = $null
-    miro_team_id = [string]$remote.miro_team_id
+    miro_team_id = $miroTeamId
     keep_review_board = $true
     merge_allowed = $false
     promotion_allowed = $false
@@ -63,9 +68,8 @@ elseif ($normalized -match '^/ddda remediate\s+(?<path>scripts/remediation/[A-Za
     if (-not $fullScriptPath.StartsWith($allowedRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
         throw "Remediation script escapes the allowed root."
     }
-    if (-not (Test-Path -LiteralPath $fullScriptPath -PathType Leaf)) {
-        throw "Remediation script does not exist at the exact PR head: $scriptPath"
-    }
+    # Existence is intentionally not checked on the trusted default-branch checkout.
+    # The workflow checks the path after checkout of the authorized exact PR head.
     $result.action = "remediate"
     $result.remediation_script = $scriptPath
 }


### PR DESCRIPTION
Implements #16

Blocks completion of #86 governance normalization until this broker defect is integrated on the default branch.

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"impact":"HIGH"}
```

## Exact baseline
- base: `main@1f66880c30b7bc1814d21200ef6fcc5b08cadfba`
- head: `8517e92f63945d4b7bd882ad1fa01b26dc708ad0`
- branch: `fix/16-remote-broker-remediation-authorization`

## Defects reproduced by run 32360161413
1. StrictMode authorization fails because `remote_execution.miro_team_id` is optional/absent but read unconditionally.
2. Remediation-script existence is checked on the trusted default-branch checkout before exact PR checkout, so a PR-staged remediation script cannot pass authorization.
3. Failure-result commenting uses `gh pr comment` and failed with GraphQL `Resource not accessible by integration (addComment)` under the workflow token.

## Fix
- tolerate absent `miro_team_id` without weakening validate/remediate authorization;
- keep path-prefix/path-escape checks on trusted main, but check actual remediation-script existence only after exact authorized PR checkout;
- post execution result through REST Issues comments using existing `issues: write` permission;
- add regression tests for all three contracts.

## Side-effect boundary
No merge, promotion, release, tag, Project mutation or history rewrite is authorized by this PR. Because impact is HIGH, any later authorized merge must use a merge commit and preserve the exact reviewed PR head ancestry.