### PR TITLE
fix(release): derive recovery ledger metadata from physical source

### DIFF
--- a/docs/adr/0011-physical-release-scope-and-releasable-main.md
+++ b/docs/adr/0011-physical-release-scope-and-releasable-main.md
@@ -41,7 +41,8 @@ reconstructed candidate odvozen od předchozího canonical tagu. Protože takov�
 candidate dostává nové commit SHA, obsahuje versioned recovery ledger. Ledger
 svazuje každý reconstructed commit s původním merged PR, jeho jediným primary
 CR, původním merge SHA a fresh-ověřenými changed-path result hashes. Právě jeden
-metadata-only ledger commit je povolen. Ledger je evidence, nikoli mechanismus
+metadata-only ledger commit je povolen; jeho identita se odvozuje z physical
+inventory, nikoli ze self-referential hodnoty uvnitř ledgeru. Ledger je evidence, nikoli mechanismus
 pro změnu release scope nebo human rozhodnutí.
 
 Dokud existuje právě jeden otevřený Milestone `DDDA X.Y.Z`, governed

--- a/docs/developer-guide/controlled-release-source-recovery.md
+++ b/docs/developer-guide/controlled-release-source-recovery.md
@@ -35,10 +35,12 @@ binds one reconstructed commit to the immutable original authority:
 }
 ```
 
-The ledger has exactly one metadata-only commit. That commit may change only
-the ledger file; every other physical commit since the previous tag must have
-one and only one ledger entry. The Release Scope Gate freshly reads back the
-original PR, its single primary CR, merged SHA and changed-path result hashes.
+The Release Scope Gate derives exactly one metadata-only commit from the
+physical inventory. That commit may change only the ledger file and is not
+listed inside that file: a ledger cannot safely contain the SHA of the commit
+that creates it. Every other physical commit since the previous tag must have
+one and only one ledger entry. The Gate freshly reads back the original PR,
+its single primary CR, merged SHA and changed-path result hashes.
 Any stale SHA, non-merged source PR, altered path result, incomplete coverage,
 duplicate mapping or out-of-scope CR is a failure.
 

--- a/runtime/platform/release_governance.py
+++ b/runtime/platform/release_governance.py
@@ -94,7 +94,10 @@ def evaluate_recovery_ledger(
     if not physical_commits:
         failures.append("RECOVERY_LEDGER_PHYSICAL_COMMIT_EVIDENCE_MISSING")
 
-    metadata = _sha_values(ledger.get("metadata_commit_shas"))
+    # The metadata commit is derived from the physical inventory, rather than
+    # declared inside the ledger it creates. Requiring a commit to contain its
+    # own SHA would make a valid ledger impossible to construct.
+    metadata = _sha_values(physical.get("metadata_commit_shas"))
     if len(metadata) != 1 or not metadata.issubset(physical_commits):
         failures.append("RECOVERY_LEDGER_METADATA_COMMIT_INVALID")
 

--- a/runtime/platform/tests/test_release_governance.py
+++ b/runtime/platform/tests/test_release_governance.py
@@ -279,6 +279,7 @@ def test_recovery_ledger_accepts_only_complete_read_back_provenance():
         "release_source_sha": SHA,
         "compare_status": "ahead",
         "commit_shas": [recovered, metadata],
+        "metadata_commit_shas": [metadata],
         "unmapped_commit_shas": [],
         "shipping_prs": [
             {
@@ -314,7 +315,6 @@ def test_recovery_ledger_accepts_only_complete_read_back_provenance():
             "schema_version": 1,
             "version": VERSION,
             "previous_release_tag": "v0.1.0",
-            "metadata_commit_shas": [metadata],
             "entries": [
                 {
                     "recovered_commit_sha": recovered,
@@ -338,11 +338,11 @@ def test_recovery_ledger_rejects_uncovered_or_tampered_recovery_commit():
     recovered = "d" * 40
     metadata = "e" * 40
     live["physical_scope"]["commit_shas"] = [recovered, metadata]
+    live["physical_scope"]["metadata_commit_shas"] = [metadata]
     live["physical_scope"]["recovery_ledger"] = {
         "schema_version": 1,
         "version": VERSION,
         "previous_release_tag": "v0.1.0",
-        "metadata_commit_shas": [metadata],
         "entries": [
             {
                 "recovered_commit_sha": recovered,

--- a/schemas/release-source-recovery-ledger.schema.json
+++ b/schemas/release-source-recovery-ledger.schema.json
@@ -4,17 +4,11 @@
   "title": "DDDA controlled release-source recovery ledger",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "version", "previous_release_tag", "metadata_commit_shas", "entries"],
+  "required": ["schema_version", "version", "previous_release_tag", "entries"],
   "properties": {
     "schema_version": {"const": 1},
     "version": {"type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"},
     "previous_release_tag": {"type": "string", "pattern": "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"},
-    "metadata_commit_shas": {
-      "type": "array",
-      "minItems": 1,
-      "maxItems": 1,
-      "items": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
-    },
     "entries": {
       "type": "array",
       "minItems": 1,


### PR DESCRIPTION
## Purpose

Implements #96

Fixes the controlled recovery-ledger contract used by CR #96.

The previous contract required the ledger file to declare the SHA of the metadata-only commit that creates that same file. That is a cryptographic self-reference and cannot be constructed reliably.

## Change

- derive the single metadata-only commit from the read-only physical inventory;
- remove the self-referential ledger field from the schema;
- cover the valid and tampered paths with regression tests;
- document the derived-metadata rule.

## Boundary

This PR changes only the fail-closed gate contract and its evidence/documentation. It does not create or modify the controlled recovery candidate, change Project or milestone data, merge anything, create a release/promotion/tag, or close CR #96.