### PR TITLE
[GOV][ORCH][#88] Fix remote broker push and non-destructive result reporting

### DIFF
--- a/.github/workflows/assistant-command.yml
+++ b/.github/workflows/assistant-command.yml
@@ -174,8 +174,16 @@ jobs:
           if ($actual -ne $env:VALIDATED_AFTER_SHA) {
             throw "Validated remediation SHA drifted before push."
           }
+          $targetRef = '${{ steps.pr.outputs.head_ref }}'
+          if ([string]::IsNullOrWhiteSpace($targetRef)) {
+            throw 'Resolved PR head ref is empty before remediation push.'
+          }
+          $refspec = '{0}:{1}' -f $env:VALIDATED_AFTER_SHA, $targetRef
           gh auth setup-git
-          git push origin "$env:VALIDATED_AFTER_SHA:${{ steps.pr.outputs.head_ref }}"
+          git push origin $refspec
+          if ($LASTEXITCODE -ne 0) {
+            throw "Validated remediation push failed for ref '$targetRef'."
+          }
 
       - name: Stage execution evidence
         if: always()
@@ -213,6 +221,7 @@ jobs:
 
       - name: Comment execution result
         if: always()
+        continue-on-error: true
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}

--- a/runtime/platform/tests/test_remote_execution_broker_contract.py
+++ b/runtime/platform/tests/test_remote_execution_broker_contract.py
@@ -23,8 +23,26 @@ def test_remediation_script_existence_is_checked_after_exact_pr_checkout():
     assert checkout < run < existence
 
 
+def test_remediation_push_refspec_avoids_powershell_env_colon_ambiguity():
+    workflow = WORKFLOW.read_text(encoding="utf-8-sig")
+
+    assert '$refspec = \'{0}:{1}\' -f $env:VALIDATED_AFTER_SHA, $targetRef' in workflow
+    assert 'git push origin $refspec' in workflow
+    assert 'git push origin "$env:VALIDATED_AFTER_SHA:' not in workflow
+
+
 def test_broker_failure_comment_uses_issues_rest_api():
     workflow = WORKFLOW.read_text(encoding="utf-8-sig")
     assert 'gh api --method POST "repos/$env:REPOSITORY/issues/$env:PR_NUMBER/comments"' in workflow
     assert 'gh pr comment $env:PR_NUMBER' not in workflow
     assert 'issues: write' in workflow
+
+
+def test_broker_result_comment_failure_is_non_destructive():
+    workflow = WORKFLOW.read_text(encoding="utf-8-sig")
+
+    start = workflow.index('- name: Comment execution result')
+    block = workflow[start:]
+    assert 'if: always()' in block
+    assert 'continue-on-error: true' in block
+    assert workflow.index('- name: Upload execution evidence') < start


### PR DESCRIPTION
Implements #88

Narrow control-plane slice only; this PR does not complete all of #88.

This PR fixes the two concrete DDDA remote broker failure modes evidenced by Actions run `32393978204`. It does **not** complete all of #88 and does not change the approved DDDA 0.1.1 product release scope.

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"impact":"HIGH"}
```

## Exact baseline
- base: `main@f4b90129bab79a4d1310f9d98eacca154570fd60`
- branch: `fix/88-broker-push-reporting`
- exact implementation HEAD: `e2db509c600883c22dd975b5b6b60900686142f2`
- Work Package: `Other`
- Item Type authority: Enabler #88
- Target Release: `TBD` / outside approved 0.1.1 product scope

## Scope
1. Build remediation push refspec explicitly instead of using PowerShell `$env:VAR:` interpolation, which produced `fatal: invalid refspec '/16-0.1.1-governance-normalization'`.
2. Keep execution evidence authoritative and make the PR result-comment step non-destructive, so a comment transport failure cannot turn an otherwise successful broker execution into workflow failure.
3. Add regression coverage for both failure classes.

## Non-goals
- no Project V2/capability-doctor implementation;
- no new credential model;
- no expansion of #88 beyond this narrow broker slice;
- no change to DDDA 0.1.1 release scope;
- no merge, promotion, release or tag.

## Acceptance for this slice
- remediation push uses a deterministic `<validated_sha>:<head_ref>` refspec without PowerShell env/colon ambiguity;
- push failure remains fail-closed;
- execution-result comment remains attempted through the Issues REST API but is best-effort/non-destructive;
- execution evidence upload precedes the optional comment;
- regression tests encode both invariants;
- standard exact-SHA CI and `validate-pr` PASS for the same HEAD.

## Exact-SHA technical evidence
- `Validate DDDA` run `32395208846`: **PASS**
- `DDDA platform CI` run `32395208787`: **PASS**
- `Platform validation`: **PASS**
- `One-command PR validation`: **PASS**
- validate-pr source SHA: `e2db509c600883c22dd975b5b6b60900686142f2`
- candidate package SHA-256: `45e17c26be1b25f026b4e195d4079bca90297a116e71f297fb85a395fc95ca5e`
- lint/schema/unit/component/integration/smoke/regression/security/e2e/acceptance: **PASS**
- Miro: NOT_RUN / not applicable to this broker-only slice.

## Evidence source
Observed run `32393978204`: guarded remediation PASS created local commit `3ebafb73fc461d6895a07cb0ced659116e99d307`; push failed only on malformed refspec; result comment separately returned HTTP 403.

## Bootstrap / governance note
The connector currently exposes no Project V2 mutation surface, so the mandatory Project delivery projection for this new PR cannot yet be materialized/read back through the connector. Per the active governance contract this remains `GOVERNANCE_INCOMPLETE` for merge readiness; code/CI PASS does not waive that invariant. This narrow PR is itself part of the control-plane bootstrap needed to restore the blocked #86 flow.

## Governance state
PR remains Draft. Technical validation is PASS for the exact HEAD above. Human Review is the next judgment gate for this HIGH-impact broker change. Any later merge requires exact-SHA Human Review PASS plus separate explicit merge authorization and merge-commit strategy. No merge/release/tag is authorized by this PR.