### PR TITLE
fix(release): verify controlled recovery source ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 - CR #96 physical release-scope contract: release preflight now derives the shipping commit/PR/primary-CR set from the previous canonical SemVer tag to the exact candidate source SHA and fails closed on an unmapped, ambiguous or out-of-scope change;
 - read-only releasable-main eligibility guard for `merge-pr`: while one DDDA release Milestone is open, a PR whose primary CR is outside that train cannot be merged into `main`;
 - machine-readable physical-source inventory and explicit `RECOVERY_DECISION_REQUIRED` result; automation neither expands release scope nor removes/deferes already integrated source.
+- fail-closed controlled release-source recovery ledger, which binds each reconstructed candidate commit to its original merged PR/primary CR/merge SHA and exact changed-path result hashes; the ledger cannot alter release authority.
 - machine-readable `human-release-decision.schema.json`, `review-pr` scaffold a fail-closed Release Scope Gate pro exact release-candidate SHA / candidate package / release-version identity;
 - governed implementation command `merge-pr` a machine-readable Human Review marker `ddda:human-pr-review:v1`, vázané na exact PR SHA a candidate package hash;
 - ADR 0008 a developer runbook oddělující Human Review/implementation merge, Human Release Decision a mechanickou release-scope completeness;

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@
 - [Vývojový lifecycle DDDA platformy](developer-guide/platform-development-lifecycle.md)
 - [Testovací strategie DDDA platformy](developer-guide/testing-strategy.md)
 - [Remote validation a remediation broker](developer-guide/remote-validation-broker.md)
+- [Controlled release-source recovery](developer-guide/controlled-release-source-recovery.md)
 
 ## Architektonická rozhodnutí a migrace
 

--- a/docs/adr/0011-physical-release-scope-and-releasable-main.md
+++ b/docs/adr/0011-physical-release-scope-and-releasable-main.md
@@ -36,6 +36,14 @@ machine-readable inventory a `RECOVERY_DECISION_REQUIRED`. Automation nikdy
 nevolí human scope expansion, controlled source recovery ani novou
 release-source strategii.
 
+Pokud člověk explicitně zvolí controlled release-source recovery, může být
+reconstructed candidate odvozen od předchozího canonical tagu. Protože takový
+candidate dostává nové commit SHA, obsahuje versioned recovery ledger. Ledger
+svazuje každý reconstructed commit s původním merged PR, jeho jediným primary
+CR, původním merge SHA a fresh-ověřenými changed-path result hashes. Právě jeden
+metadata-only ledger commit je povolen. Ledger je evidence, nikoli mechanismus
+pro změnu release scope nebo human rozhodnutí.
+
 Dokud existuje právě jeden otevřený Milestone `DDDA X.Y.Z`, governed
 implementation merge smí do `main` pouze PR s jediným primary CR v tomto
 Milestone. Tím se nová kontaminace zastaví před merge. Guard je read-only a

--- a/docs/developer-guide/controlled-release-source-recovery.md
+++ b/docs/developer-guide/controlled-release-source-recovery.md
@@ -1,0 +1,65 @@
+# Controlled release-source recovery
+
+## Purpose
+
+When `main` already contains work outside the declared release scope, DDDA may
+use a separately reconstructed release source only after an explicit human
+recovery decision. This is not a scope expansion and does not rewrite `main`
+or any historical tag.
+
+The recovery source contains
+
+```text
+previous canonical tag
+→ recovered commits for approved shipping PRs only
+→ one metadata-only recovery ledger commit
+```
+
+## Ledger
+
+The candidate source contains exactly one versioned file:
+
+```text
+config/governance/release-source-recovery-ledger.json
+```
+
+Its schema is `schemas/release-source-recovery-ledger.schema.json`. Each entry
+binds one reconstructed commit to the immutable original authority:
+
+```json
+{
+  "recovered_commit_sha": "<new recovery commit SHA>",
+  "source_pr": 74,
+  "source_merge_commit_sha": "<merged source PR SHA>",
+  "primary_cr": 9
+}
+```
+
+The ledger has exactly one metadata-only commit. That commit may change only
+the ledger file; every other physical commit since the previous tag must have
+one and only one ledger entry. The Release Scope Gate freshly reads back the
+original PR, its single primary CR, merged SHA and changed-path result hashes.
+Any stale SHA, non-merged source PR, altered path result, incomplete coverage,
+duplicate mapping or out-of-scope CR is a failure.
+
+## Authority boundary
+
+The ledger is evidence, not authorization. It cannot add an Issue to a
+milestone, defer a scope item, accept a risk, create a Human Release Decision,
+or authorize promotion, tag creation or publication. The candidate remains
+Draft until standard CI, a Human Release Decision Record and the normal release
+governance boundaries are satisfied.
+
+## Recovery procedure
+
+1. Freeze the intended candidate source SHA and read the live milestone/Project authority.
+2. Create the reconstruction branch from the previous canonical SemVer tag.
+3. Reapply only the selected original shipping changes, preserving their exact
+   changed-path results.
+4. Add the ledger as its only metadata-only commit.
+5. Open a Draft recovery candidate PR and run exact-SHA standard CI.
+6. Run the read-only Release Scope Gate inventory. A PASS proves the physical
+   source equals the declared scope; it is not a release authorization.
+
+No automatic revert, scope expansion, tag movement, force-push or history
+rewrite is permitted.

--- a/docs/developer-guide/human-release-decision-and-release-scope-gate.md
+++ b/docs/developer-guide/human-release-decision-and-release-scope-gate.md
@@ -191,6 +191,7 @@ Gate je fail-closed.
 - každý commit mezi předchozím canonical SemVer tagem a release source je dohledatelný k právě jednomu merged shipping PR a jeho právě jednomu primary CR;
 - každý shipping primary CR je v aktuálním Milestone a jeho Project `Target Release` je stejná verze;
 - physical scope se přesně rovná declared Milestone scope: ani extra shipping CR, ani declared CR bez shipping změny. Při rozdílu gate vydá inventory a `RECOVERY_DECISION_REQUIRED`; nevolí scope expansion ani source recovery.
+- controlled reconstructed source je přípustný pouze po explicitním human recovery decision a s validním versioned recovery ledgerem; ledger musí pokrýt každý reconstructed commit, kromě jediného metadata-only ledger commitu, a fresh read-backem prokázat původní merged PR/CR/SHA i changed-path result hashes.
 
 Chybějící Project credential, nedostupný Project nebo API ambiguity jsou FAIL.
 

--- a/runtime/platform/release_governance.py
+++ b/runtime/platform/release_governance.py
@@ -55,6 +55,90 @@ def _release_value(value: Any) -> str:
     return str(value or "").strip().removeprefix("DDDA ")
 
 
+def _sha_values(values: Any) -> set[str]:
+    if not isinstance(values, list):
+        return set()
+    return {str(value) for value in values if SHA40.fullmatch(str(value))}
+
+
+def evaluate_recovery_ledger(
+    physical: dict[str, Any],
+    *,
+    expected_version: str,
+    declared_scope: set[int],
+) -> list[str]:
+    """Validate an explicit controlled-release-source provenance ledger.
+
+    A reconstructed source has new commit identities.  It therefore cannot
+    inherit GitHub's original commit-to-PR association implicitly.  The ledger
+    is an explicit, versioned replacement provenance record.  It is accepted
+    only when it covers every reconstructed physical commit (except one
+    metadata-only ledger commit) and the collector has freshly read back the
+    original merged PR/CR authority and exact changed-path hashes.
+    """
+    ledger = physical.get("recovery_ledger")
+    if ledger is None:
+        return []
+    if not isinstance(ledger, dict):
+        return ["RECOVERY_LEDGER_EVIDENCE_INVALID"]
+
+    failures: list[str] = []
+    if ledger.get("schema_version") != 1:
+        failures.append("RECOVERY_LEDGER_SCHEMA_VERSION")
+    if ledger.get("version") != expected_version:
+        failures.append("RECOVERY_LEDGER_VERSION_MISMATCH")
+    if ledger.get("previous_release_tag") != physical.get("previous_release_tag"):
+        failures.append("RECOVERY_LEDGER_PREVIOUS_TAG_MISMATCH")
+
+    physical_commits = _sha_values(physical.get("commit_shas"))
+    if not physical_commits:
+        failures.append("RECOVERY_LEDGER_PHYSICAL_COMMIT_EVIDENCE_MISSING")
+
+    metadata = _sha_values(ledger.get("metadata_commit_shas"))
+    if len(metadata) != 1 or not metadata.issubset(physical_commits):
+        failures.append("RECOVERY_LEDGER_METADATA_COMMIT_INVALID")
+
+    entries = ledger.get("entries")
+    if not isinstance(entries, list) or not entries:
+        return sorted(set(failures + ["RECOVERY_LEDGER_ENTRIES_INVALID"]))
+
+    recovered: set[str] = set()
+    source_prs: set[int] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            failures.append("RECOVERY_LEDGER_ENTRY_SHAPE")
+            continue
+        recovered_sha = str(entry.get("recovered_commit_sha") or "")
+        if not SHA40.fullmatch(recovered_sha) or recovered_sha in recovered:
+            failures.append("RECOVERY_LEDGER_RECOVERED_COMMIT_INVALID")
+            continue
+        recovered.add(recovered_sha)
+        try:
+            source_pr = int(entry.get("source_pr", 0))
+            primary_cr = int(entry.get("primary_cr", 0))
+        except (TypeError, ValueError):
+            source_pr = primary_cr = 0
+        if source_pr <= 0 or source_pr in source_prs:
+            failures.append("RECOVERY_LEDGER_SOURCE_PR_INVALID")
+        source_prs.add(source_pr)
+        if primary_cr <= 0:
+            failures.append("RECOVERY_LEDGER_PRIMARY_CR_INVALID")
+        if entry.get("source_pr_merged") is not True:
+            failures.append(f"RECOVERY_LEDGER_SOURCE_PR_NOT_MERGED:PR#{source_pr}")
+        if entry.get("source_primary_crs") != [primary_cr]:
+            failures.append(f"RECOVERY_LEDGER_SOURCE_PRIMARY_CR_MISMATCH:PR#{source_pr}")
+        if entry.get("source_merge_commit_sha") != entry.get("observed_source_merge_commit_sha"):
+            failures.append(f"RECOVERY_LEDGER_SOURCE_MERGE_SHA_MISMATCH:PR#{source_pr}")
+        if entry.get("changed_path_hashes_match") is not True:
+            failures.append(f"RECOVERY_LEDGER_PATH_HASH_MISMATCH:PR#{source_pr}")
+        if primary_cr not in declared_scope:
+            failures.append(f"RECOVERY_LEDGER_OUT_OF_SCOPE_PRIMARY_CR:PR#{source_pr}:#{primary_cr}")
+
+    if recovered | metadata != physical_commits:
+        failures.append("RECOVERY_LEDGER_COMMIT_COVERAGE_MISMATCH")
+    return sorted(set(failures))
+
+
 def evaluate_physical_release_scope(
     snapshot: dict[str, Any],
     *,
@@ -82,10 +166,18 @@ def evaluate_physical_release_scope(
     if physical.get("compare_status") not in {"ahead", "identical"}:
         failures.append("PHYSICAL_SCOPE_ANCESTRY_INVALID")
 
+    scope = _ints(declared_scope)
+    failures.extend(
+        evaluate_recovery_ledger(
+            physical,
+            expected_version=expected_version,
+            declared_scope=scope,
+        )
+    )
+
     for sha in sorted({str(x) for x in physical.get("unmapped_commit_shas", []) if str(x)}):
         failures.append(f"PHYSICAL_SCOPE_UNMAPPED_COMMIT:{sha}")
 
-    scope = _ints(declared_scope)
     shipping = physical.get("shipping_prs")
     if not isinstance(shipping, list):
         return sorted(set(failures + ["PHYSICAL_SCOPE_SHIPPING_PR_EVIDENCE_MISSING"]))

--- a/runtime/platform/tests/test_release_governance.py
+++ b/runtime/platform/tests/test_release_governance.py
@@ -267,3 +267,96 @@ def test_merge_eligibility_allows_only_active_train_authority():
         "MERGE_ELIGIBILITY_OUTSIDE_ACTIVE_RELEASE:#96",
         "MERGE_ELIGIBILITY_TARGET_RELEASE_MISMATCH:#96",
     ]
+
+
+def test_recovery_ledger_accepts_only_complete_read_back_provenance():
+    live = snapshot()
+    recovered = "d" * 40
+    metadata = "e" * 40
+    live["physical_scope"] = {
+        "previous_release_tag": "v0.1.0",
+        "previous_release_sha": "c" * 40,
+        "release_source_sha": SHA,
+        "compare_status": "ahead",
+        "commit_shas": [recovered, metadata],
+        "unmapped_commit_shas": [],
+        "shipping_prs": [
+            {
+                "number": 71,
+                "merged": True,
+                "primary_crs": [9],
+                "milestone": "DDDA 0.1.1",
+                "target_release": "0.1.1",
+            },
+            {
+                "number": 72,
+                "merged": True,
+                "primary_crs": [12],
+                "milestone": "DDDA 0.1.1",
+                "target_release": "0.1.1",
+            },
+            {
+                "number": 73,
+                "merged": True,
+                "primary_crs": [67],
+                "milestone": "DDDA 0.1.1",
+                "target_release": "0.1.1",
+            },
+            {
+                "number": 74,
+                "merged": True,
+                "primary_crs": [68],
+                "milestone": "DDDA 0.1.1",
+                "target_release": "0.1.1",
+            },
+        ],
+        "recovery_ledger": {
+            "schema_version": 1,
+            "version": VERSION,
+            "previous_release_tag": "v0.1.0",
+            "metadata_commit_shas": [metadata],
+            "entries": [
+                {
+                    "recovered_commit_sha": recovered,
+                    "source_pr": 71,
+                    "primary_cr": 9,
+                    "source_pr_merged": True,
+                    "source_primary_crs": [9],
+                    "source_merge_commit_sha": "f" * 40,
+                    "observed_source_merge_commit_sha": "f" * 40,
+                    "changed_path_hashes_match": True,
+                }
+            ],
+        },
+    }
+    result = evaluate(live=live)
+    assert result.status == "PASS"
+
+
+def test_recovery_ledger_rejects_uncovered_or_tampered_recovery_commit():
+    live = snapshot()
+    recovered = "d" * 40
+    metadata = "e" * 40
+    live["physical_scope"]["commit_shas"] = [recovered, metadata]
+    live["physical_scope"]["recovery_ledger"] = {
+        "schema_version": 1,
+        "version": VERSION,
+        "previous_release_tag": "v0.1.0",
+        "metadata_commit_shas": [metadata],
+        "entries": [
+            {
+                "recovered_commit_sha": recovered,
+                "source_pr": 71,
+                "primary_cr": 9,
+                "source_pr_merged": True,
+                "source_primary_crs": [9],
+                "source_merge_commit_sha": "f" * 40,
+                "observed_source_merge_commit_sha": "0" * 40,
+                "changed_path_hashes_match": False,
+            }
+        ],
+    }
+    result = evaluate(live=live)
+    assert result.status == "FAIL"
+    assert "RECOVERY_LEDGER_SOURCE_MERGE_SHA_MISMATCH:PR#71" in result.failures
+    assert "RECOVERY_LEDGER_PATH_HASH_MISMATCH:PR#71" in result.failures

--- a/runtime/platform/tests/test_release_scope_collectors.py
+++ b/runtime/platform/tests/test_release_scope_collectors.py
@@ -64,6 +64,7 @@ def test_physical_scope_inventory_keeps_unmapped_commit_and_exact_primary_relati
 
     ns.rest_pages = fake_pages
     ns.rest_get = fake_get
+    ns.recovery_ledger_at_source = lambda *_: None
     actual = ns.physical_scope_snapshot(
         "owner/repo", "0.1.1", "d" * 40, "token", {96: {"Target Release": "0.1.1"}}
     )
@@ -83,7 +84,7 @@ def test_physical_scope_inventory_keeps_unmapped_commit_and_exact_primary_relati
 def test_merge_collector_recognizes_one_open_release_train_and_tbd_target():
     spec = importlib.util.spec_from_file_location("ddda_merge_eligibility_collector_test", MERGE_COLLECTOR)
     assert spec and spec.loader
-    ns = importlib.util.module_from_spec(spec)
+    ns = importlib.util.spec_from_spec(spec)
     spec.loader.exec_module(ns)
     assert ns.active_release([{"title": "DDDA 0.1.1", "state": "open"}]) == {
         "version": "0.1.1"

--- a/runtime/platform/tests/test_release_scope_collectors.py
+++ b/runtime/platform/tests/test_release_scope_collectors.py
@@ -84,7 +84,7 @@ def test_physical_scope_inventory_keeps_unmapped_commit_and_exact_primary_relati
 def test_merge_collector_recognizes_one_open_release_train_and_tbd_target():
     spec = importlib.util.spec_from_file_location("ddda_merge_eligibility_collector_test", MERGE_COLLECTOR)
     assert spec and spec.loader
-    ns = importlib.util.spec_from_spec(spec)
+    ns = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(ns)
     assert ns.active_release([{"title": "DDDA 0.1.1", "state": "open"}]) == {
         "version": "0.1.1"

--- a/schemas/release-source-recovery-ledger.schema.json
+++ b/schemas/release-source-recovery-ledger.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ddda.example.invalid/schemas/release-source-recovery-ledger.schema.json",
+  "title": "DDDA controlled release-source recovery ledger",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "version", "previous_release_tag", "metadata_commit_shas", "entries"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "version": {"type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"},
+    "previous_release_tag": {"type": "string", "pattern": "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"},
+    "metadata_commit_shas": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["recovered_commit_sha", "source_pr", "source_merge_commit_sha", "primary_cr"],
+        "properties": {
+          "recovered_commit_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+          "source_pr": {"type": "integer", "minimum": 1},
+          "source_merge_commit_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+          "primary_cr": {"type": "integer", "minimum": 1}
+        }
+      }
+    }
+  }
+}

--- a/scripts/platform/Test-DDDAReleaseScope.py
+++ b/scripts/platform/Test-DDDAReleaseScope.py
@@ -9,6 +9,7 @@ business invariants are evaluated by runtime/platform/release_governance.py.
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 from pathlib import Path
@@ -30,6 +31,7 @@ from release_governance import evaluate_release_scope  # noqa: E402
 API_ROOT = "https://api.github.com"
 GRAPHQL_URL = "https://api.github.com/graphql"
 PROJECT_TITLE = "DDDA Platform Backlog & Delivery"
+RECOVERY_LEDGER_PATH = "config/governance/release-source-recovery-ledger.json"
 PLANNING_VIEW = "Plánování a Backlog"
 DELIVERY_VIEW = "Implementace a Delivery"
 TARGET_RELEASE_RE = re.compile(
@@ -313,6 +315,63 @@ def primary_change_requests(body: str) -> list[int]:
     return sorted({int(value) for value in PRIMARY_CHANGE_RE.findall(body or "")})
 
 
+def recovery_ledger_at_source(repository: str, source_sha: str, token: str) -> dict[str, Any] | None:
+    """Read an optional ledger from the exact candidate source, never default main."""
+    try:
+        payload = rest_get(
+            f"repos/{repository}/contents/{RECOVERY_LEDGER_PATH}?ref={source_sha}", token
+        )
+    except GitHubReadError as exc:
+        if "HTTP 404" in str(exc):
+            return None
+        raise
+    if not isinstance(payload, dict) or payload.get("encoding") != "base64":
+        return {"invalid": "CONTENT_SHAPE"}
+    try:
+        raw = base64.b64decode(str(payload.get("content") or ""), validate=False)
+        decoded = json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        return {"invalid": f"JSON:{exc.__class__.__name__}"}
+    return decoded if isinstance(decoded, dict) else {"invalid": "ROOT_SHAPE"}
+
+
+def commit_path_hashes(repository: str, sha: str, token: str) -> dict[str, str | None] | None:
+    """Return the exact file-result hashes reported for one commit, fail closed on ambiguity."""
+    data = rest_get(f"repos/{repository}/commits/{sha}", token)
+    files = (data or {}).get("files") if isinstance(data, dict) else None
+    if not isinstance(files, list):
+        return None
+    result: dict[str, str | None] = {}
+    for row in files:
+        if not isinstance(row, dict) or not isinstance(row.get("filename"), str):
+            return None
+        path = row["filename"]
+        if path in result:
+            return None
+        result[path] = None if row.get("status") == "removed" else str(row.get("sha") or "")
+        if result[path] == "":
+            return None
+    return result
+
+
+def shipping_row(repository: str, number: int, token: str, project_rows: dict[int, dict[str, Any]]) -> dict[str, Any]:
+    pr = rest_get(f"repos/{repository}/pulls/{number}", token) or {}
+    primary = primary_change_requests(str(pr.get("body") or ""))
+    authority: dict[str, Any] = {}
+    if len(primary) == 1:
+        authority = rest_get(f"repos/{repository}/issues/{primary[0]}", token) or {}
+    milestone = (authority.get("milestone") or {}).get("title")
+    project = project_rows.get(primary[0], {}) if len(primary) == 1 else {}
+    return {
+        "number": number,
+        "merged": bool(pr.get("merged_at")),
+        "merge_commit_sha": pr.get("merge_commit_sha"),
+        "primary_crs": primary,
+        "milestone": milestone,
+        "target_release": project.get("Target Release"),
+    }
+
+
 def physical_scope_snapshot(
     repository: str,
     version: str,
@@ -322,10 +381,50 @@ def physical_scope_snapshot(
 ) -> dict[str, Any]:
     previous = previous_release_tag(repository, version, token)
     compare_status, commits = compare_commits(repository, previous["tag"], source_sha, token)
+    ledger = recovery_ledger_at_source(repository, source_sha, token)
+    ledger_entries = (ledger or {}).get("entries") if isinstance(ledger, dict) else None
+    entries_by_commit: dict[str, dict[str, Any]] = {}
+    ordered_entries: list[tuple[str, dict[str, Any]]] = []
+    metadata_commits: set[str] = set()
+    ledger_evidence: dict[str, Any] | None = None
+    if ledger is not None:
+        if not isinstance(ledger_entries, list):
+            ledger_evidence = {"invalid": "ENTRIES"}
+        else:
+            for row in ledger_entries:
+                if isinstance(row, dict) and isinstance(row.get("recovered_commit_sha"), str):
+                    entries_by_commit[row["recovered_commit_sha"]] = row
+                    ordered_entries.append((row["recovered_commit_sha"], row))
+            raw_metadata = ledger.get("metadata_commit_shas") if isinstance(ledger, dict) else []
+            if isinstance(raw_metadata, list):
+                metadata_commits = {str(value) for value in raw_metadata}
+            ledger_evidence = {
+                "schema_version": ledger.get("schema_version"),
+                "version": ledger.get("version"),
+                "previous_release_tag": ledger.get("previous_release_tag"),
+                "metadata_commit_shas": sorted(metadata_commits),
+                "entries": [],
+            }
+
     pr_numbers: set[int] = set()
     unmapped: set[str] = set()
+    metadata_only: set[str] = set()
     for commit in commits:
         sha = str(commit.get("sha") or "")
+        if sha in metadata_commits:
+            paths = commit_path_hashes(repository, sha, token)
+            if paths is not None and set(paths) == {RECOVERY_LEDGER_PATH}:
+                metadata_only.add(sha)
+                continue
+        entry = entries_by_commit.get(sha)
+        if entry is not None:
+            try:
+                number = int(entry.get("source_pr", 0))
+            except (TypeError, ValueError):
+                number = 0
+            if number > 0:
+                pr_numbers.add(number)
+            continue
         linked = rest_pages(f"repos/{repository}/commits/{sha}/pulls", token)
         numbers = {int(row["number"]) for row in linked if row.get("number") is not None}
         if not numbers:
@@ -334,23 +433,32 @@ def physical_scope_snapshot(
 
     shipping: list[dict[str, Any]] = []
     for number in sorted(pr_numbers):
-        pr = rest_get(f"repos/{repository}/pulls/{number}", token)
-        primary = primary_change_requests(str((pr or {}).get("body") or ""))
-        authority: dict[str, Any] = {}
-        if len(primary) == 1:
-            authority = rest_get(f"repos/{repository}/issues/{primary[0]}", token) or {}
-        milestone = (authority.get("milestone") or {}).get("title")
-        project = project_rows.get(primary[0], {}) if len(primary) == 1 else {}
-        shipping.append(
-            {
-                "number": number,
-                "merged": bool((pr or {}).get("merged_at")),
-                "merge_commit_sha": (pr or {}).get("merge_commit_sha"),
-                "primary_crs": primary,
-                "milestone": milestone,
-                "target_release": project.get("Target Release"),
-            }
-        )
+        shipping.append(shipping_row(repository, number, token, project_rows))
+
+    if ledger_evidence is not None and "entries" in ledger_evidence:
+        for sha, entry in sorted(ordered_entries):
+            try:
+                number = int(entry.get("source_pr", 0))
+                primary = int(entry.get("primary_cr", 0))
+            except (TypeError, ValueError):
+                number = primary = 0
+            source = shipping_row(repository, number, token, project_rows) if number > 0 else {}
+            source_sha = str(entry.get("source_merge_commit_sha") or "")
+            source_paths = commit_path_hashes(repository, source_sha, token) if source_sha else None
+            recovered_paths = commit_path_hashes(repository, sha, token)
+            ledger_evidence["entries"].append(
+                {
+                    "recovered_commit_sha": sha,
+                    "source_pr": number,
+                    "primary_cr": primary,
+                    "source_pr_merged": source.get("merged"),
+                    "source_primary_crs": source.get("primary_crs"),
+                    "source_merge_commit_sha": source_sha,
+                    "observed_source_merge_commit_sha": source.get("merge_commit_sha"),
+                    "changed_path_hashes_match": source_paths is not None and source_paths == recovered_paths,
+                }
+            )
+        ledger_evidence["metadata_commit_shas"] = sorted(metadata_only)
 
     return {
         "previous_release_tag": previous["tag"],
@@ -358,8 +466,10 @@ def physical_scope_snapshot(
         "release_source_sha": source_sha,
         "compare_status": compare_status,
         "commit_count": len(commits),
+        "commit_shas": [str(commit.get("sha") or "") for commit in commits],
         "unmapped_commit_shas": sorted(unmapped),
         "shipping_prs": shipping,
+        "recovery_ledger": ledger_evidence,
     }
 
 


### PR DESCRIPTION
Implements #96

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"change_types":["RELEASE","SECURITY-GOVERNANCE","TESTING","DOC"],"impact":"HIGH","migration_impact":"non-breaking"}
```

## Scope

Adds the fail-closed controlled release-source recovery ledger required to reconstruct an auditable DDDA 0.1.1 candidate without expanding its declared scope or rewriting history.

- versioned ledger schema and developer procedure;
- exact-candidate ledger read-back in the Physical Release Scope Gate;
- complete recovered-commit coverage, one metadata-only ledger commit, original merged PR / single primary CR / merge-SHA checks, and changed-path result-hash equality;
- regression coverage for valid, incomplete, stale and tampered ledger evidence.

## Deliberate boundaries

- no change to Milestone, Project or declared release scope;
- no release, promotion, tag, GitHub Release, merge to `main`, or CR closure;
- no automatic revert, source recovery, scope expansion or history rewrite.

A controlled DDDA 0.1.1 recovery candidate is created only after this contract has passed exact-SHA CI, Human Review and a separate authorised implementation merge.