### PR TITLE
fix(release): publish canonical GitHub Release assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 
 ### Changed
 
+- canonical promotion po validated tagu publikuje canonical DDDA ZIP a portable release reports jako ověřené GitHub Release assets;
 - GitHub-native backlog governance nyní považuje Issue/PR mutation, Project planning/delivery projection a release Milestone projection za jednu fail-closed transakci; DDDA 0.1.0/0.1.1 scope je versioned a canonical reconciler opravuje Project/Milestone drift před Ready/merge/release doporučením.
 - platform lifecycle nyní explicitně odděluje governed merge implementačních PR od skutečného release/promotion; implementation merge nevyžaduje HRDR ani Release Scope Gate a nesmí vytvořit release package, release validation nebo tag;
 - public `promote-pr` zůstává strict release-candidate command: před interním release executorem vyžaduje validní human HRDR a read-only Release Scope Gate PASS nad Milestone, native blockers a GitHub Project V2 projekcí;

--- a/docs/adr/0010-canonical-github-release-publication.md
+++ b/docs/adr/0010-canonical-github-release-publication.md
@@ -1,0 +1,43 @@
+# ADR 0010: Canonical GitHub Release publication
+
+- Status: Proposed
+- Date: 2026-08-25
+- Related: #68, #96, #98
+
+## Context
+
+The canonical promotion path validates a release package and emits a release report and annotated Git tag. A tag alone exposes GitHub-generated source archives but does not publish the validated DDDA product package or durable release evidence.
+
+The required invariant is:
+
+```text
+validated release version + source SHA + package SHA-256 + report + tag
+= one immutable GitHub Release publication
+```
+
+## Decision
+
+After all release gates and release validation PASS, promotion creates or read-backs exactly one final GitHub Release named `DDDA X.Y.Z` for tag `vX.Y.Z`. It publishes these deterministic assets:
+
+- `ddda-X.Y.Z.zip` — canonical validated DDDA package;
+- `ddda-X.Y.Z-release-report.json`;
+- `ddda-X.Y.Z-release-report.md`.
+
+Publication verifies the annotated tag dereferences to the exact validated release source SHA, then verifies each physical asset SHA-256 by GitHub digest or authenticated download/read-back. Existing tag, Release or assets are never overwritten. Partial failure is not PASS; recovery requires a separate explicit authorization and fresh identity/hash read-back.
+
+GitHub source archives remain convenience source archives, not the DDDA product package.
+
+## Consequences
+
+- Release distribution and evidence become directly discoverable in GitHub Releases.
+- Release publication adds a post-validation side-effect boundary and recovery state.
+- #96 remains responsible for proving that the release source itself is physically in scope before publication may begin.
+- #68 remains responsible for tag identity/recovery; this decision only extends recovery with Release and asset identity.
+
+## Validation
+
+- deterministic asset-name and hash checks;
+- release API orchestration and server read-back;
+- missing/wrong/duplicate asset and partial-publication regressions;
+- dry-run proves no tag, Release or asset side effect;
+- authorization and secret-isolation tests.

--- a/docs/developer-guide/github-release-publication.md
+++ b/docs/developer-guide/github-release-publication.md
@@ -1,0 +1,54 @@
+# Canonical GitHub Release publication
+
+## Terms
+
+```text
+Milestone           = declared release scope
+Release candidate   = exact frozen candidate state
+Tag                 = immutable Git identity of the released version
+GitHub Release      = published distribution/evidence object for that tag
+Canonical DDDA ZIP  = validated DDDA product package
+GitHub source ZIP   = convenience source archive, not the DDDA product package
+```
+
+## Normal publication path
+
+Publication is reached only inside an explicitly authorized non-dry-run canonical promotion, after release validation and report generation are PASS.
+
+```text
+release source SHA
+→ validated canonical ZIP + SHA-256
+→ portable result.json + result.md
+→ annotated tag vX.Y.Z
+→ GitHub Release DDDA X.Y.Z
+→ upload exact assets
+→ fresh server read-back of tag, Release and asset hashes
+```
+
+The published assets are named deterministically:
+
+```text
+ddda-X.Y.Z.zip
+ddda-X.Y.Z-release-report.json
+ddda-X.Y.Z-release-report.md
+```
+
+Automatic GitHub source archives may be visible in the Release UI. They are never canonical DDDA package evidence.
+
+## Failure and recovery
+
+Publication is fail closed. A tag created without its Release, a Release without all assets, an unexpected existing Release/asset, or a mismatching hash is `RECOVERY_REQUIRED`, not `PASS`.
+
+Do not delete, replace, retag, force-push or rerun promotion heuristically. After separate recovery authorization, use the recovery command only with the original validated release source, package and reports:
+
+```powershell
+.\scripts\platform\Invoke-DDDARecoverGitHubRelease.ps1 `
+  -Version X.Y.Z `
+  -ReleaseSourceSha <validated-release-sha> `
+  -ReleasePackagePath <validated-package.zip> `
+  -ReleaseReportJsonPath <result.json> `
+  -ReleaseReportMarkdownPath <result.md> `
+  -ConfirmRecovery
+```
+
+Recovery finishes only after fresh tag/Release/asset read-back proves the original identities and physical package SHA-256.

--- a/docs/developer-guide/platform-development-lifecycle.md
+++ b/docs/developer-guide/platform-development-lifecycle.md
@@ -118,6 +118,7 @@ release candidate (typicky release/<version> PR nebo ekvivalentní governed cand
 → release validation
 → release report
 → tag
+→ GitHub Release s canonical package a release-evidence assets
 ```
 
 Release Scope Gate zůstává striktní. Neaplikuje se ale jako podmínka integrace jednotlivých implementačních PR, jejichž merge je předpokladem pro uzavření release scope.

--- a/docs/developer-guide/release-tag-recovery.md
+++ b/docs/developer-guide/release-tag-recovery.md
@@ -73,3 +73,7 @@ result
 ```
 
 `result=PASS` je možné pouze tehdy, když fresh remote read-back prokáže canonical tag na exact validated release SHA. Technický recovery PASS nenahrazuje žádné další Human Release Decision nebo release governance rozhodnutí, které je podle aktuálního lifecycle stále vyžadováno.
+
+## Navazující GitHub Release publication
+
+Canonical tag sám o sobě není published DDDA distribution. Po vytvoření tagu musí promotion vytvořit nebo fresh read-backem ověřit GitHub Release a jeho canonical package/report assets. Pokud tag existuje, ale Release nebo některý asset chybí, tag se nepřepisuje; postupuje se podle `github-release-publication.md` se samostatnou recovery authorization.

--- a/docs/developer-guide/testing-strategy.md
+++ b/docs/developer-guide/testing-strategy.md
@@ -14,6 +14,7 @@ DDDA netestuje pouze kód. Testuje také:
 - example workspaces;
 - Miro mapping a idempotenci;
 - release lifecycle.
+- identity GitHub Release publication a fyzické SHA-256 canonical release assets.
 
 Automatizace řeší mechanické kontroly. Manuální review zůstává pro judgment.
 

--- a/docs/user-guide/validate-and-promote-pr.md
+++ b/docs/user-guide/validate-and-promote-pr.md
@@ -191,6 +191,7 @@ Canonical promotion po PASS gate:
 5. provede ingestion, security, smoke, E2E a acceptance;
 6. vytvoří release report;
 7. vytvoří/pushne tag až po PASS.
+8. vytvoří GitHub Release pro canonical tag a publikuje validated DDDA ZIP, `result.json` a `result.md`; fresh read-back ověří identity a SHA-256 assets.
 
 Při release validation FAIL se tag nevytvoří.
 

--- a/knowledge/ddda-platform-development-skill.md
+++ b/knowledge/ddda-platform-development-skill.md
@@ -217,6 +217,7 @@ release candidate preparation (typically release/<version> PR or equivalent gove
 → smoke + acceptance
 → release report
 → tag
+→ GitHub Release publication of the validated canonical package and portable release evidence
 ```
 
 Release Scope Gate stays strict: incomplete current-release scope is a release failure. It is not evaluated as a prerequisite for merging the individual implementation PRs whose integration is required to make that scope terminal.

--- a/scripts/platform/DDDAReleasePublicationSupport.ps1
+++ b/scripts/platform/DDDAReleasePublicationSupport.ps1
@@ -1,0 +1,190 @@
+﻿Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-DDDAReleasePublicationAssetDescriptors {
+    param(
+        [Parameter(Mandatory = $true)][string]$Version,
+        [Parameter(Mandatory = $true)][string]$PackagePath,
+        [Parameter(Mandatory = $true)][string]$ReportJsonPath,
+        [Parameter(Mandatory = $true)][string]$ReportMarkdownPath
+    )
+
+    foreach ($item in @(
+        [pscustomobject]@{ role = "package"; path = $PackagePath; name = "ddda-$Version.zip"; content_type = "application/zip" },
+        [pscustomobject]@{ role = "release_report_json"; path = $ReportJsonPath; name = "ddda-$Version-release-report.json"; content_type = "application/json" },
+        [pscustomobject]@{ role = "release_report_markdown"; path = $ReportMarkdownPath; name = "ddda-$Version-release-report.md"; content_type = "text/markdown" }
+    )) {
+        if (-not (Test-Path -LiteralPath $item.path -PathType Leaf)) {
+            throw "Release publication asset '$($item.role)' neexistuje: $($item.path)"
+        }
+        [pscustomobject]@{
+            role = $item.role
+            path = (Resolve-Path -LiteralPath $item.path).Path
+            name = $item.name
+            content_type = $item.content_type
+            sha256 = Get-DDDAPlatformFileHash -Path $item.path
+        }
+    }
+}
+
+function Get-DDDAGitHubReleaseByTag {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositorySlug,
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string]$Token
+    )
+
+    try {
+        return Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/releases/tags/$Tag" -Token $Token
+    }
+    catch {
+        if ($_.Exception.Message -match 'HTTP:\s*404') { return $null }
+        throw
+    }
+}
+
+function Assert-DDDACanonicalReleaseTagReadBack {
+    param(
+        [Parameter(Mandatory = $true)][string]$OriginUrl,
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string]$ExpectedCommit
+    )
+
+    $lines = @(Invoke-DDDAPlatformNative -Command "git" -Arguments @("ls-remote", "--tags", $OriginUrl, "refs/tags/$Tag", "refs/tags/$Tag^{}"))
+    $peeled = @($lines | Where-Object { $_ -match ("refs/tags/" + [regex]::Escape($Tag) + "\\^\\{\\}$") }) | Select-Object -First 1
+    if ($null -eq $peeled) {
+        throw "Fresh remote read-back neprokázal annotated canonical tag $Tag."
+    }
+    $actualCommit = ([string]$peeled -split "\s+")[0].Trim()
+    if ($actualCommit -ne $ExpectedCommit) {
+        throw "Canonical tag $Tag ukazuje na $actualCommit, očekáváno $ExpectedCommit."
+    }
+    return $actualCommit
+}
+
+function Assert-DDDAGitHubReleaseIdentity {
+    param(
+        [Parameter(Mandatory = $true)]$Release,
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string]$Title
+    )
+
+    if ([string]$Release.tag_name -ne $Tag) { throw "GitHub Release tag neodpovídá $Tag." }
+    if ([string]$Release.name -ne $Title) { throw "GitHub Release title neodpovídá '$Title'." }
+    if ([bool]$Release.draft -or [bool]$Release.prerelease) { throw "GitHub Release musí být publikovaný finální release." }
+}
+
+function Test-DDDAGitHubReleaseAssetHash {
+    param(
+        [Parameter(Mandatory = $true)]$Asset,
+        [Parameter(Mandatory = $true)][string]$ExpectedSha256,
+        [Parameter(Mandatory = $true)][string]$Token
+    )
+
+    $digest = [string]$Asset.digest
+    if ($digest -match '^sha256:(?<hash>[0-9a-fA-F]{64})$') {
+        return $Matches['hash'].ToLowerInvariant() -eq $ExpectedSha256.ToLowerInvariant()
+    }
+
+    $downloadPath = [System.IO.Path]::GetTempFileName()
+    try {
+        Invoke-WebRequest -Method GET -Uri ([string]$Asset.browser_download_url) -Headers @{ Authorization = "Bearer $Token"; Accept = "application/octet-stream"; "User-Agent" = "DDDA-Platform-Release-Publication" } -OutFile $downloadPath -ErrorAction Stop | Out-Null
+        return (Get-DDDAPlatformFileHash -Path $downloadPath) -eq $ExpectedSha256
+    }
+    finally {
+        Remove-Item -LiteralPath $downloadPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Publish-DDDAGitHubReleaseAsset {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositorySlug,
+        [Parameter(Mandatory = $true)][int64]$ReleaseId,
+        [Parameter(Mandatory = $true)]$Descriptor,
+        [Parameter(Mandatory = $true)][string]$Token
+    )
+
+    $escapedName = [uri]::EscapeDataString([string]$Descriptor.name)
+    $uri = "https://uploads.github.com/repos/$RepositorySlug/releases/$ReleaseId/assets?name=$escapedName"
+    $headers = @{ Authorization = "Bearer $Token"; Accept = "application/vnd.github+json"; "X-GitHub-Api-Version" = "2022-11-28"; "User-Agent" = "DDDA-Platform-Release-Publication" }
+    return Invoke-RestMethod -Method POST -Uri $uri -Headers $headers -ContentType ([string]$Descriptor.content_type) -InFile ([string]$Descriptor.path) -ErrorAction Stop
+}
+
+function Publish-DDDACanonicalGitHubRelease {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositorySlug,
+        [Parameter(Mandatory = $true)][string]$OriginUrl,
+        [Parameter(Mandatory = $true)][string]$Version,
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string]$ReleaseSourceSha,
+        [Parameter(Mandatory = $true)][string]$PackagePath,
+        [Parameter(Mandatory = $true)][string]$ReportJsonPath,
+        [Parameter(Mandatory = $true)][string]$ReportMarkdownPath,
+        [Parameter(Mandatory = $true)][string]$Token,
+        [Parameter(Mandatory = $true)][string]$PublicationEvidencePath
+    )
+
+    if ($ReleaseSourceSha -notmatch '^[0-9a-f]{40}$') { throw "Release source SHA není platný." }
+    $title = "DDDA $Version"
+    $tagCommit = Assert-DDDACanonicalReleaseTagReadBack -OriginUrl $OriginUrl -Tag $Tag -ExpectedCommit $ReleaseSourceSha
+    $assets = @(Get-DDDAReleasePublicationAssetDescriptors -Version $Version -PackagePath $PackagePath -ReportJsonPath $ReportJsonPath -ReportMarkdownPath $ReportMarkdownPath)
+    $report = Get-Content -LiteralPath $ReportJsonPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    if ([string]$report.status -ne "PASS" -or [string]$report.source.kind -ne "release" -or [string]$report.source.repository -ne $RepositorySlug -or [string]$report.source.commit -ne $ReleaseSourceSha) {
+        throw "Release report není PASS evidence pro exact canonical release source."
+    }
+    $package = @($assets | Where-Object { $_.role -eq "package" })[0]
+    if ([string]$report.package.sha256 -ne [string]$package.sha256) { throw "Release package SHA-256 neodpovídá release reportu." }
+
+    $release = Get-DDDAGitHubReleaseByTag -RepositorySlug $RepositorySlug -Tag $Tag -Token $Token
+    if ($null -eq $release) {
+        $release = Invoke-DDDAGitHubApi -Method POST -Path "repos/$RepositorySlug/releases" -Token $Token -Body @{
+            tag_name = $Tag
+            target_commitish = $ReleaseSourceSha
+            name = $title
+            body = "Canonical DDDA product package and release evidence for `$Tag. GitHub automatic source archives are convenience source archives, not the canonical DDDA product package."
+            draft = $false
+            prerelease = $false
+            generate_release_notes = $false
+        }
+    }
+    Assert-DDDAGitHubReleaseIdentity -Release $release -Tag $Tag -Title $title
+
+    foreach ($descriptor in $assets) {
+        $existing = @($release.assets | Where-Object { [string]$_.name -eq [string]$descriptor.name })
+        if ($existing.Count -gt 1) { throw "GitHub Release obsahuje více assets se jménem $($descriptor.name)." }
+        if ($existing.Count -eq 1) {
+            if (-not (Test-DDDAGitHubReleaseAssetHash -Asset $existing[0] -ExpectedSha256 $descriptor.sha256 -Token $Token)) {
+                throw "Existující GitHub Release asset $($descriptor.name) nemá očekávaný SHA-256; asset se nesmí přepsat."
+            }
+            continue
+        }
+        $null = Publish-DDDAGitHubReleaseAsset -RepositorySlug $RepositorySlug -ReleaseId ([int64]$release.id) -Descriptor $descriptor -Token $Token
+    }
+
+    $readBack = Get-DDDAGitHubReleaseByTag -RepositorySlug $RepositorySlug -Tag $Tag -Token $Token
+    if ($null -eq $readBack) { throw "Fresh GitHub read-back nenašel Release pro $Tag." }
+    Assert-DDDAGitHubReleaseIdentity -Release $readBack -Tag $Tag -Title $title
+    $evidenceAssets = [ordered]@{}
+    foreach ($descriptor in $assets) {
+        $asset = @($readBack.assets | Where-Object { [string]$_.name -eq [string]$descriptor.name })
+        if ($asset.Count -ne 1 -or -not (Test-DDDAGitHubReleaseAssetHash -Asset $asset[0] -ExpectedSha256 $descriptor.sha256 -Token $Token)) {
+            throw "Fresh read-back neprokázal správný obsah assetu $($descriptor.name)."
+        }
+        $evidenceAssets[$descriptor.role] = [ordered]@{ name = [string]$asset[0].name; sha256 = [string]$descriptor.sha256; id = [int64]$asset[0].id; url = [string]$asset[0].browser_download_url }
+    }
+    $evidence = [ordered]@{
+        schema_version = 1
+        repository = $RepositorySlug
+        version = $Version
+        release_source_sha = $ReleaseSourceSha
+        tag = $Tag
+        tag_read_back_sha = $tagCommit
+        github_release = [ordered]@{ id = [int64]$readBack.id; url = [string]$readBack.html_url; title = $title }
+        assets = $evidenceAssets
+        publication_timestamp = (Get-Date).ToUniversalTime().ToString('o')
+        publication_status = "PASS"
+        server_read_back_status = "PASS"
+    }
+    Write-DDDAPlatformJson -Value $evidence -Path $PublicationEvidencePath -Depth 30
+    return [pscustomobject]$evidence
+}

--- a/scripts/platform/Invoke-DDDAPlatformTest.ps1
+++ b/scripts/platform/Invoke-DDDAPlatformTest.ps1
@@ -215,6 +215,7 @@ function Invoke-OneSuite {
         "component" {
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAValidationReport.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAPromotionGuards.ps1" -Arguments @("-PlatformPath", $platformRoot)
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAReleasePublication.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroAutomation.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroEvidence.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAProjectSteering.ps1" -Arguments @("-PlatformPath", $platformRoot)
@@ -235,6 +236,7 @@ function Invoke-OneSuite {
         }
         "regression" {
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAFirstRun.ps1" -Arguments @("-PlatformPath", $platformRoot)
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAReleasePublication.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAProjectSteering.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroAutomation.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroEvidence.ps1" -Arguments @("-PlatformPath", $platformRoot)

--- a/scripts/platform/Invoke-DDDAPromotePr.ps1
+++ b/scripts/platform/Invoke-DDDAPromotePr.ps1
@@ -18,6 +18,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "DDDAPlatformSupport.ps1")
 . (Join-Path $PSScriptRoot "DDDAGitHubSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAReleasePublicationSupport.ps1")
 
 Assert-DDDAPlatformSemanticVersion -Version $Version
 $platformRoot = Get-DDDAPlatformGitRoot -Path $PlatformPath
@@ -382,6 +383,8 @@ finally {
         Diagnostics = @($releaseDiagnostics)
         StartedAt = $releaseStartedAt
         CompletedAt = (Get-Date).ToUniversalTime()
+        PortablePaths = $true
+        RedactedRoots = @($stateRoot, $promotionRoot)
     }
     if (Test-Path -LiteralPath $releasePackagePath -PathType Leaf) {
         $releaseReportArguments["PackagePath"] = $releasePackagePath
@@ -420,6 +423,18 @@ if (-not [string]::IsNullOrWhiteSpace($existingTagAfterValidation)) {
 }
 $null = Invoke-DDDAPlatformGit -Repository $releaseSource -Arguments @("tag", "-a", $tag, $mergeCommit, "-m", "DDDA $Version")
 $null = Invoke-DDDAPlatformGit -Repository $releaseSource -Arguments @("push", "origin", $tag)
+$publicationEvidencePath = Join-Path $releaseReports "publication.json"
+$publication = Publish-DDDACanonicalGitHubRelease `
+    -RepositorySlug $repositorySlug `
+    -OriginUrl $originUrl `
+    -Version $Version `
+    -Tag $tag `
+    -ReleaseSourceSha $mergeCommit `
+    -PackagePath $releasePackagePath `
+    -ReportJsonPath $releaseReportJson `
+    -ReportMarkdownPath $releaseReportMarkdown `
+    -Token $githubAuth.Token `
+    -PublicationEvidencePath $publicationEvidencePath
 
 if (-not $KeepArtifacts -and -not $KeepReviewBoard -and (Test-Path -LiteralPath $promotionRoot)) {
     Remove-Item -LiteralPath $promotionRoot -Recurse -Force -ErrorAction SilentlyContinue
@@ -434,4 +449,6 @@ Write-Host "Release version: $Version"
 Write-Host "Release package: $releasePackagePath"
 Write-Host "Release report:  $releaseReports"
 Write-Host "Tag:             $tag"
+Write-Host "GitHub Release:  $($publication.github_release.url)"
+Write-Host "Publication:     $publicationEvidencePath"
 Write-Host "========================================"

--- a/scripts/platform/Invoke-DDDARecoverGitHubRelease.ps1
+++ b/scripts/platform/Invoke-DDDARecoverGitHubRelease.ps1
@@ -1,0 +1,46 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
+    [Parameter(Mandatory = $true)][string]$Version,
+    [Parameter(Mandatory = $true)][string]$ReleaseSourceSha,
+    [Parameter(Mandatory = $true)][string]$ReleasePackagePath,
+    [Parameter(Mandatory = $true)][string]$ReleaseReportJsonPath,
+    [Parameter(Mandatory = $true)][string]$ReleaseReportMarkdownPath,
+    [switch]$ConfirmRecovery
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "DDDAPlatformSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAGitHubSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAReleasePublicationSupport.ps1")
+
+if (-not $ConfirmRecovery) {
+    throw "GitHub Release recovery vyžaduje explicitní -ConfirmRecovery authorization."
+}
+Assert-DDDAPlatformSemanticVersion -Version $Version
+if ($ReleaseSourceSha -notmatch '^[0-9a-f]{40}$') { throw "ReleaseSourceSha není plný SHA." }
+$platformRoot = Get-DDDAPlatformGitRoot -Path $PlatformPath
+Assert-DDDAPlatformCleanGit -Repository $platformRoot
+$originUrl = Get-DDDAPlatformRepositoryUrl -Repository $platformRoot
+$repositorySlug = Get-DDDAPlatformRepositorySlug -RepositoryUrl $originUrl
+$githubAuth = Get-DDDAGitHubAuthentication
+$tag = "v$Version"
+$evidenceRoot = Join-Path (Get-DDDAPlatformStateRoot) ("release-publication-recovery/$Version/" + (Get-DDDAPlatformTimestamp))
+New-Item -ItemType Directory -Path $evidenceRoot -Force | Out-Null
+
+$publication = Publish-DDDACanonicalGitHubRelease `
+    -RepositorySlug $repositorySlug `
+    -OriginUrl $originUrl `
+    -Version $Version `
+    -Tag $tag `
+    -ReleaseSourceSha $ReleaseSourceSha `
+    -PackagePath $ReleasePackagePath `
+    -ReportJsonPath $ReleaseReportJsonPath `
+    -ReportMarkdownPath $ReleaseReportMarkdownPath `
+    -Token $githubAuth.Token `
+    -PublicationEvidencePath (Join-Path $evidenceRoot "publication.json")
+
+Write-Host "DDDA GitHub Release recovery: PASS"
+Write-Host "Release: $($publication.github_release.url)"
+Write-Host "Evidence: $(Join-Path $evidenceRoot 'publication.json')"

--- a/tests/powershell/Test-DDDAReleasePublication.ps1
+++ b/tests/powershell/Test-DDDAReleasePublication.ps1
@@ -1,0 +1,50 @@
+﻿[CmdletBinding()]
+param([string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PlatformPath "scripts/platform/DDDAPlatformSupport.ps1")
+. (Join-Path $PlatformPath "scripts/platform/DDDAReleasePublicationSupport.ps1")
+
+function Assert-True {
+    param([Parameter(Mandatory = $true)][bool]$Condition, [Parameter(Mandatory = $true)][string]$Message)
+    if (-not $Condition) { throw $Message }
+}
+
+$root = Join-Path ([System.IO.Path]::GetTempPath()) ("ddda-release-publication-" + [Guid]::NewGuid().ToString("N"))
+try {
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+    $package = Join-Path $root "package.zip"
+    $reportJson = Join-Path $root "result.json"
+    $reportMarkdown = Join-Path $root "result.md"
+    [System.IO.File]::WriteAllText($package, "canonical package fixture")
+    [System.IO.File]::WriteAllText($reportJson, '{"status":"PASS"}')
+    [System.IO.File]::WriteAllText($reportMarkdown, "# PASS")
+
+    $descriptors = @(Get-DDDAReleasePublicationAssetDescriptors -Version "1.2.3" -PackagePath $package -ReportJsonPath $reportJson -ReportMarkdownPath $reportMarkdown)
+    Assert-True -Condition ($descriptors.Count -eq 3) -Message "Publication contract musí mít právě package + dva release report assets."
+    Assert-True -Condition ((@($descriptors.name) -join ',') -eq "ddda-1.2.3.zip,ddda-1.2.3-release-report.json,ddda-1.2.3-release-report.md") -Message "Asset names nejsou deterministické podle release verze."
+    Assert-True -Condition ($descriptors[0].sha256 -eq (Get-DDDAPlatformFileHash -Path $package)) -Message "Package asset SHA-256 není fyzický hash vstupního package."
+
+    $goodAsset = [pscustomobject]@{ digest = "sha256:$($descriptors[0].sha256)"; browser_download_url = "https://example.invalid/package" }
+    $badAsset = [pscustomobject]@{ digest = "sha256:$(('0' * 64))"; browser_download_url = "https://example.invalid/package" }
+    Assert-True -Condition (Test-DDDAGitHubReleaseAssetHash -Asset $goodAsset -ExpectedSha256 $descriptors[0].sha256 -Token "not-used-for-digest") -Message "GitHub digest matching nebyl akceptován."
+    Assert-True -Condition (-not (Test-DDDAGitHubReleaseAssetHash -Asset $badAsset -ExpectedSha256 $descriptors[0].sha256 -Token "not-used-for-digest")) -Message "Nesprávný GitHub digest nebyl odmítnut."
+
+    $missingRejected = $false
+    try { $null = Get-DDDAReleasePublicationAssetDescriptors -Version "1.2.3" -PackagePath $package -ReportJsonPath (Join-Path $root "missing.json") -ReportMarkdownPath $reportMarkdown } catch { $missingRejected = $true }
+    Assert-True -Condition $missingRejected -Message "Chybějící publication input musí failnout před side effectem."
+
+    $support = Get-Content -LiteralPath (Join-Path $PlatformPath "scripts/platform/DDDAReleasePublicationSupport.ps1") -Raw -Encoding UTF8
+    $promotion = Get-Content -LiteralPath (Join-Path $PlatformPath "scripts/platform/Invoke-DDDAPromotePr.ps1") -Raw -Encoding UTF8
+    $recovery = Get-Content -LiteralPath (Join-Path $PlatformPath "scripts/platform/Invoke-DDDARecoverGitHubRelease.ps1") -Raw -Encoding UTF8
+    Assert-True -Condition ($support -match 'Fresh GitHub read-back' -and $support -match 'assets\?name=' -and $support -match 'se nesmí přepsat') -Message "Publication support nemá fail-closed read-back/asset contract."
+    Assert-True -Condition ($promotion -match 'PortablePaths\s*=\s*\$true' -and $promotion -match 'Publish-DDDACanonicalGitHubRelease') -Message "Promotion nepublikuje portable validated evidence po tagu."
+    Assert-True -Condition ($recovery -match '\[switch\]\$ConfirmRecovery' -and $recovery -match 'if \(-not \$ConfirmRecovery\)') -Message "Recovery nemá explicitní authorization boundary."
+    Assert-True -Condition ($support -notmatch 'DELETE.+releases|Remove-DDDA.*Release|Delete-DDDA.*Asset') -Message "Publication contract nesmí obsahovat automatické přepsání Release/assets."
+}
+finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "DDDA release publication contract: PASS"


### PR DESCRIPTION
Implements #98

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"change_types":["RELEASE","SECURITY-GOVERNANCE","TESTING"],"impact":"HIGH","migration_impact":"non-breaking"}
```

## Scope

Publishes the exact validated canonical DDDA ZIP, portable `result.json` and `result.md` as deterministic assets of one GitHub Release bound to `vX.Y.Z`.

## Safety contract

- publication is reachable only after release validation PASS and canonical tag creation;
- fresh tag/Release/asset read-back verifies identity and physical SHA-256;
- existing tag, Release or asset is never overwritten;
- partial publication is fail-closed; recovery has its own `-ConfirmRecovery` boundary;
- dry-run remains side-effect free.

## Deliberate ownership boundary

- #96 owns declared release scope = physical release source.
- #68 owns annotated-tag identity/recovery.
- This PR owns validated canonical output = published GitHub Release assets.

## Governance state

The implementation branch and PR were created from exact `main` `0e84252a76050bc38d626f6125326253721c0095`. Project/Milestone reconciliation is pending the canonical privileged workflow and must complete with `remaining_mismatches = 0`; this PR is therefore not governance-PASS or merge-ready.

No merge, promotion, tag or actual Release is authorized by this PR.