### PR TITLE
recovery(0.1.1): controlled release-source candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 ### Fixed
 
 - promotion dry-run wrapper nyní používá operation-local výsledek a explicitní post-read-back side-effect assertions; očekávaná `404` absence tagu/GitHub Release je PASS assertion, zatímco auth/network/API chyby zůstávají FAIL, takže PR8-class `semantic PASS / wrapper FAIL` false-negative se nemůže opakovat přes stale `$LASTEXITCODE`.
+- annotated release tag nyní používá deterministic non-secret Git identity pouze v izolovaném release-source clone; clean runner proto nezávisí na ambientním `user.name`/`user.email` a bounded recovery po post-validation tag failure je explicitně zdokumentována.
 
 Změny pro další verzi se během vývoje zapisují sem. Před promotion se všechny položky přesunou do jediné verze `X.Y.Z` s ISO datem a tato sekce zůstane bez release položek.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- machine-readable `human-release-decision.schema.json`, `review-pr` scaffold a fail-closed Release Scope Gate pro exact release-candidate SHA / candidate package / release-version identity;
+- governed implementation command `merge-pr` a machine-readable Human Review marker `ddda:human-pr-review:v1`, vázané na exact PR SHA a candidate package hash;
+- ADR 0008 a developer runbook oddělující Human Review/implementation merge, Human Release Decision a mechanickou release-scope completeness.
+
+### Changed
+
+- platform lifecycle nyní explicitně odděluje governed merge implementačních PR od skutečného release/promotion; implementation merge nevyžaduje HRDR ani Release Scope Gate a nesmí vytvořit release package, release validation nebo tag;
+- public `promote-pr` zůstává strict release-candidate command: před interním release executorem vyžaduje validní human HRDR a read-only Release Scope Gate PASS nad Milestone, native blockers a GitHub Project V2 projekcí.
+
 Změny pro další verzi se během vývoje zapisují sem. Před promotion se všechny položky přesunou do jediné verze `X.Y.Z` s ISO datem a tato sekce zůstane bez release položek.
 
 ## [0.1.0] - 2026-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,20 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 
 - machine-readable `human-release-decision.schema.json`, `review-pr` scaffold a fail-closed Release Scope Gate pro exact release-candidate SHA / candidate package / release-version identity;
 - governed implementation command `merge-pr` a machine-readable Human Review marker `ddda:human-pr-review:v1`, vázané na exact PR SHA a candidate package hash;
-- ADR 0008 a developer runbook oddělující Human Review/implementation merge, Human Release Decision a mechanickou release-scope completeness.
+- ADR 0008 a developer runbook oddělující Human Review/implementation merge, Human Release Decision a mechanickou release-scope completeness;
+- ADR 0009 a versioned merge-strategy contract zachovávající exact validated SHA ancestry pro HIGH/BREAKING změny a explicitní human squash exception pro LOW/MEDIUM.
 
 ### Changed
 
 - platform lifecycle nyní explicitně odděluje governed merge implementačních PR od skutečného release/promotion; implementation merge nevyžaduje HRDR ani Release Scope Gate a nesmí vytvořit release package, release validation nebo tag;
-- public `promote-pr` zůstává strict release-candidate command: před interním release executorem vyžaduje validní human HRDR a read-only Release Scope Gate PASS nad Milestone, native blockers a GitHub Project V2 projekcí.
+- public `promote-pr` zůstává strict release-candidate command: před interním release executorem vyžaduje validní human HRDR a read-only Release Scope Gate PASS nad Milestone, native blockers a GitHub Project V2 projekcí;
+- governed implementation merge používá po aktivaci #70 merge commit jako canonical default; HIGH/BREAKING a neklasifikované PR nesmějí squash/rebase, LOW/MEDIUM squash vyžaduje explicitní human exception a canonical merge ověřuje validated PR HEAD server-side jako parent/ancestor výsledného main state.
 
 ### Fixed
 
-- promotion dry-run wrapper nyní používá operation-local výsledek a explicitní post-read-back side-effect assertions; očekávaná `404` absence tagu/GitHub Release je PASS assertion, zatímco auth/network/API chyby zůstávají FAIL, takže PR8-class `semantic PASS / wrapper FAIL` false-negative se nemůže opakovat přes stale `$LASTEXITCODE`.
-- annotated release tag nyní používá deterministic non-secret Git identity pouze v izolovaném release-source clone; clean runner proto nezávisí na ambientním `user.name`/`user.email` a bounded recovery po post-validation tag failure je explicitně zdokumentována.
+- promotion dry-run wrapper nyní používá operation-local výsledek a explicitní post-read-back side-effect assertions; očekávaná `404` absence tagu/GitHub Release je PASS assertion, zatímco auth/network/API chyby zůstávají FAIL, takže PR8-class `semantic PASS / wrapper FAIL` false-negative se nemůže opakovat přes stale `$LASTEXITCODE`;
+- annotated release tag nyní používá deterministic non-secret Git identity pouze v izolovaném release-source clone; clean runner proto nezávisí na ambientním `user.name`/`user.email` a bounded recovery po post-validation tag failure je explicitně zdokumentována;
+- Miro acceptance evidence zachová exact board ID/URL i při child failure po vytvoření boardu, ale před child reportem; konfliktní handoff identity nebo mismatch s reportem failují closed a cleanup může cílit na skutečně vytvořený board.
 
 Změny pro další verzi se během vývoje zapisují sem. Před promotion se všechny položky přesunou do jediné verze `X.Y.Z` s ISO datem a tato sekce zůstane bez release položek.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 - CR #96 physical release-scope contract: release preflight now derives the shipping commit/PR/primary-CR set from the previous canonical SemVer tag to the exact candidate source SHA and fails closed on an unmapped, ambiguous or out-of-scope change;
 - read-only releasable-main eligibility guard for `merge-pr`: while one DDDA release Milestone is open, a PR whose primary CR is outside that train cannot be merged into `main`;
 - machine-readable physical-source inventory and explicit `RECOVERY_DECISION_REQUIRED` result; automation neither expands release scope nor removes/deferes already integrated source.
+- fail-closed controlled release-source recovery ledger, which binds each reconstructed candidate commit to its original merged PR/primary CR/merge SHA and exact changed-path result hashes; the ledger cannot alter release authority.
 - machine-readable `human-release-decision.schema.json`, `review-pr` scaffold a fail-closed Release Scope Gate pro exact release-candidate SHA / candidate package / release-version identity;
 - governed implementation command `merge-pr` a machine-readable Human Review marker `ddda:human-pr-review:v1`, vázané na exact PR SHA a candidate package hash;
 - ADR 0008 a developer runbook oddělující Human Review/implementation merge, Human Release Decision a mechanickou release-scope completeness;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 - platform lifecycle nyní explicitně odděluje governed merge implementačních PR od skutečného release/promotion; implementation merge nevyžaduje HRDR ani Release Scope Gate a nesmí vytvořit release package, release validation nebo tag;
 - public `promote-pr` zůstává strict release-candidate command: před interním release executorem vyžaduje validní human HRDR a read-only Release Scope Gate PASS nad Milestone, native blockers a GitHub Project V2 projekcí.
 
+### Fixed
+
+- promotion dry-run wrapper nyní používá operation-local výsledek a explicitní post-read-back side-effect assertions; očekávaná `404` absence tagu/GitHub Release je PASS assertion, zatímco auth/network/API chyby zůstávají FAIL, takže PR8-class `semantic PASS / wrapper FAIL` false-negative se nemůže opakovat přes stale `$LASTEXITCODE`.
+
 Změny pro další verzi se během vývoje zapisují sem. Před promotion se všechny položky přesunou do jediné verze `X.Y.Z` s ISO datem a tato sekce zůstane bez release položek.
 
 ## [0.1.0] - 2026-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 
 ### Added
 
+- CR #96 physical release-scope contract: release preflight now derives the shipping commit/PR/primary-CR set from the previous canonical SemVer tag to the exact candidate source SHA and fails closed on an unmapped, ambiguous or out-of-scope change;
+- read-only releasable-main eligibility guard for `merge-pr`: while one DDDA release Milestone is open, a PR whose primary CR is outside that train cannot be merged into `main`;
+- machine-readable physical-source inventory and explicit `RECOVERY_DECISION_REQUIRED` result; automation neither expands release scope nor removes/deferes already integrated source.
 - machine-readable `human-release-decision.schema.json`, `review-pr` scaffold a fail-closed Release Scope Gate pro exact release-candidate SHA / candidate package / release-version identity;
 - governed implementation command `merge-pr` a machine-readable Human Review marker `ddda:human-pr-review:v1`, vázané na exact PR SHA a candidate package hash;
 - ADR 0008 a developer runbook oddělující Human Review/implementation merge, Human Release Decision a mechanickou release-scope completeness;
@@ -15,12 +18,18 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 
 ### Changed
 
+- GitHub-native backlog governance nyní považuje Issue/PR mutation, Project planning/delivery projection a release Milestone projection za jednu fail-closed transakci; DDDA 0.1.0/0.1.1 scope je versioned a canonical reconciler opravuje Project/Milestone drift před Ready/merge/release doporučením.
 - platform lifecycle nyní explicitně odděluje governed merge implementačních PR od skutečného release/promotion; implementation merge nevyžaduje HRDR ani Release Scope Gate a nesmí vytvořit release package, release validation nebo tag;
 - public `promote-pr` zůstává strict release-candidate command: před interním release executorem vyžaduje validní human HRDR a read-only Release Scope Gate PASS nad Milestone, native blockers a GitHub Project V2 projekcí;
 - governed implementation merge používá po aktivaci #70 merge commit jako canonical default; HIGH/BREAKING a neklasifikované PR nesmějí squash/rebase, LOW/MEDIUM squash vyžaduje explicitní human exception a canonical merge ověřuje validated PR HEAD server-side jako parent/ancestor výsledného main state.
 
 ### Fixed
 
+- delivery governance nyní odvozuje PR `Blocked` a `Status` z unresolved blocker state primárního Change Requestu; stale Project dvojice `Blocked = Yes` / `Status = Blocked` proto nemůže projít fresh fail-closed read-backem a druhý reconcile je idempotentní;
+- governed `merge-pr` nyní sestavuje GitHub Contents API URL bez PowerShell variable-name ambiguity mezi cestou dokumentu a `?ref` query, takže isolated post-Human-Review dry-run ověří povinné dokumenty na exact PR SHA;
+- Human Review provenance nyní materializuje GitHub Issues Comments REST pole před marker selection a porovnává reviewer výhradně s jediným canonical `user.login`; display name se neconcatenatuje a chybějící, víceznačný nebo botí autor failuje closed;
+- exact-SHA PR governance nyní používá jeden canonical candidate artifact napříč platform CI, `validate-pr`, remote brokerem, validation reportem, Human Review a isolated `merge-pr -DryRun`; paralelní rebuildy, runner-local evidence paths a chybějící či víceznačné artifact identity failují closed;
+- pre-HR merge orchestrace nyní odděluje `Human Review readiness` od skutečného `Governed merge dry-run`; bez Human Review je dry-run `skipped`/`NOT_RUN` a `success` může vzniknout pouze po provedeném `merge-pr -DryRun` nad existujícím exact-run candidate/reportem;
 - promotion dry-run wrapper nyní používá operation-local výsledek a explicitní post-read-back side-effect assertions; očekávaná `404` absence tagu/GitHub Release je PASS assertion, zatímco auth/network/API chyby zůstávají FAIL, takže PR8-class `semantic PASS / wrapper FAIL` false-negative se nemůže opakovat přes stale `$LASTEXITCODE`;
 - annotated release tag nyní používá deterministic non-secret Git identity pouze v izolovaném release-source clone; clean runner proto nezávisí na ambientním `user.name`/`user.email` a bounded recovery po post-validation tag failure je explicitně zdokumentována;
 - Miro acceptance evidence zachová exact board ID/URL i při child failure po vytvoření boardu, ale před child reportem; konfliktní handoff identity nebo mismatch s reportem failují closed a cleanup může cílit na skutečně vytvořený board.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 
 ### Changed
 
+- canonical promotion po validated tagu publikuje canonical DDDA ZIP a portable release reports jako ověřené GitHub Release assets;
 - GitHub-native backlog governance nyní považuje Issue/PR mutation, Project planning/delivery projection a release Milestone projection za jednu fail-closed transakci; DDDA 0.1.0/0.1.1 scope je versioned a canonical reconciler opravuje Project/Milestone drift před Ready/merge/release doporučením.
 - platform lifecycle nyní explicitně odděluje governed merge implementačních PR od skutečného release/promotion; implementation merge nevyžaduje HRDR ani Release Scope Gate a nesmí vytvořit release package, release validation nebo tag;
 - public `promote-pr` zůstává strict release-candidate command: před interním release executorem vyžaduje validní human HRDR a read-only Release Scope Gate PASS nad Milestone, native blockers a GitHub Project V2 projekcí;

--- a/config/governance/release-source-recovery-ledger.json
+++ b/config/governance/release-source-recovery-ledger.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "version": "0.1.1",
+  "previous_release_tag": "v0.1.0",
+  "entries": [
+    {
+      "recovered_commit_sha": "877bcc36d1bc6527ab88f169f4423d465270c3fc",
+      "source_pr": 74,
+      "source_merge_commit_sha": "43a62152b7fd8be383337c23ffb10d0fda9e7077",
+      "primary_cr": 9
+    },
+    {
+      "recovered_commit_sha": "80b896e6de6a363fec14603a46748a6398d52360",
+      "source_pr": 77,
+      "source_merge_commit_sha": "baad4684328262ef94b31f50cef7c51193cf8ad3",
+      "primary_cr": 67
+    },
+    {
+      "recovered_commit_sha": "efeb874afd6d5cd9cbd28c6737687ff754c81f76",
+      "source_pr": 78,
+      "source_merge_commit_sha": "2646bf28918dfbb98fb8980f2be07428dc1ebbb1",
+      "primary_cr": 68
+    },
+    {
+      "recovered_commit_sha": "bee39deb5290610ffdf2f82e377f94d84f2e850b",
+      "source_pr": 79,
+      "source_merge_commit_sha": "297f61f6012f180e70805999df2ac1abe9616a05",
+      "primary_cr": 12
+    },
+    {
+      "recovered_commit_sha": "ba979ab2fe134cd04533784d08ba5b2d07dc6664",
+      "source_pr": 84,
+      "source_merge_commit_sha": "1f66880c30b7bc1814d21200ef6fcc5b08cadfba",
+      "primary_cr": 70
+    },
+    {
+      "recovered_commit_sha": "9170ab04cdde7b82c494ee8888a7989fac9ee799",
+      "source_pr": 97,
+      "source_merge_commit_sha": "cdb9237391cafc9dbc1779debd834154828b644c",
+      "primary_cr": 96
+    },
+    {
+      "recovered_commit_sha": "5c85cfd029bd75ecf8aeeccfa146c1f33f3050cb",
+      "source_pr": 99,
+      "source_merge_commit_sha": "e5faf19a6377e72e25b69064f5a3ac3ed2543e6e",
+      "primary_cr": 98
+    },
+    {
+      "recovered_commit_sha": "9fb3545ef829d06161cba705cac1d2f2dd906458",
+      "source_pr": 101,
+      "source_merge_commit_sha": "5ebc3eb79c8cc7d5732afa077f7c0d072448c879",
+      "primary_cr": 96
+    },
+    {
+      "recovered_commit_sha": "74d7836c7efac306f91159da7c352aa1b99618da",
+      "source_pr": 102,
+      "source_merge_commit_sha": "b61392ace66a95c808f321f3bd4b046cc5f564e5",
+      "primary_cr": 96
+    },
+    {
+      "recovered_commit_sha": "825f156366eee52b7b9b3c573c51df36fe9bcc4d",
+      "source_pr": 111,
+      "source_merge_commit_sha": "036a686568f35ec0f9588d5a06cb2994b6c2d22b",
+      "primary_cr": 96
+    }
+  ]
+}

--- a/config/platform/development-policy.yaml
+++ b/config/platform/development-policy.yaml
@@ -1,7 +1,55 @@
 {
   "schema_version": 1,
   "base_branch": "main",
-  "merge_method": "squash",
+  "merge_method": "merge",
+  "merge_strategy": {
+    "schema_version": 1,
+    "classification_marker": "<!-- ddda:change-classification:v1 -->",
+    "squash_exception_marker": "<!-- ddda:squash-exception:v1 -->",
+    "default_method": "merge",
+    "unknown_impact_allowed_methods": [
+      "merge"
+    ],
+    "impacts": {
+      "LOW": {
+        "default_method": "merge",
+        "allowed_methods": [
+          "merge",
+          "squash"
+        ],
+        "squash_requires_human_exception": true
+      },
+      "MEDIUM": {
+        "default_method": "merge",
+        "allowed_methods": [
+          "merge",
+          "squash"
+        ],
+        "squash_requires_human_exception": true
+      },
+      "HIGH": {
+        "default_method": "merge",
+        "allowed_methods": [
+          "merge"
+        ],
+        "squash_requires_human_exception": false
+      },
+      "BREAKING": {
+        "default_method": "merge",
+        "allowed_methods": [
+          "merge"
+        ],
+        "squash_requires_human_exception": false
+      }
+    },
+    "bootstrap_transition": {
+      "change_issue": 70,
+      "legacy_base_sha": "297f61f6012f180e70805999df2ac1abe9616a05",
+      "legacy_merge_method": "squash",
+      "prospective_after_integration": true,
+      "reason": "Issue #70 changes the merge contract itself. Its own integration remains governed by the pre-existing main policy; the new merge-commit contract applies only after #70 is integrated into main."
+    }
+  },
   "minimum_approvals": 0,
   "require_explicit_confirmation": true,
   "execution_interfaces": {
@@ -101,7 +149,9 @@
     "docs/adr/0005-chat-work-only-development-operating-model.md",
     "docs/adr/0006-chat-atomic-platform-implementation.md",
     "docs/adr/0007-miro-execution-profiles-and-persistent-validation-boards.md",
+    "docs/adr/0009-exact-sha-merge-strategy.md",
     "docs/developer-guide/chat-work-operating-model.md",
+    "docs/developer-guide/merge-strategy.md",
     "docs/developer-guide/miro-execution-profiles.md",
     "docs/migration/pr8-non-breaking-steering-extension.md"
   ],

--- a/ddda.ps1
+++ b/ddda.ps1
@@ -1,7 +1,7 @@
 ﻿[CmdletBinding()]
 param(
     [Parameter(Mandatory = $true, Position = 0)]
-    [ValidateSet("doctor", "test", "validate-pr", "promote-pr")]
+    [ValidateSet("doctor", "test", "validate-pr", "merge-pr", "review-pr", "promote-pr")]
     [string]$Command,
 
     [ValidateSet("lint", "schema", "unit", "component", "integration", "smoke", "regression", "security", "e2e", "acceptance", "all")]
@@ -10,6 +10,9 @@ param(
     [int]$Pr,
     [string]$Version,
     [string]$PackagePath,
+    [string]$Reviewer,
+    [string]$DecisionOwner,
+    [switch]$PublishScaffold,
     [switch]$WithMiro,
     [switch]$Full,
     [switch]$CleanupOnFailure,
@@ -92,6 +95,28 @@ switch ($Command) {
         if ($NonInteractive) { $arguments += "-NonInteractive" }
         Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAValidatePr.ps1" -Arguments $arguments
     }
+    "merge-pr" {
+        if ($Pr -le 0) {
+            throw "Příkaz merge-pr vyžaduje kladné -Pr."
+        }
+        $arguments = @("-PlatformPath", $platformRoot, "-Pr", [string]$Pr)
+        if ($ConfirmMerge) { $arguments += "-ConfirmMerge" }
+        if ($DryRun) { $arguments += "-DryRun" }
+        Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAGovernedMergePr.ps1" -Arguments $arguments
+    }
+    "review-pr" {
+        if ($Pr -le 0) {
+            throw "Příkaz review-pr vyžaduje kladné -Pr."
+        }
+        if ([string]::IsNullOrWhiteSpace($Version)) {
+            throw "Příkaz review-pr vyžaduje -Version."
+        }
+        $arguments = @("-PlatformPath", $platformRoot, "-Pr", [string]$Pr, "-Version", $Version)
+        if (-not [string]::IsNullOrWhiteSpace($Reviewer)) { $arguments += @("-Reviewer", $Reviewer) }
+        if (-not [string]::IsNullOrWhiteSpace($DecisionOwner)) { $arguments += @("-DecisionOwner", $DecisionOwner) }
+        if ($PublishScaffold) { $arguments += "-PublishScaffold" }
+        Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAReviewPr.ps1" -Arguments $arguments
+    }
     "promote-pr" {
         if ($Pr -le 0) {
             throw "Příkaz promote-pr vyžaduje kladné -Pr."
@@ -109,6 +134,6 @@ switch ($Command) {
         if (-not [string]::IsNullOrWhiteSpace($MiroTeamId)) { $arguments += @("-MiroTeamId", $MiroTeamId) }
         if ($NonInteractive) { $arguments += "-NonInteractive" }
         if ($DryRun) { $arguments += "-DryRun" }
-        Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAPromotePr.ps1" -Arguments $arguments
+        Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAGovernedPromotePr.ps1" -Arguments $arguments
     }
 }

--- a/ddda.ps1
+++ b/ddda.ps1
@@ -21,6 +21,7 @@ param(
     [switch]$KeepReviewBoard,
     [string]$MiroTeamId,
     [switch]$NonInteractive,
+    [switch]$PrePromotionCandidate,
     [switch]$ConfirmMerge,
     [switch]$DryRun
 )
@@ -80,6 +81,7 @@ switch ($Command) {
         if ($KeepReviewBoard) { $arguments += "-KeepReviewBoard" }
         if (-not [string]::IsNullOrWhiteSpace($MiroTeamId)) { $arguments += @("-MiroTeamId", $MiroTeamId) }
         if ($NonInteractive) { $arguments += "-NonInteractive" }
+        if ($PrePromotionCandidate) { $arguments += "-PrePromotionCandidate" }
         Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAPlatformTest.ps1" -Arguments $arguments
     }
     "validate-pr" {
@@ -94,6 +96,7 @@ switch ($Command) {
         if ($KeepReviewBoard) { $arguments += "-KeepReviewBoard" }
         if (-not [string]::IsNullOrWhiteSpace($MiroTeamId)) { $arguments += @("-MiroTeamId", $MiroTeamId) }
         if ($NonInteractive) { $arguments += "-NonInteractive" }
+        if ($PrePromotionCandidate) { $arguments += "-PrePromotionCandidate" }
         Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAValidatePr.ps1" -Arguments $arguments
     }
     "merge-pr" {

--- a/ddda.ps1
+++ b/ddda.ps1
@@ -12,6 +12,7 @@ param(
     [string]$PackagePath,
     [string]$Reviewer,
     [string]$DecisionOwner,
+    [ValidateSet("merge", "squash")][string]$MergeMethod,
     [switch]$PublishScaffold,
     [switch]$WithMiro,
     [switch]$Full,
@@ -100,6 +101,7 @@ switch ($Command) {
             throw "Příkaz merge-pr vyžaduje kladné -Pr."
         }
         $arguments = @("-PlatformPath", $platformRoot, "-Pr", [string]$Pr)
+        if (-not [string]::IsNullOrWhiteSpace($MergeMethod)) { $arguments += @("-MergeMethod", $MergeMethod) }
         if ($ConfirmMerge) { $arguments += "-ConfirmMerge" }
         if ($DryRun) { $arguments += "-DryRun" }
         Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAGovernedMergePr.ps1" -Arguments $arguments

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@
 - [Vývojový lifecycle DDDA platformy](developer-guide/platform-development-lifecycle.md)
 - [Testovací strategie DDDA platformy](developer-guide/testing-strategy.md)
 - [Remote validation a remediation broker](developer-guide/remote-validation-broker.md)
+- [Controlled release-source recovery](developer-guide/controlled-release-source-recovery.md)
 
 ## Architektonická rozhodnutí a migrace
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@
 - [ADR 0003 — Control Center, Artifact Registry a kanonický workshop shell](adr/0003-miro-control-center-and-workshop-shell.md)
 - [ADR 0004 — Redline traceability a navigovatelný frame 01](adr/0004-miro-redline-traceability-and-frame-01.md)
 - [ADR 0005 — Chat/Work platform development a Cursor project runtime](adr/0005-chat-work-only-development-operating-model.md)
+- [ADR 0011 — Fyzický release scope a releasable main](adr/0011-physical-release-scope-and-releasable-main.md)
 - [PR #8 migration note](migration/pr8-non-breaking-steering-extension.md)
 - [Miro scaffold migration 2.4 → 2.5](migration/miro-scaffold-2.4-to-2.5.md)
 - [Forenzní review REM-PR8-HVA-CC-001](reviews/REM-PR8-HVA-CC-001-forensic-review.md)

--- a/docs/adr/0001-platform-development-lifecycle.md
+++ b/docs/adr/0001-platform-development-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR: Reprodukovatelný lifecycle vývoje DDDA platformy
 
-Status: Accepted
+Status: Accepted — amended 2026-08-18 by ADR 0008
 
 Date: 2026-07-26
 
@@ -19,26 +19,58 @@ Prioritní quality attributes:
 
 ## Decision
 
-Zavádíme tento lifecycle:
+Git je source of truth, PR je jednotka platformní změny a candidate/release package je jednotka reprodukovatelné validace/distribuce. Package-dependent smoke, E2E a acceptance musí běžet z nově rozbaleného package, ne z development working tree.
+
+### Amendment 2026-08-18 — implementation merge ≠ release promotion
+
+Post-release review DDDA 0.1.0 a PR #74 ukázaly, že původní lineární sekvence `human review → promote-pr → merge → release` směšovala dvě různé governance boundaries. ADR 0008 proto tento lifecycle prospektivně zpřesňuje.
+
+#### Governed implementation PR
 
 ```text
 change request
-→ feature branch
+→ feature/fix branch
 → implementation
-→ CI
+→ exact-SHA CI
 → validate-pr nad exact PR head
-→ human review
-→ promote-pr s explicitním potvrzením
-→ merge
+→ Human Review pro stejné SHA/package
+→ merge-pr -DryRun
+→ explicitní human merge authorization
+→ merge-pr -ConfirmMerge
+→ merge do main
+→ NO release package
+→ NO release validation
+→ NO release tag
+```
+
+Implementation merge nevyžaduje HRDR ani Release Scope Gate. `merge-pr` je merge-only command a nesmí volat release/tag execution path.
+
+#### Release candidate
+
+Až po integraci práce určené pro konkrétní release:
+
+```text
+release candidate (typicky release/<version> PR nebo ekvivalent)
+→ exact-SHA candidate validation
+→ release cut / changelog consistency
+→ Human Release Decision Record
+→ strict Release Scope Gate
+→ promotion dry-run
+→ explicitní Human Release Decision
+→ samostatná explicitní release/promotion authorization
+→ canonical promotion
+→ release-candidate merge, pokud jej workflow vyžaduje
 → release package
-→ generated example workspace
+→ generated release-validation workspace
 → manifest-driven ingestion
 → smoke + acceptance
 → release report
 → release tag
 ```
 
-Git je source of truth, PR je jednotka změny a candidate/release package je jednotka distribuce a validace. Smoke, E2E a acceptance testy musí běžet z nově rozbaleného package, ne z development working tree.
+Release Scope Gate vyžaduje kompletní/konzistentní release scope, ale **není** precondition pro předchozí merge jednotlivých implementačních PR. Tím se zachová strict release governance bez multi-PR deadlocku.
+
+Human Review, implementation merge authorization, Human Release Decision a release/promotion authorization jsou odlišné lidské boundaries. Automation nesmí žádnou z nich inferovat z technického PASS ani z jiné authorization.
 
 Veřejným entry pointem je `ddda.ps1`. Specializované skripty zůstávají interními stavebními bloky a compatibility entry points.
 
@@ -77,29 +109,36 @@ Pros:
 
 - silná reprodukovatelnost a auditovatelnost;
 - jasná hranice platforma/workspace/release;
-- automatizovatelný promotion gate;
+- automatizovatelné mechanical gates;
 - example workspace prokazuje reálnou použitelnost balíčku.
 
 Cons:
 
 - delší validation běh;
 - potřeba správy dočasných clone, package a reportů;
-- promotion vyžaduje dostupnou GitHub autentizaci; GitHub CLI je pouze volitelný provider a není povinnou závislostí.
+- release promotion vyžaduje dostupnou GitHub autentizaci; GitHub CLI je pouze volitelný provider.
+
+### D. Jeden promote-pr pro implementation merge i release
+
+Zamítnuto dodatkem 2026-08-18. Se strict Release Scope Gate může vytvořit kruhovou závislost u multi-PR releasu a směšuje integration a release authority.
 
 ## Consequences
 
 Positive:
 
-- jeden doporučený command flow;
-- validation report je svázán s PR head SHA a package hashem;
+- exact-SHA validation report je svázán s PR head SHA a package hashem;
 - klientský workspace se nepoužívá jako test fixture;
-- běžné testy nemohou samy mergovat nebo tagovat.
+- běžné testy nemohou samy mergovat nebo tagovat;
+- implementation PR lze bezpečně integrovat bez vytvoření release;
+- strict Release Scope Gate se aplikuje až na skutečný release candidate;
+- merge a release authorization zůstávají oddělené.
 
 Negative:
 
-- více platformního kódu a testovací infrastruktury;
+- lifecycle má explicitně dva orchestration commands/boundaries (`merge-pr`, `promote-pr`);
+- před release je potřeba explicitní release candidate;
 - E2E a online Miro acceptance jsou pomalejší než unit testy;
-- release proces má explicitní nároky na nástroje a oprávnění.
+- release proces má explicitní nároky na nástroje, evidence a oprávnění.
 
 New obligations:
 
@@ -107,7 +146,9 @@ New obligations:
 - doplnit ADR u dlouhodobých rozhodnutí;
 - doplnit migration note u změn kompatibility;
 - udržovat minimal example a invariant-based regression;
-- zachovat fail-closed promotion.
+- zachovat fail-closed implementation merge i release promotion;
+- Human Review evidence vázat na exact implementation SHA/package;
+- HRDR + Release Scope Gate vázat na exact release candidate.
 
 ## Impact
 
@@ -128,7 +169,7 @@ Existing workspaces:
 
 Migration:
 
-- none; změna je aditivní.
+- none; změna je aditivní/non-breaking governance tightening.
 
 ## Validation
 
@@ -137,10 +178,13 @@ Migration:
 - security test package contents a path isolation;
 - offline acceptance;
 - volitelný online Miro acceptance;
-- promotion dry-run bez merge oprávnění.
+- governed `merge-pr` dry-run bez side effects;
+- multi-PR anti-deadlock regression;
+- strict release-scope regression;
+- promotion dry-run bez release side effects.
 
 ## Follow-up actions
 
-- [ ] Použít lifecycle pro PR #9–#11.
-- [ ] Po prvním release zpřesnit časové limity a retention reportů.
-- [ ] Podle repository policy upravit počet požadovaných approvals.
+- [ ] Používat oddělený implementation merge / release candidate lifecycle pro post-0.1.0 stabilization.
+- [ ] Po maintenance release zpřesnit časové limity a retention reportů.
+- [ ] Podle repository policy upravit počet požadovaných approvals a merge strategy (#70).

--- a/docs/adr/0001-platform-development-lifecycle.md
+++ b/docs/adr/0001-platform-development-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR: Reprodukovatelný lifecycle vývoje DDDA platformy
 
-Status: Accepted — amended 2026-08-18 by ADR 0008
+Status: Accepted — amended 2026-08-18 by ADR 0008; amended 2026-08-20 by ADR 0009
 
 Date: 2026-07-26
 
@@ -72,6 +72,25 @@ Release Scope Gate vyžaduje kompletní/konzistentní release scope, ale **není
 
 Human Review, implementation merge authorization, Human Release Decision a release/promotion authorization jsou odlišné lidské boundaries. Automation nesmí žádnou z nich inferovat z technického PASS ani z jiné authorization.
 
+### Amendment 2026-08-20 — exact-SHA ancestry a merge strategy
+
+ADR 0009 prospektivně zpřesňuje způsob samotného implementation merge:
+
+```text
+HIGH / BREAKING → merge commit REQUIRED
+LOW / MEDIUM    → merge commit DEFAULT; squash jen explicitní human exception
+UNKNOWN impact  → merge commit only
+rebase           → forbidden
+```
+
+Důvodem je zachování exact validated PR HEAD jako přímo dohledatelného ancestor výsledného `main` state. Čitelnost hlavní historie se řeší first-parent pohledem, nikoli ztrátou reviewované ancestry.
+
+LOW/MEDIUM squash exception je samostatný human-governed record vázaný na stejné PR/SHA/candidate package/impact a musí po merge vytvořit explicitní source→result mapping. Automation ji nesmí vytvořit ani inferovat.
+
+Pro canonical merge provádí `merge-pr` server-side post-read-back a ověřuje validated PR HEAD jako parent/ancestor výsledného merge commit.
+
+#70 mění merge policy samotnou; jeho vlastní integraci proto řídí pre-existing policy z exact base `297f61f6012f180e70805999df2ac1abe9616a05`. Nový contract je účinný až po integraci #70 do `main`. Transition je exact-base-bound a není precedentem pro budoucí HIGH/BREAKING squash. Historie PR #8 / `v0.1.0` ani dalších již mergovaných PR se nepřepisuje.
+
 Veřejným entry pointem je `ddda.ps1`. Specializované skripty zůstávají interními stavebními bloky a compatibility entry points.
 
 ## Options considered
@@ -122,6 +141,10 @@ Cons:
 
 Zamítnuto dodatkem 2026-08-18. Se strict Release Scope Gate může vytvořit kruhovou závislost u multi-PR releasu a směšuje integration a release authority.
 
+### E. Globální squash jako merge default
+
+Zamítnuto dodatkem 2026-08-20 pro HIGH/BREAKING. Squash zachová výsledný obsah, ale exact reviewed PR HEAD není ancestor výsledného main state a audit závisí na externím mappingu. Detail trade-offu a LOW/MEDIUM exception popisuje ADR 0009.
+
 ## Consequences
 
 Positive:
@@ -131,14 +154,18 @@ Positive:
 - běžné testy nemohou samy mergovat nebo tagovat;
 - implementation PR lze bezpečně integrovat bez vytvoření release;
 - strict Release Scope Gate se aplikuje až na skutečný release candidate;
-- merge a release authorization zůstávají oddělené.
+- merge a release authorization zůstávají oddělené;
+- HIGH/BREAKING validated SHA zůstává po merge v ancestry;
+- first-parent history zachovává čitelnost bez ztráty auditability.
 
 Negative:
 
 - lifecycle má explicitně dva orchestration commands/boundaries (`merge-pr`, `promote-pr`);
 - před release je potřeba explicitní release candidate;
 - E2E a online Miro acceptance jsou pomalejší než unit testy;
-- release proces má explicitní nároky na nástroje, evidence a oprávnění.
+- release proces má explicitní nároky na nástroje, evidence a oprávnění;
+- historie obsahuje více merge commits;
+- LOW/MEDIUM squash vyžaduje explicitní human exception evidence.
 
 New obligations:
 
@@ -148,7 +175,9 @@ New obligations:
 - udržovat minimal example a invariant-based regression;
 - zachovat fail-closed implementation merge i release promotion;
 - Human Review evidence vázat na exact implementation SHA/package;
-- HRDR + Release Scope Gate vázat na exact release candidate.
+- HRDR + Release Scope Gate vázat na exact release candidate;
+- wrong merge method odmítnout před irreversible merge;
+- canonical merge ověřit post-merge ancestry read-backem.
 
 ## Impact
 
@@ -179,12 +208,14 @@ Migration:
 - offline acceptance;
 - volitelný online Miro acceptance;
 - governed `merge-pr` dry-run bez side effects;
+- impact → merge-method matrix a wrong-method negative regression;
+- canonical merge ancestry invariant a LOW/MEDIUM squash exception contract;
 - multi-PR anti-deadlock regression;
 - strict release-scope regression;
 - promotion dry-run bez release side effects.
 
 ## Follow-up actions
 
-- [ ] Používat oddělený implementation merge / release candidate lifecycle pro post-0.1.0 stabilization.
+- [x] Používat oddělený implementation merge / release candidate lifecycle pro post-0.1.0 stabilization.
 - [ ] Po maintenance release zpřesnit časové limity a retention reportů.
-- [ ] Podle repository policy upravit počet požadovaných approvals a merge strategy (#70).
+- [x] Verzovat risk-based merge strategy a exact-SHA ancestry contract v ADR 0009 / #70; activation zůstává podmíněna HVR a samostatnou merge authorization #70.

--- a/docs/adr/0008-human-release-decision-and-release-scope-gate.md
+++ b/docs/adr/0008-human-release-decision-and-release-scope-gate.md
@@ -1,0 +1,228 @@
+# ADR 0008: Human Review, governed implementation merge a fail-closed Release Scope Gate
+
+- Status: **Accepted**
+- Date: 2026-08-18
+- Decision owner: Roman Hlaváč (`romanhlavac`)
+- Related: #9, #12, #15, #17, #44, #67, #68, #70, PR #8 / DDDA 0.1.0, PR #74
+
+## Context
+
+DDDA 0.1.0 prokázalo, že release readiness nelze redukovat na jediný technický gate. Musí být odděleny minimálně:
+
+1. **Technical candidate evidence** — CI, `validate-pr`, package hash a další mechanické důkazy.
+2. **Human Review implementační změny** — lidské posouzení metodiky, architektury, gate semantics a dalších judgment-heavy aspektů konkrétního PR.
+3. **Human Release Decision** — lidské `GO`, `GO_WITH_ACCEPTED_RISKS` nebo `NO_GO` pro konkrétní release candidate.
+4. **Release-scope completeness** — zda autoritativní release scope v Issues, native dependencies, Milestone a GitHub Project projekci neobsahuje neuzavřenou/neodloženou práci nebo neakceptovaný blocker.
+
+Post-release read-back 0.1.0 ukázal, že promotion nevynutil release-scope completeness před nevratným release tokem.
+
+První implementace Release Scope Gate v PR #74 následně odhalila další problém: pokud stejný `promote-pr` současně slouží jako mechanismus merge každého implementačního PR a Release Scope Gate vyžaduje všechny release-scope Issues již terminal, vzniká u multi-PR releasu kruhová závislost:
+
+```text
+implementation Issue musí být terminal
+→ Release Scope Gate může PASS
+→ promotion může mergnout implementation PR
+
+ALE
+
+implementation PR musí být mergnut
+→ Issue může být korektně terminal
+```
+
+Decision owner proto 2026-08-18 explicitně schválil oddělení **governed implementation merge** od **release/promotion**.
+
+Tento ADR nepřepisuje historický release 0.1.0 ani jeho human decision.
+
+## Decision
+
+DDDA zavádí tři explicitně oddělené governance boundaries.
+
+### 1. Human Review + governed implementation merge
+
+Implementační PR používá tok:
+
+```text
+exact-SHA CI PASS
+→ validate-pr PASS + candidate package binding
+→ Human Review PASS pro stejné SHA/package
+→ merge-pr -DryRun
+→ explicitní human merge authorization
+→ merge-pr -ConfirmMerge
+→ merge do main
+→ NO release package
+→ NO release validation
+→ NO tag
+```
+
+`merge-pr` je merge-only command. Nevyhodnocuje HRDR ani Release Scope Gate. Důvodem není oslabení release governance, ale odstranění kruhové závislosti: jednotlivé implementační změny musí být nejprve bezpečně integrovány, aby mohl vzniknout kompletní release candidate.
+
+Human Review a merge authorization jsou dvě různé lidské akce. Automation nesmí vytvořit Human Review PASS ani merge authorization.
+
+Human Review evidence je vázána minimálně na:
+
+```text
+repository
+pr
+reviewed_sha
+candidate_package_sha256
+reviewer
+reviewed_at
+verdict
+```
+
+Autoritativní implementation-review comment používá marker:
+
+```text
+<!-- ddda:human-pr-review:v1 -->
+```
+
+Změna PR SHA nebo package hash review invaliduje.
+
+### 2. Human Release Decision
+
+Human Release Decision Record (HRDR) se vytváří až pro **release candidate**, nikoli jako podmínka každého implementačního merge.
+
+HRDR je vázán minimálně na:
+
+- repository a release-candidate PR;
+- exact source SHA;
+- candidate package SHA-256;
+- target version;
+- reviewer a concrete decision owner;
+- timestamp;
+- findings GREEN/AMBER/RED;
+- accepted residual risks;
+- authoritative release-scope snapshot.
+
+Automation smí vytvořit pouze `pending` scaffold, validovat strukturu/evidence a publikovat read-back. Nesmí vytvořit/inferovat `GO`, měnit lidské rozhodnutí, accepted-risk set ani decision ownera.
+
+Autoritativní HRDR comment používá marker:
+
+```text
+<!-- ddda:human-release-decision:v1 -->
+```
+
+### 3. Release Scope Gate
+
+Release Scope Gate je read-only a fail-closed. Vyhodnocuje se **pouze na release-candidate promotion boundary**:
+
+```text
+GitHub Milestone / version identity
++ Issue state
++ native unresolved blocked-by
++ Project planning projection
++ HRDR exact candidate/version identity
++ accepted-risk follow-up Issues
+```
+
+Gate `PASS` vyžaduje mimo jiné:
+
+- právě jeden odpovídající release milestone;
+- current-release Issues přesně odpovídají HRDR scope;
+- všechny current-release Issues jsou terminal;
+- žádný current-release Issue nemá unresolved blocker;
+- Project `Status=Done`, `Blocked=No` pro current-release Issues;
+- deferred accepted-risk Issues jsou mimo current release milestone, otevřené a mají ownera + target/horizon;
+- HRDR nemá RED;
+- risk set je přesně lidsky přijatý set;
+- live release-candidate head, HRDR source SHA, candidate hash a version se shodují.
+
+Nedostupný authoritative read-back je `FAIL`, nikoli warning.
+
+## Canonical invariants
+
+### Implementation merge
+
+```text
+implementation_merge_allowed =
+    exact_sha_ci_valid
+AND validate_pr_valid
+AND candidate_package_hash_valid
+AND human_review_pass_for_same_sha
+AND explicit_merge_authorization
+```
+
+Release Scope Gate není součástí tohoto výrazu.
+
+### Release promotion
+
+```text
+release_promotion_allowed =
+    release_candidate_evidence_valid
+AND HRDR_valid
+AND ReleaseScopeGate == PASS
+AND human_decision in {GO, GO_WITH_ACCEPTED_RISKS}
+AND explicit_release_promotion_authorization
+```
+
+Implementation merge authorization nikdy neimplikuje release/promotion/tag authorization.
+
+## Command boundary
+
+Public CLI rozlišuje:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr <PR> -DryRun
+.\ddda.ps1 merge-pr -Pr <PR> -ConfirmMerge
+
+.\ddda.ps1 review-pr -Pr <RELEASE_PR> -Version <VERSION> ...
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version <VERSION> -DryRun
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version <VERSION> -ConfirmMerge
+```
+
+`merge-pr` nesmí volat release executor. `promote-pr` je release command a jeho governed wrapper musí vyhodnotit HRDR + Release Scope Gate před dosažením release executor side effects.
+
+## Alternatives considered
+
+### A. Jeden `promote-pr` pro merge každého PR i release
+
+Zamítnuto. Při striktním Release Scope Gate vytváří multi-PR deadlock a směšuje integration boundary s release boundary.
+
+### B. Oslabit Release Scope Gate tak, aby toleroval open implementation Issues
+
+Zamítnuto. Opravilo by to symptom za cenu ztráty hlavního post-0.1.0 invariantu: skutečný release nesmí proběhnout s nekompletním autoritativním scope.
+
+### C. Automaticky uzavírat Issues před merge
+
+Zamítnuto. Přepisovalo by skutečný delivery stav a vytvářelo falešnou governance projekci.
+
+### D. Spoléhat pouze na HRDR
+
+Zamítnuto. HRDR je human decision evidence, ale sám nemusí odhalit live drift release scope.
+
+## Consequences
+
+### Positive
+
+- multi-PR release se nezablokuje kruhovou závislostí;
+- Release Scope Gate může zůstat striktní;
+- implementation merge je auditovatelný exact-SHA/package Human Review;
+- release decision zůstává explicitně lidský;
+- merge a release/tag jsou samostatně autorizované side effects;
+- PR8-class failure zůstává pokrytelný deterministickou regresí.
+
+### Costs
+
+- lifecycle má dva explicitní příkazy/boundaries místo jednoho;
+- před release je potřeba explicitní release candidate;
+- Human Review evidence musí být machine-readable a bound na exact SHA/package;
+- release milestone/Project projection musí být před promotion skutečně konzistentní.
+
+## Required validation
+
+Povinné testy zahrnují:
+
+- `merge-pr` dry-run před merge side effectem;
+- explicitní confirmation guard;
+- exact-SHA CI + validate-pr + package binding;
+- Human Review marker/provenance/SHA/hash checks;
+- důkaz, že `merge-pr` nevolá HRDR, Release Scope Gate, release package ani tag path;
+- multi-PR anti-deadlock regression;
+- strict Release Scope Gate positive/negative scenarios;
+- PR8-class zero-release-side-effect regression;
+- changed SHA/package invalidation;
+- pending/RED/risk-set failure cases.
+
+## Historical note
+
+DDDA 0.1.0 zůstává `RELEASED — GO_WITH_ACCEPTED_RISKS` s accepted-risk setem přesně #66 a #67. Tento ADR nemění PR #8, `v0.1.0`, jeho merge SHA ani historickou HRDR evidence.

--- a/docs/adr/0009-exact-sha-merge-strategy.md
+++ b/docs/adr/0009-exact-sha-merge-strategy.md
@@ -1,0 +1,208 @@
+# ADR 0009: Exact-SHA ancestry a merge strategy řízených platformních PR
+
+Status: Accepted candidate — pending Human Review of PR implementing #70
+
+Date: 2026-08-20
+
+## Context
+
+DDDA používá exact PR HEAD SHA a candidate-package SHA-256 jako základ auditovatelné technické evidence. Dosavadní repository policy používala `squash`, takže výsledný commit na `main` obsahoval reviewovaný obsah, ale reviewovaný PR HEAD nebyl součástí ancestry výsledného main state. Audit proto závisel na odděleném source→result mappingu.
+
+Pro běžný produkt to může být přijatelný trade-off. Pro DDDA platformu ale mají `HIGH` a `BREAKING` změny silnější požadavek na auditability: commit, který prošel exact-SHA CI, `validate-pr` a Human Review, má zůstat přímo dohledatelný v Git historii po merge.
+
+Prioritní quality attributes jsou:
+
+- auditability;
+- traceability;
+- safety / fail-closed governance;
+- reproducibility;
+- readability historie;
+- jednoduchost provozu.
+
+## Decision
+
+Po integraci změny #70 platí prospektivně tento contract:
+
+```text
+HIGH / BREAKING
+  → merge commit REQUIRED
+  → squash/rebase forbidden
+  → validated PR HEAD musí být ancestor výsledného main state
+
+LOW / MEDIUM
+  → merge commit DEFAULT
+  → squash pouze jako explicitní human-governed exception
+  → rebase forbidden
+
+UNKNOWN impact
+  → merge commit only (fail-safe default)
+```
+
+`merge-pr` načte impact z jednoho autoritativního PR-body markeru:
+
+```text
+<!-- ddda:change-classification:v1 -->
+```
+
+s fenced JSON objektem `schema_version=1` a `impact=LOW|MEDIUM|HIGH|BREAKING`. Chybějící marker je `UNKNOWN`; malformed nebo duplicitní marker failuje closed.
+
+### Proč merge commit
+
+Merge commit zachová reviewovaný PR HEAD jako parent/ancestor výsledného main state. Tím je vazba:
+
+```text
+validated source SHA
+→ Human Review stejného SHA/package
+→ explicit merge authorization
+→ resulting main state
+```
+
+ověřitelná přímo z Gitu a není závislá pouze na externím komentáři nebo reportu.
+
+### Readability
+
+Čitelnost hlavní historie se řeší pohledem first-parent (`git log --first-parent`), nikoli ztrátou auditní ancestry. Merge commits tvoří přehlednou delivery páteř, zatímco detailní commit historie zůstává dostupná podle potřeby.
+
+## LOW/MEDIUM squash exception
+
+Squash je legitimní pouze pro LOW/MEDIUM změnu a pouze po explicitním lidském rozhodnutí. Automatizace nesmí exception vytvořit ani inferovat.
+
+Autoritativní PR comment obsahuje marker:
+
+```text
+<!-- ddda:squash-exception:v1 -->
+```
+
+a machine-readable record minimálně s:
+
+```text
+repository
+pr
+validated_source_head_sha
+candidate_package_sha256
+impact
+reason
+reviewer
+approved_at
+```
+
+Comment musí mít lidskou GitHub provenance a reviewer musí odpovídat autorovi komentáře. SHA/package/impact musí přesně odpovídat aktuálnímu candidate. Změna identity exception invaliduje.
+
+Po squash merge se evidence uloží jako explicitní source→result mapping:
+
+```text
+validated_source_head_sha
+candidate_package_sha256
+resulting_merge_sha
+source_to_result_relation = explicit_squash_mapping
+human exception metadata
+```
+
+Squash exception nemění Human Review ani explicitní merge authorization.
+
+## Post-merge read-back
+
+Pro canonical `merge` musí `merge-pr` po irreversible operaci ověřit server-side:
+
+1. výsledný merge commit obsahuje validated PR HEAD mezi parenty;
+2. GitHub compare read-back potvrzuje validated PR HEAD jako merge base / ancestor výsledného merge commit;
+3. evidence zaznamená `source_to_result_relation=ancestor` a `ancestry_verified=true`.
+
+Nesoulad je governance failure a musí být zachován jako diagnostika; shared history se automaticky nepřepisuje.
+
+## Vztah k candidate package, HRDR a release
+
+Merge strategy nemění exact-SHA CI, `validate-pr`, candidate-package hash ani Human Review. Implementační merge je stále oddělen od release.
+
+HRDR, Release Scope Gate a Human Release Decision vznikají až pro skutečný release candidate po integraci zamýšlených implementation PR. Release tag ukazuje na validovaný release state; merge ancestry poskytuje auditní trasu od release state zpět k reviewovaným implementation SHA.
+
+Squash exception nikdy neoslabuje HRDR, Release Scope Gate, release authorization nebo tag governance.
+
+## Bootstrap / prospective activation
+
+#70 mění právě merge policy, podle které by měl být sám integrován. Proto se nesmí sám retroaktivně prohlásit za již účinnou autoritu.
+
+Explicitní transition contract je:
+
+```text
+legacy governing base: 297f61f6012f180e70805999df2ac1abe9616a05
+legacy merge method: squash
+change issue: #70
+new policy effective: až po integraci #70 do main
+```
+
+Pokud bude PR implementující #70 po exact-SHA PASS, Human Review a samostatné merge autorizaci skutečně mergován, jeho vlastní merge se řídí pre-existing policy z uvedeného base. Tento jediný transition případ je versioned a exact-base-bound; po posunu `main` už podmínku nelze splnit.
+
+Tento bootstrap není precedent pro HIGH/BREAKING squash po aktivaci nové policy.
+
+## Historical scope
+
+Rozhodnutí je výhradně prospektivní. Nemění a nepřepisuje historii:
+
+- PR #8 / `v0.1.0`;
+- PR #74;
+- PR #77;
+- PR #78;
+- PR #79;
+- jiné již sdílené branche nebo tagy.
+
+Historické squash merges zůstávají auditovatelné prostřednictvím existujících source→result evidence. Žádný force push, rebase nebo retag není součástí tohoto rozhodnutí.
+
+## Options considered
+
+### A. Zachovat globální squash
+
+Výhoda: velmi kompaktní historie.
+
+Nevýhoda: exact reviewed SHA se ztrácí z ancestry; audit musí spoléhat na externí mapping. Pro HIGH/BREAKING zamítnuto.
+
+### B. Globální merge commit bez výjimek
+
+Výhoda: nejjednodušší a nejsilnější ancestry invariant.
+
+Nevýhoda: zbytečně rigidní pro triviální LOW/MEDIUM změny. Použito jako default, ale s úzkou human squash exception.
+
+### C. Rebase merge
+
+Výhoda: lineární historie.
+
+Nevýhoda: přepisuje commit identity, takže exact validated PR HEAD není zachován. Zamítnuto pro canonical DDDA merge path.
+
+### D. Risk-based merge commit + LOW/MEDIUM squash exception
+
+Přijato. Zachovává auditní invariant tam, kde je nejdůležitější, a dovoluje explicitní, auditovatelnou výjimku pro nízké riziko.
+
+## Consequences
+
+Positive:
+
+- HIGH/BREAKING reviewed SHA zůstává přímo v ancestry;
+- wrong merge method failuje před irreversible side effect;
+- first-parent history zachovává čitelnost;
+- LOW/MEDIUM squash je explicitní lidské rozhodnutí, nikoli automation default;
+- release traceability se zjednodušuje.
+
+Negative:
+
+- historie obsahuje více merge commits;
+- impact classification se stává součástí merge preflightu;
+- LOW/MEDIUM squash vyžaduje další auditní record;
+- jeden exact-base-bound bootstrap je nutný pro samotnou aktivaci #70.
+
+## Validation
+
+Povinné regresní scénáře:
+
+- HIGH + merge → PASS;
+- HIGH/BREAKING + squash → FAIL před merge;
+- UNKNOWN + squash → FAIL;
+- LOW/MEDIUM default → merge;
+- LOW/MEDIUM squash bez human exception → FAIL;
+- validní human squash exception → PASS preflight;
+- bot/identity/package drift exception → FAIL;
+- canonical merge post-read-back → validated SHA je parent/ancestor;
+- #70 bootstrap funguje pouze pro exact legacy base a nelze jej znovu použít.
+
+## Decision ownership
+
+Technická validace tohoto ADR neznamená jeho Human Review. Judgment-heavy trade-off — auditní ancestry versus kompaktnost historie a jednorázový bootstrap #70 — musí být explicitně schválen při HVR implementačního PR.

--- a/docs/adr/0010-canonical-github-release-publication.md
+++ b/docs/adr/0010-canonical-github-release-publication.md
@@ -1,0 +1,43 @@
+# ADR 0010: Canonical GitHub Release publication
+
+- Status: Proposed
+- Date: 2026-08-25
+- Related: #68, #96, #98
+
+## Context
+
+The canonical promotion path validates a release package and emits a release report and annotated Git tag. A tag alone exposes GitHub-generated source archives but does not publish the validated DDDA product package or durable release evidence.
+
+The required invariant is:
+
+```text
+validated release version + source SHA + package SHA-256 + report + tag
+= one immutable GitHub Release publication
+```
+
+## Decision
+
+After all release gates and release validation PASS, promotion creates or read-backs exactly one final GitHub Release named `DDDA X.Y.Z` for tag `vX.Y.Z`. It publishes these deterministic assets:
+
+- `ddda-X.Y.Z.zip` — canonical validated DDDA package;
+- `ddda-X.Y.Z-release-report.json`;
+- `ddda-X.Y.Z-release-report.md`.
+
+Publication verifies the annotated tag dereferences to the exact validated release source SHA, then verifies each physical asset SHA-256 by GitHub digest or authenticated download/read-back. Existing tag, Release or assets are never overwritten. Partial failure is not PASS; recovery requires a separate explicit authorization and fresh identity/hash read-back.
+
+GitHub source archives remain convenience source archives, not the DDDA product package.
+
+## Consequences
+
+- Release distribution and evidence become directly discoverable in GitHub Releases.
+- Release publication adds a post-validation side-effect boundary and recovery state.
+- #96 remains responsible for proving that the release source itself is physically in scope before publication may begin.
+- #68 remains responsible for tag identity/recovery; this decision only extends recovery with Release and asset identity.
+
+## Validation
+
+- deterministic asset-name and hash checks;
+- release API orchestration and server read-back;
+- missing/wrong/duplicate asset and partial-publication regressions;
+- dry-run proves no tag, Release or asset side effect;
+- authorization and secret-isolation tests.

--- a/docs/adr/0011-physical-release-scope-and-releasable-main.md
+++ b/docs/adr/0011-physical-release-scope-and-releasable-main.md
@@ -1,0 +1,59 @@
+# ADR 0011: Physical release scope and releasable main
+
+Status: Accepted
+
+Date: 2026-08-25
+
+## Context
+
+Milestone a Project mohou správně deklarovat release scope, zatímco canonical
+`main` už obsahuje jinou, dříve integrovanou změnu. Původní Release Scope Gate
+ověřoval pouze deklarovanou authority. Mohl proto propustit package obsahující
+PR pro pozdější release nebo `TBD`.
+
+## Decision
+
+Pro exact release-candidate source se gate read-only odvodí:
+
+```text
+previous canonical SemVer tag
+→ exact candidate source SHA
+→ every physical commit
+→ associated merged shipping PR
+→ exactly one primary Implements/Closes CR
+→ Milestone + Project Target Release projection
+```
+
+Invariant je:
+
+```text
+DECLARED_RELEASE_SCOPE == PHYSICAL_RELEASE_SOURCE_SCOPE
+```
+
+Chybějící commit→PR vztah, více nebo nula primary CR, non-merged PR, rozdíl
+Milestone/Target Release nebo source ancestry je fail-closed. Gate publikuje
+machine-readable inventory a `RECOVERY_DECISION_REQUIRED`. Automation nikdy
+nevolí human scope expansion, controlled source recovery ani novou
+release-source strategii.
+
+Dokud existuje právě jeden otevřený Milestone `DDDA X.Y.Z`, governed
+implementation merge smí do `main` pouze PR s jediným primary CR v tomto
+Milestone. Tím se nová kontaminace zastaví před merge. Guard je read-only a
+není Release Scope Gate, HRDR ani release authorization.
+
+## Consequences
+
+- již kontaminovaný current source nelze vydat bez explicitního lidského
+  recovery decision;
+- implementační merge zůstává oddělený od release promotion, ale budoucí
+  later/TBD scope nemůže běžnou cestou kontaminovat otevřený train;
+- release evidence obsahuje exact tag/source/commit/PR/CR inventory;
+- `v0.1.0` ani historické tagy se nemění.
+
+## Validation
+
+- unit regrese A+B declared / A+B+E physical = FAIL;
+- unit regrese pro TBD/later primary CR, chybějící commit mapping, více primary
+  CR a wrong ancestry;
+- contract test, že merge guard běží před merge side effect;
+- exact-SHA standardní PR CI a package-first validation.

--- a/docs/adr/0011-physical-release-scope-and-releasable-main.md
+++ b/docs/adr/0011-physical-release-scope-and-releasable-main.md
@@ -41,7 +41,8 @@ reconstructed candidate odvozen od předchozího canonical tagu. Protože takov�
 candidate dostává nové commit SHA, obsahuje versioned recovery ledger. Ledger
 svazuje každý reconstructed commit s původním merged PR, jeho jediným primary
 CR, původním merge SHA a fresh-ověřenými changed-path result hashes. Právě jeden
-metadata-only ledger commit je povolen. Ledger je evidence, nikoli mechanismus
+metadata-only ledger commit je povolen; jeho identita se odvozuje z physical
+inventory, nikoli ze self-referential hodnoty uvnitř ledgeru. Ledger je evidence, nikoli mechanismus
 pro změnu release scope nebo human rozhodnutí.
 
 Dokud existuje právě jeden otevřený Milestone `DDDA X.Y.Z`, governed

--- a/docs/adr/0011-physical-release-scope-and-releasable-main.md
+++ b/docs/adr/0011-physical-release-scope-and-releasable-main.md
@@ -36,6 +36,14 @@ machine-readable inventory a `RECOVERY_DECISION_REQUIRED`. Automation nikdy
 nevolí human scope expansion, controlled source recovery ani novou
 release-source strategii.
 
+Pokud člověk explicitně zvolí controlled release-source recovery, může být
+reconstructed candidate odvozen od předchozího canonical tagu. Protože takový
+candidate dostává nové commit SHA, obsahuje versioned recovery ledger. Ledger
+svazuje každý reconstructed commit s původním merged PR, jeho jediným primary
+CR, původním merge SHA a fresh-ověřenými changed-path result hashes. Právě jeden
+metadata-only ledger commit je povolen. Ledger je evidence, nikoli mechanismus
+pro změnu release scope nebo human rozhodnutí.
+
 Dokud existuje právě jeden otevřený Milestone `DDDA X.Y.Z`, governed
 implementation merge smí do `main` pouze PR s jediným primary CR v tomto
 Milestone. Tím se nová kontaminace zastaví před merge. Guard je read-only a

--- a/docs/developer-guide/controlled-release-source-recovery.md
+++ b/docs/developer-guide/controlled-release-source-recovery.md
@@ -1,0 +1,65 @@
+# Controlled release-source recovery
+
+## Purpose
+
+When `main` already contains work outside the declared release scope, DDDA may
+use a separately reconstructed release source only after an explicit human
+recovery decision. This is not a scope expansion and does not rewrite `main`
+or any historical tag.
+
+The recovery source contains
+
+```text
+previous canonical tag
+→ recovered commits for approved shipping PRs only
+→ one metadata-only recovery ledger commit
+```
+
+## Ledger
+
+The candidate source contains exactly one versioned file:
+
+```text
+config/governance/release-source-recovery-ledger.json
+```
+
+Its schema is `schemas/release-source-recovery-ledger.schema.json`. Each entry
+binds one reconstructed commit to the immutable original authority:
+
+```json
+{
+  "recovered_commit_sha": "<new recovery commit SHA>",
+  "source_pr": 74,
+  "source_merge_commit_sha": "<merged source PR SHA>",
+  "primary_cr": 9
+}
+```
+
+The ledger has exactly one metadata-only commit. That commit may change only
+the ledger file; every other physical commit since the previous tag must have
+one and only one ledger entry. The Release Scope Gate freshly reads back the
+original PR, its single primary CR, merged SHA and changed-path result hashes.
+Any stale SHA, non-merged source PR, altered path result, incomplete coverage,
+duplicate mapping or out-of-scope CR is a failure.
+
+## Authority boundary
+
+The ledger is evidence, not authorization. It cannot add an Issue to a
+milestone, defer a scope item, accept a risk, create a Human Release Decision,
+or authorize promotion, tag creation or publication. The candidate remains
+Draft until standard CI, a Human Release Decision Record and the normal release
+governance boundaries are satisfied.
+
+## Recovery procedure
+
+1. Freeze the intended candidate source SHA and read the live milestone/Project authority.
+2. Create the reconstruction branch from the previous canonical SemVer tag.
+3. Reapply only the selected original shipping changes, preserving their exact
+   changed-path results.
+4. Add the ledger as its only metadata-only commit.
+5. Open a Draft recovery candidate PR and run exact-SHA standard CI.
+6. Run the read-only Release Scope Gate inventory. A PASS proves the physical
+   source equals the declared scope; it is not a release authorization.
+
+No automatic revert, scope expansion, tag movement, force-push or history
+rewrite is permitted.

--- a/docs/developer-guide/controlled-release-source-recovery.md
+++ b/docs/developer-guide/controlled-release-source-recovery.md
@@ -35,10 +35,12 @@ binds one reconstructed commit to the immutable original authority:
 }
 ```
 
-The ledger has exactly one metadata-only commit. That commit may change only
-the ledger file; every other physical commit since the previous tag must have
-one and only one ledger entry. The Release Scope Gate freshly reads back the
-original PR, its single primary CR, merged SHA and changed-path result hashes.
+The Release Scope Gate derives exactly one metadata-only commit from the
+physical inventory. That commit may change only the ledger file and is not
+listed inside that file: a ledger cannot safely contain the SHA of the commit
+that creates it. Every other physical commit since the previous tag must have
+one and only one ledger entry. The Gate freshly reads back the original PR,
+its single primary CR, merged SHA and changed-path result hashes.
 Any stale SHA, non-merged source PR, altered path result, incomplete coverage,
 duplicate mapping or out-of-scope CR is a failure.
 

--- a/docs/developer-guide/github-release-publication.md
+++ b/docs/developer-guide/github-release-publication.md
@@ -1,0 +1,54 @@
+# Canonical GitHub Release publication
+
+## Terms
+
+```text
+Milestone           = declared release scope
+Release candidate   = exact frozen candidate state
+Tag                 = immutable Git identity of the released version
+GitHub Release      = published distribution/evidence object for that tag
+Canonical DDDA ZIP  = validated DDDA product package
+GitHub source ZIP   = convenience source archive, not the DDDA product package
+```
+
+## Normal publication path
+
+Publication is reached only inside an explicitly authorized non-dry-run canonical promotion, after release validation and report generation are PASS.
+
+```text
+release source SHA
+→ validated canonical ZIP + SHA-256
+→ portable result.json + result.md
+→ annotated tag vX.Y.Z
+→ GitHub Release DDDA X.Y.Z
+→ upload exact assets
+→ fresh server read-back of tag, Release and asset hashes
+```
+
+The published assets are named deterministically:
+
+```text
+ddda-X.Y.Z.zip
+ddda-X.Y.Z-release-report.json
+ddda-X.Y.Z-release-report.md
+```
+
+Automatic GitHub source archives may be visible in the Release UI. They are never canonical DDDA package evidence.
+
+## Failure and recovery
+
+Publication is fail closed. A tag created without its Release, a Release without all assets, an unexpected existing Release/asset, or a mismatching hash is `RECOVERY_REQUIRED`, not `PASS`.
+
+Do not delete, replace, retag, force-push or rerun promotion heuristically. After separate recovery authorization, use the recovery command only with the original validated release source, package and reports:
+
+```powershell
+.\scripts\platform\Invoke-DDDARecoverGitHubRelease.ps1 `
+  -Version X.Y.Z `
+  -ReleaseSourceSha <validated-release-sha> `
+  -ReleasePackagePath <validated-package.zip> `
+  -ReleaseReportJsonPath <result.json> `
+  -ReleaseReportMarkdownPath <result.md> `
+  -ConfirmRecovery
+```
+
+Recovery finishes only after fresh tag/Release/asset read-back proves the original identities and physical package SHA-256.

--- a/docs/developer-guide/human-release-decision-and-release-scope-gate.md
+++ b/docs/developer-guide/human-release-decision-and-release-scope-gate.md
@@ -191,6 +191,7 @@ Gate je fail-closed.
 - každý commit mezi předchozím canonical SemVer tagem a release source je dohledatelný k právě jednomu merged shipping PR a jeho právě jednomu primary CR;
 - každý shipping primary CR je v aktuálním Milestone a jeho Project `Target Release` je stejná verze;
 - physical scope se přesně rovná declared Milestone scope: ani extra shipping CR, ani declared CR bez shipping změny. Při rozdílu gate vydá inventory a `RECOVERY_DECISION_REQUIRED`; nevolí scope expansion ani source recovery.
+- controlled reconstructed source je přípustný pouze po explicitním human recovery decision a s validním versioned recovery ledgerem; ledger musí pokrýt každý reconstructed commit, kromě jediného metadata-only ledger commitu, a fresh read-backem prokázat původní merged PR/CR/SHA i changed-path result hashes.
 
 Chybějící Project credential, nedostupný Project nebo API ambiguity jsou FAIL.
 

--- a/docs/developer-guide/human-release-decision-and-release-scope-gate.md
+++ b/docs/developer-guide/human-release-decision-and-release-scope-gate.md
@@ -1,0 +1,285 @@
+# Human Review, governed implementation merge a Release Scope Gate
+
+## Účel
+
+Tento runbook je závazný pro governance část DDDA platformního lifecycle. Odděluje čtyři různé otázky:
+
+```text
+technical evidence
+≠ Human Review implementačního PR
+≠ merge authorization
+≠ Human Release Decision / release-scope completeness
+```
+
+Žádná z těchto dimenzí nenahrazuje ostatní.
+
+## 1. Candidate validation implementačního PR
+
+Pro exact PR HEAD musí existovat standardní PASS evidence:
+
+```powershell
+.\ddda.ps1 validate-pr -Pr <PR> ...
+```
+
+Validation report a candidate package SHA-256 tvoří technickou identitu Human Review.
+
+## 2. Human Review implementačního PR
+
+Člověk posoudí judgment-heavy oblasti změny. PASS musí být auditovatelně svázán minimálně s:
+
+```text
+repository
+pr
+reviewed_sha
+candidate_package_sha256
+reviewer
+reviewed_at
+verdict
+```
+
+Authoritativní PR comment používá marker:
+
+```text
+<!-- ddda:human-pr-review:v1 -->
+```
+
+a fenced JSON kontrakt:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "implementation_pr_review",
+  "repository": "owner/repository",
+  "pr": 74,
+  "reviewed_sha": "<40-char-sha>",
+  "candidate_package_sha256": "<64-char-sha256>",
+  "reviewer": "<github-login>",
+  "reviewed_at": "<ISO-8601>",
+  "verdict": "pass"
+}
+```
+
+Povolené verdict semantics jsou lidské `PASS` nebo `CHANGES_REQUIRED`; machine-readable hodnoty jsou `pass` a `changes_required`.
+
+Automation nesmí vytvořit `pass` pouze z technického PASS. Změna PR HEAD nebo candidate package hash před merge review invaliduje.
+
+## 3. Governed implementation merge
+
+Human Review PASS není sám o sobě merge authorization.
+
+Preflight:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr <PR> -DryRun
+```
+
+Skutečný merge:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr <PR> -ConfirmMerge
+```
+
+`merge-pr` mechanicky ověřuje:
+
+- PR je open a není Draft;
+- base branch odpovídá policy;
+- live head SHA je platné a mergeable;
+- required CI je PASS pro exact SHA;
+- `validate-pr` PASS existuje pro stejné SHA;
+- candidate package SHA-256 odpovídá validation reportu;
+- existuje právě jeden authoritativní Human Review marker;
+- marker má lidskou GitHub provenance;
+- reviewer, exact SHA a package hash odpovídají live evidence;
+- Human Review verdict je `pass`;
+- required governance documents existují;
+- merge method odpovídá aktuální repository policy;
+- actual merge má explicitní `-ConfirmMerge`.
+
+`merge-pr` záměrně **nevyhodnocuje**:
+
+- HRDR;
+- Release Scope Gate;
+- release milestone completeness jako podmínku implementation merge.
+
+A záměrně **nevytváří**:
+
+- release package;
+- release-validation workspace/report;
+- release tag;
+- release decision;
+- accepted risk.
+
+To je hlavní anti-deadlock invariant pro multi-PR release.
+
+## 4. Release candidate
+
+Teprve když jsou všechny implementační změny určené pro release integrovány a jejich delivery Issues mohou být korektně terminal, vytvoří se explicitní release candidate, typicky `release/<version>` PR nebo jiný lifecyclem schválený ekvivalent.
+
+Pro release candidate znovu platí exact-SHA validation. Implementation Human Review z jednotlivých PR **není** HRDR release candidate.
+
+## 5. Vytvoření HRDR scaffoldu
+
+Pro exact release candidate:
+
+```powershell
+.\ddda.ps1 review-pr `
+  -Pr <RELEASE_PR> `
+  -Version <X.Y.Z> `
+  -Reviewer <github-login> `
+  -DecisionOwner <github-login> `
+  -PublishScaffold
+```
+
+Příkaz načte live release-candidate HEAD, PASS `validate-pr` evidence, candidate hash a current release milestone. Automation vytváří pouze `decision=pending`.
+
+## 6. Human Release Decision
+
+Člověk explicitně zvolí:
+
+```text
+GO
+GO_WITH_ACCEPTED_RISKS
+NO_GO
+```
+
+Machine-readable:
+
+```text
+go
+go_with_accepted_risks
+no_go
+```
+
+Pro pozitivní rozhodnutí HRDR obsahuje konkrétního reviewer/decision ownera, timestamp, exact candidate identity, kompletní release scope, GREEN/AMBER/RED findings a explicitní accepted risks.
+
+`go` nesmí obsahovat accepted risks. `go_with_accepted_risks` musí mít neprázdný explicitní risk set. RED blokuje release promotion.
+
+Automation nesmí decision ani risk set doplnit odhadem.
+
+## 7. Release Scope Gate
+
+`promote-pr` pro release candidate provede read-only live gate nad:
+
+```text
+current release-candidate head
++ candidate hash
++ Milestone DDDA <version>
++ milestone Issues
++ native unresolved blockers
++ Project V2 planning projection
++ accepted-risk follow-up Issues
++ HRDR
+```
+
+Gate je fail-closed.
+
+### PASS invariants
+
+- Milestone identity je jednoznačná.
+- HRDR scope Issues přesně odpovídají current milestone Issues.
+- Všechny current-release Issues jsou closed/terminal.
+- Žádný current-release Issue nemá aktivního blockeru.
+- Project rows mají `Status=Done` a `Blocked=No`.
+- Project planning/delivery view odpovídají governance contractu.
+- Accepted-risk Issues jsou mimo current release milestone a zůstávají open follow-ups.
+- Owner v HRDR odpovídá live owner/assignee kontraktu.
+- Follow-up Issue obsahuje target release/resolution/horizon.
+- HRDR nemá RED.
+- Human Release Decision je pozitivní.
+- live release-candidate head, source SHA, candidate hash a version se shodují.
+
+Chybějící Project credential, nedostupný Project nebo API ambiguity jsou FAIL.
+
+## 8. Release promotion
+
+Dry-run:
+
+```powershell
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version <X.Y.Z> -DryRun
+```
+
+Skutečný release vyžaduje samostatnou explicitní human authorization:
+
+```powershell
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version <X.Y.Z> -ConfirmMerge
+```
+
+Implementation `merge-pr -ConfirmMerge` autorizace se na release nikdy nepřenáší.
+
+## 9. Invalidation
+
+### Human Review implementačního PR
+
+Review se nesmí použít, pokud se změnilo:
+
+- PR HEAD SHA;
+- candidate package hash;
+- judgment-heavy scope relevantní pro review.
+
+### HRDR release candidate
+
+Human Release Decision se nesmí použít, pokud se změnilo:
+
+- release-candidate HEAD SHA;
+- candidate package hash;
+- version;
+- release scope;
+- accepted-risk set/provenance;
+- RED status.
+
+Automation nesmí staré rozhodnutí přemapovat na nový candidate.
+
+## 10. Povinné regressions
+
+### Multi-PR anti-deadlock
+
+```text
+implementation PR CI PASS
+validate-pr PASS
+Human Review PASS
+explicit merge authorization
+AND jiné release-scope Issues jsou stále open
+→ merge-pr může PASS/merge
+→ Release Scope Gate se nevyhodnotí
+→ release/tag side effects = zero
+```
+
+### PR8-class release-scope regression
+
+```text
+release candidate technical evidence PASS
+HRDR positive
+BUT current release Issue open
+→ Release Scope Gate FAIL
+→ release promotion FAIL
+→ release/tag side effects = zero
+```
+
+Stejně pro unresolved blocker nebo Project/Milestone mismatch.
+
+## 11. Authority
+
+```text
+CI/validate-pr/package
+  technical evidence
+
+Human PR Review marker
+  judgment evidence pro implementation PR
+
+merge-pr
+  mechanical implementation merge enforcement
+
+Git/Issue/native dependency/Milestone
+  release-scope authority
+
+GitHub Project
+  validated operational projection
+
+HRDR
+  human release decision evidence
+
+Release Scope Gate + promote-pr
+  mechanical release enforcement
+```
+
+Žádný CI status, Project field ani automation comment nemůže vytvořit Human Review PASS, Human Release Decision ani merge/release authorization.

--- a/docs/developer-guide/human-release-decision-and-release-scope-gate.md
+++ b/docs/developer-guide/human-release-decision-and-release-scope-gate.md
@@ -163,6 +163,7 @@ Automation nesmí decision ani risk set doplnit odhadem.
 ```text
 current release-candidate head
 + candidate hash
++ previous canonical SemVer tag → exact release-source SHA → shipping commit/PR/primary-CR inventory
 + Milestone DDDA <version>
 + milestone Issues
 + native unresolved blockers
@@ -187,6 +188,9 @@ Gate je fail-closed.
 - HRDR nemá RED.
 - Human Release Decision je pozitivní.
 - live release-candidate head, source SHA, candidate hash a version se shodují.
+- každý commit mezi předchozím canonical SemVer tagem a release source je dohledatelný k právě jednomu merged shipping PR a jeho právě jednomu primary CR;
+- každý shipping primary CR je v aktuálním Milestone a jeho Project `Target Release` je stejná verze;
+- physical scope se přesně rovná declared Milestone scope: ani extra shipping CR, ani declared CR bez shipping změny. Při rozdílu gate vydá inventory a `RECOVERY_DECISION_REQUIRED`; nevolí scope expansion ani source recovery.
 
 Chybějící Project credential, nedostupný Project nebo API ambiguity jsou FAIL.
 

--- a/docs/developer-guide/merge-strategy.md
+++ b/docs/developer-guide/merge-strategy.md
@@ -1,0 +1,141 @@
+# Merge strategy řízených DDDA platformních PR
+
+## Účel
+
+Tento runbook konkretizuje ADR 0009 a `config/platform/development-policy.yaml`. Řeší pouze způsob integrace implementačního PR do `main`; nemění Human Review, HRDR, Release Scope Gate ani release/tag authorization.
+
+## Kanonická pravidla
+
+```text
+HIGH / BREAKING
+  merge commit REQUIRED
+  squash forbidden
+  rebase forbidden
+
+LOW / MEDIUM
+  merge commit DEFAULT
+  squash jen s explicitní human squash exception
+  rebase forbidden
+
+UNKNOWN impact
+  merge commit only
+```
+
+Důvodem není preference „hezčího Gitu“, ale auditability exact-SHA evidence. Commit, který prošel CI, `validate-pr` a Human Review, má u HIGH/BREAKING zůstat ancestor výsledného main state.
+
+## Impact classification
+
+Governed PR může nést právě jeden marker `<!-- ddda:change-classification:v1 -->`, bezprostředně následovaný fenced JSON objektem například:
+
+```json
+{"schema_version":1,"impact":"HIGH"}
+```
+
+Povolené hodnoty jsou `LOW`, `MEDIUM`, `HIGH`, `BREAKING`. Pokud marker chybí, merge preflight použije `UNKNOWN` a dovolí pouze merge commit. Duplicitní, malformed nebo nepodporovaný marker failuje closed.
+
+Impact je judgment-heavy governance vstup. Automatizace smí marker validovat, ale nesmí sama změnit risk classification jen proto, aby povolila jiný merge method.
+
+## Dry-run
+
+Default:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr <PR> -DryRun
+```
+
+Explicitní metoda pro kontrolu policy:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr <PR> -MergeMethod merge -DryRun
+```
+
+Pro LOW/MEDIUM lze vyžádat squash pouze po existenci platné human exception:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr <PR> -MergeMethod squash -DryRun
+```
+
+Dry-run musí skončit před `Merge-DDDAGitHubPullRequest`; wrong method, chybějící exception nebo identity drift tedy nemohou vytvořit irreversible side effect.
+
+## Human squash exception
+
+Squash je výjimka, nikoli default. Je povolen pouze pro LOW/MEDIUM a vyžaduje právě jeden PR Conversation comment s markerem `<!-- ddda:squash-exception:v1 -->` a fenced JSON recordem:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "squash_exception",
+  "repository": "romanhlavac/ddd-accelerator",
+  "pr": 123,
+  "validated_source_head_sha": "<40-char-sha>",
+  "candidate_package_sha256": "<64-char-sha256>",
+  "impact": "LOW",
+  "reason": "Proč je ztráta ancestry v tomto nízkorizikovém případě přijatelná.",
+  "reviewer": "<human-login>",
+  "approved_at": "<ISO-8601>"
+}
+```
+
+Marker musí mít lidskou GitHub provenance. `reviewer` musí odpovídat autorovi komentáře. SHA, package hash a impact musí přesně odpovídat current PR candidate. Bot/automation marker, stale SHA nebo prázdný reason znamenají FAIL.
+
+Human squash exception nenahrazuje HVR ani samostatnou merge authorization.
+
+## Post-merge evidence
+
+Pro `merge` se po server-side merge ověřuje:
+
+- validated PR HEAD je parent výsledného merge commit;
+- compare read-back potvrzuje validated HEAD jako ancestor;
+- `result.json` obsahuje `source_to_result_relation=ancestor` a `ancestry_verified=true`.
+
+Pro povolený LOW/MEDIUM squash se ukládá explicitní source→result mapping:
+
+```text
+validated_source_head_sha
+candidate_package_sha256
+resulting_merge_sha
+source_to_result_relation = explicit_squash_mapping
+human squash exception metadata
+```
+
+Post-merge read-back failure se neopravuje force-pushem nebo přepisem shared history. Je to governance failure vyžadující diagnostiku a explicitní recovery rozhodnutí.
+
+## First-parent historie
+
+Pro běžné čtení delivery historie používej:
+
+```bash
+git log --first-parent
+```
+
+Tím zůstává hlavní tok kompaktní, aniž by se ztrácela reviewovaná commit ancestry.
+
+## Prospective bootstrap #70
+
+#70 mění samotný merge contract. Jeho vlastní integraci proto stále řídí pre-existing policy na exact base:
+
+```text
+297f61f6012f180e70805999df2ac1abe9616a05
+```
+
+Tato policy používala squash. Versioned `bootstrap_transition` dovoluje tento jediný exact-base-bound transition a po integraci #70 je neaktivní. Nový contract se aplikuje na následné PR. Historické PR/tagy se nepřepisují.
+
+HVR #70 musí explicitně posoudit a přijmout tento bootstrap trade-off. Technický PASS jej nemůže schválit.
+
+## Release boundary
+
+Merge strategy je implementation-integration concern. Po merge jednotlivých PR stále platí samostatný release-candidate tok:
+
+```text
+integrated work
+→ release candidate
+→ exact-SHA validation
+→ HRDR
+→ Release Scope Gate
+→ Human Release Decision
+→ separate release authorization
+→ release validation
+→ tag
+```
+
+Implementation merge ani squash exception nikdy neautorizují promotion, release nebo tag.

--- a/docs/developer-guide/miro-board-identity-handoff.md
+++ b/docs/developer-guide/miro-board-identity-handoff.md
@@ -1,0 +1,38 @@
+# Miro board identity handoff při acceptance failure
+
+## Účel
+
+Online Miro acceptance může vytvořit dočasný review board a následně selhat ještě před vytvořením child acceptance reportu. Board identity je auditní identifikátor, nikoli secret, a musí zůstat dostupná pro cleanup a evidence i v tomto failure pathu.
+
+## Kontrakt
+
+Jakmile Miro REST `POST /boards` úspěšně vrátí board ID, Miro CLI emituje na stderr jediný explicitní marker:
+
+```text
+DDDA_MIRO_BOARD_ID_HANDOFF:<board-id>
+```
+
+Marker vzniká bezprostředně po úspěšném vytvoření boardu, tedy dříve než navazující render, sync nebo child-report kroky. Neobsahuje token, Authorization metadata ani jiná secret-like data.
+
+`Invoke-DDDAMiroAcceptanceEvidence.ps1` zachytí child stdout/stderr a board identity z markeru načte ještě před kontrolou existence child reportu. Pokud child report existuje, jeho `miro_board_id` musí být buď shodné s handoff identitou, nebo handoff nesmí být přítomen. Rozpor znamená fail-closed.
+
+## Failure semantics
+
+Pokud child selže po vytvoření boardu, ale před child reportem:
+
+- wrapper zachová `board_id` a `board_url` ve fallback evidence;
+- `-CleanupOnFailure` může board deterministicky odstranit;
+- bez cleanup requestu může být board zachován a evidence musí uvést `cleanup.state=preserved`;
+- více různých handoff identit je nejednoznačný stav a wrapper failuje closed;
+- board identity se nikdy neregeneruje odhadem z logu, URL nebo názvu boardu.
+
+Technický PASS tohoto kontraktu nenahrazuje Human Review. Handoff nemění HRDR, Release Scope Gate, release authorization ani tag governance.
+
+## Regression contract
+
+Automatické testy musí minimálně prokázat:
+
+1. create-board proxy emituje přesně jednu identitu ihned po úspěšném vytvoření boardu;
+2. syntetický child failure před reportem stále poskytne board ID/URL wrapperu;
+3. konfliktní handoff identity failují closed;
+4. existující success-path evidence a cleanup kontrakt zůstávají kompatibilní.

--- a/docs/developer-guide/platform-development-lifecycle.md
+++ b/docs/developer-guide/platform-development-lifecycle.md
@@ -146,6 +146,8 @@ INGESTION, CLI, WORKSPACE-GENERATOR, EXAMPLE,
 TESTING, RELEASE, SECURITY-GOVERNANCE
 ```
 
+Impact je `LOW`, `MEDIUM`, `HIGH` nebo `BREAKING`. Pro governed merge jej lze auditovatelně zapsat do PR body markeru `ddda:change-classification:v1`; chybějící marker se při merge považuje za `UNKNOWN` a používá fail-safe merge-commit-only policy.
+
 ## 2. Feature branch a implementace
 
 `main` se nemění přímo. Doporučené názvy:
@@ -231,6 +233,17 @@ Skutečný merge:
 
 `merge-pr` fail-closed ověřuje live PR state, exact head SHA, required CI, exact-SHA `validate-pr`, candidate package hash, Human Review PASS stejného SHA/package, required governance docs a repository merge policy.
 
+Po aktivaci ADR 0009 je merge strategy risk-based:
+
+```text
+HIGH / BREAKING → merge commit REQUIRED
+LOW / MEDIUM    → merge commit DEFAULT; squash jen explicitní human exception
+UNKNOWN         → merge commit only
+rebase           → forbidden
+```
+
+Wrong merge method musí failnout před irreversible merge. Pro canonical merge následuje server-side ancestry read-back: validated PR HEAD musí být parent/ancestor výsledného main state. LOW/MEDIUM squash exception je samostatný human record vázaný na stejné PR/SHA/package/impact; automation jej nesmí vytvořit. Detailní kontrakt je v ADR 0009 a `docs/developer-guide/merge-strategy.md`.
+
 `merge-pr`:
 
 - **nevyhodnocuje HRDR**;
@@ -241,6 +254,12 @@ Skutečný merge:
 - bez explicitního `-ConfirmMerge` nemerguje.
 
 To umožňuje bezpečně integrovat více implementačních PR před sestavením release candidate bez kruhové závislosti na release-scope completeness.
+
+### 6.2 Prospective transition #70
+
+#70 mění samotný merge contract. Jeho vlastní integraci proto stále řídí pre-existing `main` policy z exact base `297f61f6012f180e70805999df2ac1abe9616a05`, která používala squash. Nová merge-commit policy se stává autoritativní až po integraci #70 do `main`.
+
+Transition je versioned, exact-base-bound a single-purpose; není to HIGH/BREAKING squash exception pro budoucí PR. HVR #70 musí tento bootstrap trade-off explicitně posoudit. Historické PR/tagy se nepřepisují.
 
 ## 7. Release candidate a HRDR
 
@@ -283,6 +302,8 @@ Po canonical release-candidate merge vznikne release package; tag se vytvoří a
 
 Work musí rozlišit connector/access failure, implementation failure, CI/test failure, Human Review rejection, implementation merge failure, release-scope failure a release validation failure. Nedokončená práce se nesmí prezentovat jako PASS.
 
+Post-merge ancestry failure se nikdy neopravuje automatickým force-pushem nebo přepisem shared history; vyžaduje zachování diagnostiky a explicitní recovery rozhodnutí.
+
 ## 10. Definition of Done
 
 Implementační PR je připraven k merge pouze když:
@@ -294,6 +315,7 @@ Implementační PR je připraven k merge pouze když:
 - relevantní acceptance je PASS;
 - compatibility/ADR/changelog obligations jsou splněny;
 - mandatory Human Review je PASS pro stejné SHA/package;
+- impact/merge strategy preflight je PASS;
 - merge nebyl proveden bez explicitní human merge authorization.
 
 Release je připraven pouze když navíc existuje validní release candidate, HRDR, Release Scope Gate PASS, explicitní Human Release Decision a samostatná release/promotion authorization. Technický PASS ani implementační merge sám o sobě release neautorizuje.

--- a/docs/developer-guide/platform-development-lifecycle.md
+++ b/docs/developer-guide/platform-development-lifecycle.md
@@ -43,7 +43,7 @@ Před návrhem nebo aplikací změny platformy se musí ověřit:
 - případný rozpor mezi skillem a dokumentací je vyřešen v Gitu.
 ```
 
-Chybějící nebo zastaralá registrace je governance defect. U změn s dopadem `HIGH` nebo `BREAKING` se pokračování zastaví, dokud není routing opraven. Samotná existence skillu v repozitáři není důkazem, že jej runtime používá.
+Chybějící nebo zastaralá registrace je governance defect. U změn s dopadem `HIGH` nebo `BREAKING` se pokračování zastaví, dokud není routing opraven.
 
 ## Povolený Chat/Work operating model
 
@@ -62,30 +62,65 @@ Zakázáno:
 - legacy **`/agent`**;
 - jiný neschválený cloudový coding agent.
 
-GitHub Actions je autoritativní execution plane pro shell, build, testy, candidate package a package-first acceptance. Work nesmí tvrdit, že provedl lokální příkaz, pokud jej ve skutečnosti nespustil schválený execution plane.
+GitHub Actions je autoritativní execution plane pro shell, build, testy, candidate package a package-first acceptance.
 
-Kanonická pravidla jsou v:
+## GitHub authentication contract
+
+Governed merge/release commands používají stejný kanonický provider order:
+
+1. `GH_TOKEN`;
+2. `GITHUB_TOKEN`;
+3. `gh auth token`;
+4. `git credential helper`.
+
+GitHub CLI není povinná závislost. Token se nikdy nepředává jako CLI argument a nesmí se objevit v Chat/Work kontextu, logu, reportu ani shell history. Secret-bearing execution zůstává v GitHub Actions nebo schváleném secret store.
+
+## Kanonické toky
+
+DDDA explicitně odděluje **integraci implementačního PR** od **release/promotion**.
+
+### A. Governed implementation PR
 
 ```text
-docs/developer-guide/chat-work-operating-model.md
-docs/adr/0005-chat-work-only-development-operating-model.md
+change request
+→ branch
+→ implementation
+→ exact-SHA GitHub Actions
+→ validate-pr
+→ Human Review pro stejné SHA/package
+→ merge-pr -DryRun
+→ explicitní human merge authorization
+→ merge-pr -ConfirmMerge
+→ merge do main
+→ NO release package
+→ NO release validation
+→ NO tag
 ```
 
-## Kanonický tok
+`merge-pr` je merge-only command. Nevyžaduje HRDR ani Release Scope Gate a nesmí dosáhnout release/tag execution path.
+
+### B. Release candidate
+
+Až když je práce určená pro release integrována a release-scope Issues jsou terminal nebo explicitně deferred mimo release:
 
 ```text
-change request v Chat nebo Work
-→ branch
-→ Work implementation přes schválené Apps
-→ standardní GitHub Actions nad exact SHA
-→ validate-pr
-→ human review
-→ promote-pr
-→ merge
+release candidate (typicky release/<version> PR nebo ekvivalentní governed candidate)
+→ exact-SHA candidate validation
+→ release cut / changelog consistency
+→ HRDR pro exact release candidate
+→ Release Scope Gate
+→ promotion dry-run
+→ explicitní Human Release Decision
+→ samostatná explicitní release/promotion authorization
+→ canonical promotion
+→ release-candidate merge, pokud je součástí canonical workflow
 → release package
 → release validation
+→ release report
 → tag
 ```
+
+Release Scope Gate zůstává striktní. Neaplikuje se ale jako podmínka integrace jednotlivých implementačních PR, jejichž merge je předpokladem pro uzavření release scope.
 
 Git je source of truth. PR je jednotka změny. Package je jednotka distribuce a reprodukovatelné validace.
 
@@ -124,15 +159,7 @@ release/<version>
 
 Behaviorální změna bez testu je neúplná. Změna kontraktu bez dokumentace a compatibility rozhodnutí je neúplná.
 
-Work před prvním zápisem ověří:
-
-- aktuální PR head SHA;
-- deklarovanou target branch;
-- allowed paths;
-- že autorizace neobsahuje merge, promotion, release, tag ani force-push;
-- že požadovaný GitHub/Miro connector je skutečně dostupný.
-
-Pokud connector, board nebo oprávnění nejsou dostupné, Work zastaví a omezení oznámí. Nesmí je tiše nahradit předpokladem.
+Work před prvním zápisem ověří aktuální PR head SHA, target branch, allowed paths, side-effect authorization a dostupnost connectorů.
 
 ## 3. Test suites a execution plane
 
@@ -148,32 +175,15 @@ Stabilní platformní kontrakt:
 .\ddda.ps1 test -Suite security
 ```
 
-Na Chat/Work-only cestě tyto příkazy spouštějí standardní GitHub Actions workflows. Uživatel nemusí poskytovat Work lokální shell a nesmí být směrován do Codexu.
-
-Package-dependent suites dostávají `-PackagePath` a používají nově rozbalený balíček.
+Na Chat/Work-only cestě tyto příkazy spouštějí standardní GitHub Actions workflows.
 
 ## 4. Candidate package
 
 `validate-pr` načte exact PR head SHA, vytvoří izolovaný checkout a candidate package pomocí `git archive`. Package dostane `ddda-package.json` s původem, verzí a source commit SHA.
 
-Package nesmí obsahovat:
-
-```text
-.git/
-.ddda/
-.tmp/
-.reports/
-.releases/
-dist/
-Python caches
-credentials
-client data
-uživatelské absolutní cesty
-```
+Package nesmí obsahovat `.git/`, `.ddda/`, `.tmp/`, reports, releases, dist, caches, credentials, client data ani uživatelské absolutní cesty.
 
 ## 5. Validace PR
-
-Stabilní kontrakt:
 
 ```powershell
 .\ddda.ps1 validate-pr -Pr 8
@@ -185,144 +195,105 @@ S Miro:
 .\ddda.ps1 validate-pr -Pr 8 -WithMiro -Full -CleanupOnFailure
 ```
 
-V Chat/Work-only režimu jej spouští standardní PR workflow nebo remote validation broker.
+Příkaz ověřuje exact PR SHA, candidate package, package-first suites, example workspace, ingestion, acceptance a report.
 
-Příkaz:
+## 6. Human Review implementačního PR
 
-1. ověří čistý aktivní repozitář;
-2. načte `refs/pull/<PR>/head`;
-3. vytvoří izolovaný checkout exact SHA;
-4. vytvoří a validuje candidate package;
-5. rozbalí package do nového adresáře;
-6. inicializuje lokální baseline Git pouze pro testy, nikoli jako distribuovaný obsah;
-7. spustí test suites;
-8. vytvoří example workspace z package;
-9. provede manifest-driven ingestion;
-10. ověří G1 → G2;
-11. volitelně provede Miro acceptance;
-12. vytvoří JSON a Markdown report.
+Člověk posuzuje judgment-heavy oblasti, zejména metodiku, architekturu, semantics gatů, použitelnost a relevantní rizika. Syntax, schemas, packaging, idempotence a absence secrets kontroluje automatizace.
 
-PASS automaticky uklidí pracovní clone a workspaces, pokud není použito `-KeepArtifacts`. Report a candidate package zůstávají pro promotion.
+Human Review implementačního PR musí být auditovatelně vázán minimálně na:
 
-## 6. Lidské review
-
-Člověk posuzuje pouze oblasti vyžadující judgment:
-
-- metodickou správnost;
-- architektonické hranice;
-- semantics gatů;
-- srozumitelnost chat-first workflow;
-- vizuální kvalitu Miro boardu;
-- release readiness a přijetí rizik.
-
-Syntax, schémata, cesty, packaging, idempotence a absence secrets kontroluje automatizace.
-
-### Miro visual review
-
-Před tvrzením, že implementace odpovídá redline nebo referenčnímu boardu, musí Work skutečně načíst:
-
-- referenční board;
-- konkrétní source frames;
-- relevantní children, images a geometry;
-- cílové frames pro side-by-side porovnání.
-
-Vizuální acceptance hodnotí minimálně:
-
-- čitelnost při `Fit to frame`;
-- first-viewer srozumitelnost;
-- fonty a vizuální hierarchii;
-- překryvy frames/items;
-- využití plochy;
-- přítomnost požadovaných obrázků a examples;
-- věrnost schválenému template;
-- metodickou a doménovou koherenci.
-
-Item count, parent ownership, schema PASS a idempotence nejsou visual acceptance. Technický PASS ponechává `human_review_status=PENDING`, dokud člověk výsledek nepřijme.
-
-## 7. GitHub autentizace a release dokumentace
-
-`promote-pr` používá GitHub REST API. GitHub CLI není povinná závislost. Implementace i dokumentace používají stejné pořadí providerů:
-
-1. `GH_TOKEN`;
-2. `GITHUB_TOKEN`;
-3. `gh auth token`;
-4. Git credential helper.
-
-Token se nikdy nepředává jako CLI argument a nesmí se objevit v logu, reportu, Chat/Work kontextu ani shell history.
-
-Během vývoje se změny zapisují pod `## [Unreleased]`. Před promotion se všechny release položky přesunou pod právě jednu sekci `## [X.Y.Z] - YYYY-MM-DD`, `Unreleased` zůstane bez release položek a stejná verze se předá jako `-Version X.Y.Z`. Tag je deterministicky `vX.Y.Z`.
-
-Promotion preflight kontroluje syntaxi changelogu, platné ISO datum, neprázdnou release sekci, prázdnou `Unreleased` sekci a shodu verze s parametrem promotion.
-
-## 8. Promotion
-
-Nejdřív bezpečný preflight:
-
-```powershell
-.\ddda.ps1 promote-pr -Pr 8 -Version 0.8.0 -DryRun
+```text
+repository
+pr
+reviewed_sha
+candidate_package_sha256
+reviewer
+reviewed_at
+verdict
 ```
 
-Skutečný promotion vyžaduje explicitní potvrzení:
+`PASS` Human Review je oddělen od **merge authorization**. Změna reviewed SHA nebo candidate package hash Human Review pro merge invaliduje.
+
+### 6.1 Governed implementation merge
+
+Bezpečný preflight:
 
 ```powershell
-.\ddda.ps1 promote-pr -Pr 8 -Version 0.8.0 -ConfirmMerge
+.\ddda.ps1 merge-pr -Pr 74 -DryRun
 ```
 
-Promotion je fail-closed. Ověřuje:
+Skutečný merge:
 
-- PR je otevřený a není draft;
-- head SHA se nezměnil;
-- CI checks jsou PASS;
-- validation report je PASS pro stejný SHA;
-- candidate package hash odpovídá reportu;
-- approvals odpovídají repository policy;
-- povinné ADR, changelog a migration note existují;
-- changelog release verze odpovídá `-Version` a budoucímu tagu `vX.Y.Z`;
-- `Unreleased` neobsahuje nepřiřazené release položky;
-- `-ConfirmMerge` je explicitně zadáno.
+```powershell
+.\ddda.ps1 merge-pr -Pr 74 -ConfirmMerge
+```
 
-Po merge vznikne release package. Tag se vytvoří až po package validation, generated release workspace, ingestion, smoke a acceptance.
+`merge-pr` fail-closed ověřuje live PR state, exact head SHA, required CI, exact-SHA `validate-pr`, candidate package hash, Human Review PASS stejného SHA/package, required governance docs a repository merge policy.
+
+`merge-pr`:
+
+- **nevyhodnocuje HRDR**;
+- **nevyhodnocuje Release Scope Gate**;
+- **nevytváří release package**;
+- **nespouští release validation**;
+- **nevytváří tag**;
+- bez explicitního `-ConfirmMerge` nemerguje.
+
+To umožňuje bezpečně integrovat více implementačních PR před sestavením release candidate bez kruhové závislosti na release-scope completeness.
+
+## 7. Release candidate a HRDR
+
+Po integraci zahrnutých implementačních PR se připraví explicitní release candidate. Pro jeho exact SHA se provede standardní validation a vytvoří Human Release Decision Record.
+
+HRDR je **release decision evidence**, nikoli implementační merge evidence. Obsahuje exact release-candidate identity, findings, residual risks, reviewer/decision owner a explicitní lidské rozhodnutí.
+
+Během vývoje se změny zapisují pod `## [Unreleased]`. Před promotion se release položky přesunou pod právě jednu sekci `## [X.Y.Z] - YYYY-MM-DD`; stejná verze se předá jako `-Version X.Y.Z` a tag je `vX.Y.Z`.
+
+## 8. Release Scope Gate a promotion
+
+Release Scope Gate se vyhodnocuje **výhradně na release-candidate boundary**.
+
+```powershell
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version <X.Y.Z> -DryRun
+```
+
+Gate fail-closed ověřuje zejména:
+
+- current release/version/milestone identity;
+- všechny release-scope Issues terminal nebo explicitně deferred mimo release;
+- žádné unresolved native blockers;
+- Project/Milestone consistency;
+- accepted-risk owner/follow-up/horizon;
+- přesnou shodu HRDR risk setu;
+- žádný RED/neakceptovaný blocker;
+- exact SHA/package/version identity.
+
+Skutečný promotion vyžaduje novou explicitní lidskou autorizaci:
+
+```powershell
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version <X.Y.Z> -ConfirmMerge
+```
+
+Implementation merge authorization nikdy neimplikuje release/promotion/tag authorization.
+
+Po canonical release-candidate merge vznikne release package; tag se vytvoří až po package validation, generated release workspace, ingestion, smoke a acceptance PASS.
 
 ## 9. Selhání a diagnostika
 
-Lokální stav je pod uživatelským DDDA state rootem:
-
-```text
-validation/
-validation-reports/
-packages/
-promotion/
-release-reports/
-```
-
-Při FAIL zůstávají logy a diagnostický workspace. Miro board lze při testu odstranit přes `-CleanupOnFailure`.
-
-Work musí rozlišit:
-
-- connector/access failure;
-- implementation failure;
-- CI/test failure;
-- human review rejection.
-
-Nesmí je sloučit do neurčitého statusu ani prezentovat nedokončenou práci jako PASS.
+Work musí rozlišit connector/access failure, implementation failure, CI/test failure, Human Review rejection, implementation merge failure, release-scope failure a release validation failure. Nedokončená práce se nesmí prezentovat jako PASS.
 
 ## 10. Definition of Done
 
-PR je hotový, když:
+Implementační PR je připraven k merge pouze když:
 
 - implementace, testy a dokumentace tvoří jeden change package;
 - CI je PASS;
 - `validate-pr` je PASS pro aktuální head SHA;
 - candidate package je validní;
-- example workspace vznikl z package;
-- ingestion je manifest-driven;
-- acceptance je PASS;
-- změna kompatibility má migration note;
-- dlouhodobé rozhodnutí má ADR;
-- changelog je aktualizován;
-- povinný platform-development skill je verzovaný a runtime routing jej skutečně načítá;
-- Chat/Work-only policy je splněna;
-- connector a visual-access omezení byla transparentně uvedena;
-- secrets nevstoupily do Chat nebo Work kontextu;
-- Codex ani `/agent` nebyly použity;
-- merge nebyl proveden bez explicitního lidského rozhodnutí.
+- relevantní acceptance je PASS;
+- compatibility/ADR/changelog obligations jsou splněny;
+- mandatory Human Review je PASS pro stejné SHA/package;
+- merge nebyl proveden bez explicitní human merge authorization.
+
+Release je připraven pouze když navíc existuje validní release candidate, HRDR, Release Scope Gate PASS, explicitní Human Release Decision a samostatná release/promotion authorization. Technický PASS ani implementační merge sám o sobě release neautorizuje.

--- a/docs/developer-guide/platform-development-lifecycle.md
+++ b/docs/developer-guide/platform-development-lifecycle.md
@@ -122,6 +122,8 @@ release candidate (typicky release/<version> PR nebo ekvivalentní governed cand
 
 Release Scope Gate zůstává striktní. Neaplikuje se ale jako podmínka integrace jednotlivých implementačních PR, jejichž merge je předpokladem pro uzavření release scope.
 
+Dokud je otevřený právě jeden release train `DDDA X.Y.Z`, `merge-pr` navíc fail-closed odmítne PR, jehož jediný primary CR není v jeho Milestone. To je prevence nové kontaminace `main`; není to Release Scope Gate ani release authorization.
+
 Git je source of truth. PR je jednotka změny. Package je jednotka distribuce a reprodukovatelné validace.
 
 ## 1. Příprava změny
@@ -181,7 +183,11 @@ Na Chat/Work-only cestě tyto příkazy spouštějí standardní GitHub Actions 
 
 ## 4. Candidate package
 
-`validate-pr` načte exact PR head SHA, vytvoří izolovaný checkout a candidate package pomocí `git archive`. Package dostane `ddda-package.json` s původem, verzí a source commit SHA.
+Standardní PR CI načte exact PR head SHA a vytvoří pomocí `git archive` právě jeden canonical candidate package. Stabilní package metadata jsou odvozena z exact SHA; package dostane `ddda-package.json` s původem, verzí a `source_commit`.
+
+Navazující `validate-pr-command` čeká na package job, stáhne jeho exact-SHA artifact a předá ZIP do `validate-pr -PackagePath`. V tomto režimu `validate-pr` package znovu nesestavuje: ověří `kind=candidate`, `source_commit=current PR HEAD`, přepočítá SHA-256 a stejný hash zapíše do `result.json` i `result.md`. Lokální spuštění bez `-PackagePath` zůstává convenience cestou, ale jeho package není CI governance evidence.
+
+Candidate artifact a validation report jsou společně dohledatelné přes repository, PR, exact HEAD SHA, workflow run, artifact ID/name a package SHA-256. Publikovaný report používá přenositelné reference; runner-local cesta není součástí evidence.
 
 Package nesmí obsahovat `.git/`, `.ddda/`, `.tmp/`, reports, releases, dist, caches, credentials, client data ani uživatelské absolutní cesty.
 
@@ -231,7 +237,7 @@ Skutečný merge:
 .\ddda.ps1 merge-pr -Pr 74 -ConfirmMerge
 ```
 
-`merge-pr` fail-closed ověřuje live PR state, exact head SHA, required CI, exact-SHA `validate-pr`, candidate package hash, Human Review PASS stejného SHA/package, required governance docs a repository merge policy.
+`merge-pr` fail-closed ověřuje live PR state, exact head SHA, required CI, exact-SHA `validate-pr`, candidate package hash, Human Review PASS stejného SHA/package, required governance docs a repository merge policy. Standardní CI nejprve spustí samostatný `Human Review readiness` coordinator. Dokud chybí Human Review marker, vlastní `Governed merge dry-run` job je `skipped` a merge preflight má stav `NOT_RUN`; úspěch coordinatoru není merge-preflight PASS. Po publikaci exact-SHA Human Review se znovu spustí readiness job a jeho dependent dry-run bez nového candidate buildu. Dry-run na čistém runneru stáhne candidate i report ze stejného workflow runu a předá jejich nové lokální cesty přes `-PackagePath` a `-ValidationReportPath`; nikdy nepoužívá cestu uloženou na předchozím runneru.
 
 Po aktivaci ADR 0009 je merge strategy risk-based:
 

--- a/docs/developer-guide/platform-development-lifecycle.md
+++ b/docs/developer-guide/platform-development-lifecycle.md
@@ -118,6 +118,7 @@ release candidate (typicky release/<version> PR nebo ekvivalentní governed cand
 → release validation
 → release report
 → tag
+→ GitHub Release s canonical package a release-evidence assets
 ```
 
 Release Scope Gate zůstává striktní. Neaplikuje se ale jako podmínka integrace jednotlivých implementačních PR, jejichž merge je předpokladem pro uzavření release scope.

--- a/docs/developer-guide/release-tag-recovery.md
+++ b/docs/developer-guide/release-tag-recovery.md
@@ -73,3 +73,7 @@ result
 ```
 
 `result=PASS` je možné pouze tehdy, když fresh remote read-back prokáže canonical tag na exact validated release SHA. Technický recovery PASS nenahrazuje žádné další Human Release Decision nebo release governance rozhodnutí, které je podle aktuálního lifecycle stále vyžadováno.
+
+## Navazující GitHub Release publication
+
+Canonical tag sám o sobě není published DDDA distribution. Po vytvoření tagu musí promotion vytvořit nebo fresh read-backem ověřit GitHub Release a jeho canonical package/report assets. Pokud tag existuje, ale Release nebo některý asset chybí, tag se nepřepisuje; postupuje se podle `github-release-publication.md` se samostatnou recovery authorization.

--- a/docs/developer-guide/release-tag-recovery.md
+++ b/docs/developer-guide/release-tag-recovery.md
@@ -1,0 +1,75 @@
+# Recovery canonical annotated release tagu
+
+## Účel
+
+Tento runbook platí pouze pro úzký případ, kdy canonical release promotion už vytvořil a úspěšně validoval release package a release report, ale finální annotated-tag krok selhal při vytvoření, push nebo následném read-backu.
+
+Selhání tagu po validačním PASS neznamená `RELEASED`. Release zůstává nedokončený, dokud canonical tag neexistuje a neprojde read-backem.
+
+## Preconditions
+
+Recovery je přípustná pouze po **separate explicit human recovery authorization**. Před jakýmkoli zápisem musí být doloženo:
+
+- same version jako v původním promotion;
+- same validated release SHA;
+- same release report se stavem PASS;
+- same release package SHA-256;
+- canonical tag odvozený ze stejného release/version kontraktu;
+- žádná nová release validation ani jiný release candidate mezitím nenahradily původní evidence.
+
+Pokud některý z těchto invariantů nelze prokázat, recovery se zastaví fail closed a musí se rozhodnout nový release postup.
+
+## Deterministic tagger identity
+
+Canonical annotated tag používá ne-secret identitu:
+
+```text
+DDDA Release Tagger <ddda-release-tagger@example.invalid>
+```
+
+`promote-pr` ji nastavuje pouze v izolovaném `release-source` clone. Nespoléhá na runner/global `user.name` ani `user.email` a nepoužívá token nebo osobní identitu jako tagger metadata.
+
+Canonical message zůstává přesně:
+
+```text
+DDDA <version>
+```
+
+Tag musí dereferencovat na same validated release SHA.
+
+## Bounded recovery
+
+Recovery neopakuje implementation merge ani celý promotion jen kvůli mechanickému tag failure.
+
+Nejdříve proveď fresh read-back existing canonical tagu:
+
+1. **Tag chybí** — po explicitní recovery authorization lze zopakovat pouze vytvoření canonical annotated tagu se stejnou verzí, stejným validated release SHA, canonical message a deterministic tagger identity; poté push a fresh read-back.
+2. **Tag existuje a přesně odpovídá** očekávanému target SHA, message a canonical identity — neprováděj další mutation; read-back je evidence dokončení tag kroku.
+3. **Existing canonical tag existuje, ale liší se** target SHA, message nebo očekávaný význam — recovery okamžitě fail closed. Tag se nesmí přepsat ani přesunout.
+
+Recovery nikdy:
+
+- nepřepisuje ani nepřesouvá existing canonical tag;
+- nepoužívá force push;
+- nemění release package ani release report;
+- neopakuje merge bez nové odpovídající autorizace;
+- dodržuje invariant `no history rewrite` a neprovádí jiný přepis Git historie.
+
+## Evidence
+
+Recovery evidence musí minimálně obsahovat:
+
+```text
+repository
+version
+canonical_tag
+validated_release_sha
+release_package_sha256
+release_report
+human_recovery_authorization
+remote_tag_state_before
+remote_tag_state_after
+result
+```
+
+`result=PASS` je možné pouze tehdy, když fresh remote read-back prokáže canonical tag na exact validated release SHA. Technický recovery PASS nenahrazuje žádné další Human Release Decision nebo release governance rozhodnutí, které je podle aktuálního lifecycle stále vyžadováno.

--- a/docs/developer-guide/testing-strategy.md
+++ b/docs/developer-guide/testing-strategy.md
@@ -14,6 +14,7 @@ DDDA netestuje pouze kód. Testuje také:
 - example workspaces;
 - Miro mapping a idempotenci;
 - release lifecycle.
+- identity GitHub Release publication a fyzické SHA-256 canonical release assets.
 
 Automatizace řeší mechanické kontroly. Manuální review zůstává pro judgment.
 
@@ -124,6 +125,8 @@ Test běží v component, integration i regression suite, aby byl kontrakt vidit
 ## Package-first validace
 
 Smoke, integration, E2E a acceptance během `validate-pr` běží z nově rozbaleného candidate package. Lokální Git baseline vytvořená uvnitř rozbaleného package slouží jen k ověření Git guardrails a není součástí distribuovaného ZIP.
+
+CI contract test navíc dokládá single-candidate invariant: `validate-platform` je jediný production candidate builder, `validate-pr-command` na něj explicitně čeká a sekundární workflow ani remote broker nevytvářejí paralelní candidate package. Regrese pokrývají reuse přes `-PackagePath`, odmítnutí jiného `source_commit` nebo `kind`, shodu artifact/report hashe, fail-closed chybějící či víceznačnou evidence, portable report bez secretů a absolutních uživatelských cest a isolated `merge-pr -DryRun` bez lokálního validation adresáře. Samostatně chrání pre-HR semantiku: readiness coordinator nesmí být vydáván za merge-preflight PASS, dependent dry-run je bez Human Review `skipped`/`NOT_RUN` a po Human Review znovu používá existující exact-run candidate místo rebuildu.
 
 Tím se odděluje:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -32,46 +32,75 @@ acceptance
 all
 ```
 
-Package-dependent suites dostávají:
-
-```powershell
-.\ddda.ps1 test -Suite e2e -PackagePath $PackagePath
-```
-
-Online acceptance:
-
-```powershell
-.\ddda.ps1 test -Suite acceptance -WithMiro -Full -CleanupOnFailure
-```
-
 ### Validate PR
 
 ```powershell
-.\ddda.ps1 validate-pr -Pr 8
+.\ddda.ps1 validate-pr -Pr 74
 ```
 
 Volitelné parametry:
 
 - `-WithMiro` — přidá online Miro acceptance;
 - `-Full` — plný Miro smoke rozsah;
-- `-CleanupOnFailure` — odstraní neúspěšný testovací Miro board, pokud je znám;
-- `-KeepArtifacts` — zachová isolated checkout a workspaces i při PASS;
+- `-CleanupOnFailure` — uklidí failed test resource podle ownership policy;
+- `-KeepArtifacts` — zachová isolated validation artifacts;
 - `-NonInteractive` — nepovolí prompt pro chybějící secret.
 
 Příkaz testuje exact PR head SHA, candidate package a generovaný example workspace. Aktivní větev a working tree nemění.
 
-### Promote PR
+### Merge PR
+
+Governed implementation merge je samostatný příkaz oddělený od release promotion.
 
 Preflight:
 
 ```powershell
-.\ddda.ps1 promote-pr -Pr 8 -Version 0.8.0 -DryRun
+.\ddda.ps1 merge-pr -Pr 74 -DryRun
+```
+
+Skutečný merge:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr 74 -ConfirmMerge
+```
+
+`merge-pr` vyžaduje:
+
+- open/ready/mergeable PR do canonical base;
+- PASS required checks pro live exact head SHA;
+- PASS `validate-pr` evidence pro stejné SHA;
+- shodný candidate package SHA-256;
+- právě jeden authoritativní Human Review marker `ddda:human-pr-review:v1` s lidskou provenance;
+- Human Review `pass` pro stejné PR/SHA/package;
+- required governance documents;
+- explicitní `-ConfirmMerge` pro actual merge.
+
+`merge-pr` je **merge-only**. Nečte HRDR, nevyhodnocuje Release Scope Gate a nevytváří release package, release validation ani tag.
+
+### Review PR / HRDR scaffold
+
+`review-pr` je release-candidate command. Po frozen release-candidate validaci lze vytvořit HRDR scaffold:
+
+```powershell
+.\ddda.ps1 review-pr -Pr <RELEASE_PR> -Version 0.1.1 -Reviewer <login> -DecisionOwner <login> -PublishScaffold
+```
+
+Automation vytváří pouze `decision=pending`; nevytváří `GO`, nepřijímá residual risk a nevolí člověka, který smí release rozhodnout.
+
+### Promote PR
+
+`promote-pr` je **release command**, ne obecný implementation merge command.
+
+Preflight:
+
+```powershell
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version 0.1.1 -DryRun
 ```
 
 Skutečný promotion:
 
 ```powershell
-.\ddda.ps1 promote-pr -Pr 8 -Version 0.8.0 -ConfirmMerge
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version 0.1.1 -ConfirmMerge
 ```
 
 Volitelné parametry:
@@ -80,13 +109,19 @@ Volitelné parametry:
 - `-KeepArtifacts` — zachová promotion workspace;
 - `-NonInteractive` — zakáže secret prompt.
 
-`-ConfirmMerge` je povinná explicitní approval boundary. Bez něj se merge neprovede.
+Public `promote-pr` nejdříve fail-closed validuje právě jeden authoritativní human HRDR a Release Scope Gate nad live Milestone, native blockers a GitHub Project V2 projection. Interní release executor se nespustí, dokud gate není `PASS`.
 
-GitHub autentizace se načítá v pořadí `GH_TOKEN` → `GITHUB_TOKEN` → `gh auth token` → Git credential helper. GitHub CLI není povinný. Token nemá veřejný CLI parametr.
+`-ConfirmMerge` zde znamená explicitní **release/promotion authorization** pro release candidate. Předchozí implementation `merge-pr -ConfirmMerge` authorization se sem nepřenáší.
 
-Preflight vyžaduje release sekci `## [X.Y.Z] - YYYY-MM-DD` odpovídající `-Version X.Y.Z`, prázdnou `## [Unreleased]` sekci a volný tag `vX.Y.Z`.
+GitHub autentizace se načítá v pořadí `GH_TOKEN` → `GITHUB_TOKEN` → `gh auth token` → Git credential helper. GitHub CLI není povinný. Release Scope Gate navíc používá `DDDA_GITHUB_PROJECT_TOKEN` pouze ze secret store/process environment.
+
+Během běžného vývoje mohou být release položky pod `## [Unreleased]`. Promotion preflight vyžaduje release sekci `## [X.Y.Z] - YYYY-MM-DD` odpovídající `-Version X.Y.Z`, prázdnou release-content část `Unreleased` a volný tag `vX.Y.Z`.
 
 ## Interní platform lifecycle skripty
+
+### `Invoke-DDDAGovernedMergePr.ps1`
+
+Governed implementation merge executor. Ověří exact-SHA CI, `validate-pr`, candidate package hash a Human Review evidence. `-DryRun` je bez side effects; actual merge vyžaduje `-ConfirmMerge`. Script nesmí volat HRDR, Release Scope Gate, release package/validation ani tag path.
 
 ### `New-DDDAPlatformPackage.ps1`
 
@@ -98,15 +133,23 @@ Kontroluje manifest, package hash, povinné soubory, zakázané lokální cesty,
 
 ### `Invoke-DDDAExampleIngestion.ps1`
 
-Načte `examples/minimal/manifest.yaml`, ověří source/target boundaries, zkopíruje syntetické vstupy a vytvoří ingestion report.
+Načte example manifest, ověří source/target boundaries, ingestuje syntetické vstupy a vytvoří report.
 
 ### `New-DDDAValidationWorkspace.ps1`
 
-Z rozbaleného package vytvoří workspace, ingestuje minimal example a inicializuje steering projekt v `align/G1`.
+Z rozbaleného package vytvoří workspace a inicializuje validation scenario.
 
 ### `New-DDDAValidationReport.ps1`
 
 Vytvoří JSON a Markdown validation report svázaný se source SHA a package SHA-256.
+
+### `Invoke-DDDAGovernedPromotePr.ps1`
+
+Read-only governance wrapper pro release `promote-pr`: ověří HRDR human provenance, exact release-candidate identity a Release Scope Gate; teprve po PASS deleguje na interní release executor.
+
+### `Test-DDDAReleaseScope.py`
+
+Read-only collector/evaluator live GitHub release scope. Používá Milestone/Issue/native dependency evidence a Project V2 read-back. Chybějící/nejednoznačná evidence je FAIL.
 
 ## Project steering compatibility commands
 
@@ -116,35 +159,16 @@ Instaluje izolovaný Python runtime do `.ddda/runtime/steering-venv`.
 
 ### `Initialize-DDDAProjectFirstRun.ps1`
 
-Povinné parametry: `-WorkspaceRoot`, `-IntakeFile`.
-
-Důležité přepínače:
-
-- `-WithMiro` — vytvoří a otestuje projektový board;
-- `-Resume` — bezpečně pokračuje v existujícím projektu;
-- `-NoInitialCommit` — pouze pro offline testy;
-- `-NonInteractive` — zakáže prompt na chybějící token;
-- `-ForceRecreateRuntime` — znovu vytvoří steering runtime.
+Inicializuje konkrétní DDDA project workspace. Project runtime je oddělen od platform-development merge/release lifecycle.
 
 ### `Get-DDDAProjectStatus.ps1`
 
-Výchozí režim je read-only a načte `reports/project-status.yaml` bez změny Git working tree.
-
-- `-Json` — vrátí strojově čitelný výstup;
-- `-Refresh` — explicitně přepočítá a zapíše current status, next actions a status report.
-
-Po `-Refresh` zkontroluj a commitni změny před navazující Miro operací.
+Výchozí režim je read-only; `-Refresh` explicitně přepočítá status.
 
 ### `Test-DDDAGates.ps1`
 
-Vypíše evidence status všech gatů nebo jedné gate přes `-Gate`.
+Vypíše evidence status projektových gatů.
 
 ### `Complete-DDDALifecycleStep.ps1`
 
-Zaznamená explicitní outcome `passed`, `conditional` nebo `rejected`. `-Commit` vytvoří lokální commit po `diff --check`; push ani merge neprovádí.
-
-### `Test-DDDAAcceptance.ps1`
-
-```powershell
-.\scripts\Test-DDDAAcceptance.ps1 -Suite project-steering [-WithMiro] [-Full] [-KeepReviewBoard] [-MiroTeamId <team-id>] [-CleanupOnFailure]
-```
+Zaznamená explicitní project-gate outcome. Produkční human decision nesmí vytvářet automatizace.

--- a/docs/user-guide/validate-and-promote-pr.md
+++ b/docs/user-guide/validate-and-promote-pr.md
@@ -194,6 +194,7 @@ Canonical promotion po PASS gate:
 5. provede ingestion, security, smoke, E2E a acceptance;
 6. vytvoří release report;
 7. vytvoří/pushne tag až po PASS.
+8. vytvoří GitHub Release pro canonical tag a publikuje validated DDDA ZIP, `result.json` a `result.md`; fresh read-back ověří identity a SHA-256 assets.
 
 Při release validation FAIL se tag nevytvoří.
 

--- a/docs/user-guide/validate-and-promote-pr.md
+++ b/docs/user-guide/validate-and-promote-pr.md
@@ -59,9 +59,33 @@ Dry-run fail-closed ověří:
 - existuje právě jeden authoritativní Human Review marker `ddda:human-pr-review:v1`;
 - Human Review má lidskou provenance, stejné PR/SHA/package a verdict `pass`;
 - required governance documents existují;
-- merge method odpovídá repository policy.
+- impact classification a merge method odpovídají repository merge-strategy policy.
 
 Dry-run neprovede merge, release, promotion ani tag.
+
+### Merge strategy a exact-SHA ancestry
+
+Po aktivaci ADR 0009 je canonical default `merge`:
+
+```text
+HIGH / BREAKING → merge commit REQUIRED
+LOW / MEDIUM    → merge commit DEFAULT
+UNKNOWN impact  → merge commit only
+rebase           → forbidden
+```
+
+LOW/MEDIUM může použít `squash` pouze s explicitním lidským `ddda:squash-exception:v1` recordem pro stejné PR/SHA/package/impact. Automation tuto exception nesmí vytvořit ani inferovat.
+
+Explicitní dry-run varianty:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr 74 -MergeMethod merge -DryRun
+.\ddda.ps1 merge-pr -Pr <LOW_OR_MEDIUM_PR> -MergeMethod squash -DryRun
+```
+
+Pro canonical merge se po skutečném merge server-side ověří, že validated PR HEAD je parent/ancestor výsledného main state. Evidence používá `source_to_result_relation=ancestor`. U schváleného LOW/MEDIUM squash se místo ancestry ukládá explicitní source→result mapping s human exception metadata.
+
+Detailní contract je v `docs/developer-guide/merge-strategy.md` a ADR 0009.
 
 Skutečný implementation merge:
 
@@ -189,5 +213,7 @@ release-reports/
 - běžné testy nikdy nemergují ani netagují;
 - Human Review PASS nevytváří automation;
 - merge authorization a release authorization jsou oddělené;
+- wrong merge method musí failnout před irreversible side effect;
+- LOW/MEDIUM squash exception musí mít lidskou provenance a exact candidate binding;
 - `merge-pr` nesmí být release bypass;
 - `promote-pr` nesmí být použit jako obecný mechanismus merge implementačních PR.

--- a/docs/user-guide/validate-and-promote-pr.md
+++ b/docs/user-guide/validate-and-promote-pr.md
@@ -1,18 +1,21 @@
-# Validace a promotion DDDA platformního PR
+# Validace, governed merge a promotion DDDA platformního PR
 
 ## Předpoklady
 
 - pracuješ v čistém clone DDDA platformy;
 - `origin` ukazuje na GitHub repository;
 - je dostupný Git a Python 3.11+;
-- pro `promote-pr` je dostupná GitHub autentizace alespoň jedním z podporovaných způsobů, v tomto pořadí preference:
-  1. environment variable `GH_TOKEN`;
-  2. environment variable `GITHUB_TOKEN`;
-  3. token z autentizovaného GitHub CLI přes `gh auth token`;
-  4. existující Git credential helper použitý už pro clone/push;
-- pro online Miro test je token uložen v DDDA secret store nebo environment variable.
+- GitHub autentizace používá podporovaný provider chain;
+- secret-bearing online acceptance běží v GitHub Actions / schváleném secret store.
 
-GitHub CLI není povinná závislost. Promotion používá GitHub REST API a automaticky preferuje `GH_TOKEN`, potom `GITHUB_TOKEN`, potom token z `gh auth token` a nakonec existující Git credential helper. Token se nevypisuje ani nepředává jako CLI argument.
+Kanonický GitHub authentication provider order je:
+
+1. `GH_TOKEN`;
+2. `GITHUB_TOKEN`;
+3. `gh auth token`;
+4. `git credential helper`.
+
+GitHub CLI není povinná závislost. GitHub token se nikdy nevypisuje ani nepředává jako veřejný CLI argument a nesmí se objevit v Chat/Work kontextu, logu, reportu ani shell history.
 
 Stav ověř:
 
@@ -25,159 +28,152 @@ Stav ověř:
 Offline:
 
 ```powershell
-.\ddda.ps1 validate-pr -Pr 8
+.\ddda.ps1 validate-pr -Pr 74
 ```
 
-Včetně Miro:
+Včetně Miro, pokud je relevantní:
 
 ```powershell
-.\ddda.ps1 validate-pr -Pr 8 -WithMiro -Full -CleanupOnFailure
+.\ddda.ps1 validate-pr -Pr 74 -WithMiro -Full -CleanupOnFailure
 ```
 
-Příkaz nemění aktivní větev ani aktivní working tree. PR načte přes `refs/pull/<PR>/head`, vytvoří izolovaný checkout a testuje candidate package svázaný s exact head SHA.
+Příkaz nemění aktivní větev ani working tree. PR načte přes exact head SHA, vytvoří izolovaný candidate package a package-first validation evidence.
 
-## Co se provede automaticky
+## Governed implementation merge
 
-```text
-clean-tree check
-→ exact PR SHA
-→ isolated checkout
-→ candidate package
-→ package security validation
-→ unpacked package baseline
-→ lint/schema/unit/component
-→ integration/smoke/regression/security
-→ E2E
-→ steering acceptance
-→ optional Miro acceptance
-→ JSON + Markdown report
-→ cleanup
+Implementační PR se **nemerguje přes release promotion**.
+
+Po exact-SHA CI + `validate-pr` PASS a explicitním Human Review PASS pro stejné SHA/package proveď nejdřív merge dry-run:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr 74 -DryRun
 ```
 
-Candidate package a validation report zůstávají pro následný promotion. Diagnostický workspace zůstává pouze při FAIL nebo při `-KeepArtifacts`.
+Dry-run fail-closed ověří:
 
-## Výstup
+- PR je open, ready for review a míří do canonical base;
+- current head SHA se nezměnilo;
+- required GitHub checks jsou PASS;
+- `validate-pr` report je PASS pro stejné SHA;
+- candidate package SHA-256 odpovídá reportu;
+- existuje právě jeden authoritativní Human Review marker `ddda:human-pr-review:v1`;
+- Human Review má lidskou provenance, stejné PR/SHA/package a verdict `pass`;
+- required governance documents existují;
+- merge method odpovídá repository policy.
 
-Úspěch končí přehledem:
+Dry-run neprovede merge, release, promotion ani tag.
 
-```text
-DDDA PR validation: PASS
-PR:       8
-Branch:   <branch>
-Commit:   <exact-sha>
-Package:  <candidate-zip>
-Report:   <report-directory>
+Skutečný implementation merge:
+
+```powershell
+.\ddda.ps1 merge-pr -Pr 74 -ConfirmMerge
 ```
 
-Report obsahuje:
+`-ConfirmMerge` je samostatná explicitní lidská merge authorization boundary.
 
-- PR a branch;
-- exact SHA;
-- package SHA-256;
-- stav a délku každé suite;
-- diagnostické logy;
-- workspace a Miro board ID, pokud jsou relevantní.
+`merge-pr` provede pouze merge implementačního PR a následný server read-back. Záměrně:
 
-## Review před promotion
+- nevyžaduje HRDR;
+- nevyhodnocuje Release Scope Gate;
+- nevytváří release package;
+- nespouští release validation;
+- nevytváří tag.
 
-Před promotion zkontroluj:
+Tím lze bezpečně integrovat více implementačních PR pro jednu budoucí verzi, aniž by Release Scope Gate vytvořil kruhovou závislost.
 
-- obsah a rozsah PR;
-- metodickou správnost;
-- architektonická rozhodnutí a trade-offy;
-- compatibility a migration note;
-- changelog;
-- relevantní části validation reportu;
-- Miro board při vizuálně významné změně.
+## Release candidate
 
-Mechanické kontroly neopakuj ručně.
+Až po integraci práce určené pro konkrétní release vytvoř explicitní release candidate — typicky `release/<version>` PR nebo jiný lifecyclem schválený ekvivalent.
+
+Release candidate má vlastní exact-SHA `validate-pr` evidence. Human Review jednotlivých implementačních PR není Human Release Decision pro release candidate.
+
+## HRDR pro release candidate
+
+Po frozen release-candidate validation lze vytvořit Human Release Decision Record scaffold:
+
+```powershell
+.\ddda.ps1 review-pr `
+  -Pr <RELEASE_PR> `
+  -Version <X.Y.Z> `
+  -Reviewer <login> `
+  -DecisionOwner <login> `
+  -PublishScaffold
+```
+
+Automation vytváří pouze `decision=pending`; nevytváří `GO`, nepřijímá residual risk a nevolí člověka, který smí release rozhodnout.
 
 ## Release cut v changelogu
 
-Během vývoje zapisuj změny pouze pod `## [Unreleased]`. Před finálním promotion dry-runem proveď deterministický release cut:
+Během vývoje zapisuj změny pod `## [Unreleased]`. Před finálním release dry-runem:
 
-1. zvol jedinou Semantic Version `X.Y.Z`;
-2. přesuň všechny release položky z `Unreleased` pod `## [X.Y.Z] - YYYY-MM-DD`;
-3. ponech `## [Unreleased]` bez release položek;
-4. použij stejnou hodnotu `X.Y.Z` v parametru `-Version`;
-5. promotion odvodí tag výhradně jako `vX.Y.Z`.
+1. zvol `X.Y.Z`;
+2. přesuň release položky pod `## [X.Y.Z] - YYYY-MM-DD`;
+3. ponech `Unreleased` bez release položek;
+4. použij stejné `X.Y.Z` v `-Version`;
+5. canonical tag je `vX.Y.Z`.
 
-Promotion preflight odmítne chybějící nebo duplicitní release heading, neplatné ISO datum, neprázdnou `Unreleased` sekci nebo neshodu mezi `-Version` a changelogem. Datum nemusí být datum spuštění preflightu, musí však být platné a explicitně schválené jako release datum.
+## Release Scope Gate a promotion dry-run
 
-## Promotion dry-run
-
-```powershell
-.\ddda.ps1 promote-pr -Pr 8 -Version 0.8.0 -DryRun
-```
-
-Dry-run ověří:
-
-- PR je otevřený a není draft;
-- target branch odpovídá policy;
-- head SHA se nezměnil;
-- CI je PASS;
-- validation report je PASS pro stejný SHA;
-- candidate package hash odpovídá reportu;
-- approval policy je splněna;
-- povinné governance dokumenty existují;
-- changelog obsahuje právě jednu release sekci pro zadané `-Version` s platným ISO datem;
-- `Unreleased` neobsahuje nepřiřazené release položky;
-- release tag `vX.Y.Z` ještě neexistuje.
-
-Neprovede merge, release ani tag.
-
-## Skutečný promotion
+Po explicitním Human Release Decision pro release candidate:
 
 ```powershell
-.\ddda.ps1 promote-pr -Pr 8 -Version 0.8.0 -ConfirmMerge
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version <X.Y.Z> -DryRun
 ```
 
-S online Miro release acceptance:
+Public `promote-pr` nejdříve validuje právě jeden authoritativní HRDR a strict Release Scope Gate nad live Milestone, native blockers a GitHub Project V2 projection.
+
+Release Scope Gate vyžaduje, aby current release scope byl před skutečným release terminal nebo explicitně deferred mimo release. Toto pravidlo **neplatí jako precondition pro předchozí implementation merges**.
+
+Dry-run neprovede merge release candidate, release ani tag.
+
+## Skutečný release promotion
+
+Vyžaduje novou samostatnou explicitní human authorization:
 
 ```powershell
-.\ddda.ps1 promote-pr -Pr 8 -Version 0.8.0 -ConfirmMerge -WithMiro -Full -CleanupOnFailure
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version <X.Y.Z> -ConfirmMerge
 ```
 
-`-ConfirmMerge` je explicitní lidská approval boundary. Bez něj se merge neprovede.
+S online Miro release acceptance, je-li relevantní:
 
-Po merge promotion:
+```powershell
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version <X.Y.Z> -ConfirmMerge -WithMiro -Full -CleanupOnFailure
+```
 
-1. načte nový `main`;
-2. ověří merge commit;
+Implementation `merge-pr -ConfirmMerge` authorization nikdy neautorizuje release.
+
+Canonical promotion po PASS gate:
+
+1. provede release-candidate merge, pokud jej workflow vyžaduje;
+2. načte nový canonical release source;
 3. vytvoří release package;
 4. vygeneruje release validation workspace;
 5. provede ingestion, security, smoke, E2E a acceptance;
 6. vytvoří release report;
-7. vytvoří a pushne tag až po PASS.
+7. vytvoří/pushne tag až po PASS.
 
 Při release validation FAIL se tag nevytvoří.
 
 ## Diagnostické cesty
 
-Lokální výstupy jsou pod DDDA state rootem:
+Lokální evidence jsou pod DDDA state rootem, typicky:
 
 ```text
 validation/
 validation-reports/
 packages/
+merge-reports/
 promotion/
 release-reports/
 ```
 
-Na Windows typicky:
-
-```text
-%LOCALAPPDATA%\DDDA\
-```
-
-Tyto adresáře nejsou součástí platformního Git repozitáře.
-
 ## Bezpečnostní pravidla
 
 - nikdy nepředávej token jako CLI argument;
-- necommituj validation nebo release workspaces;
+- necommituj validation/release workspaces;
 - nepoužívej klientský workspace jako fixture;
-- nemaž diagnostický adresář ručně před přečtením FAIL reportu;
-- nepoužívej `git clean -fdx` nad neověřenou cestou;
-- nepoužívej promotion bez dry-run a review;
-- běžné testy nikdy nemergují ani netagují.
+- běžné testy nikdy nemergují ani netagují;
+- Human Review PASS nevytváří automation;
+- merge authorization a release authorization jsou oddělené;
+- `merge-pr` nesmí být release bypass;
+- `promote-pr` nesmí být použit jako obecný mechanismus merge implementačních PR.

--- a/docs/user-guide/validate-and-promote-pr.md
+++ b/docs/user-guide/validate-and-promote-pr.md
@@ -37,7 +37,7 @@ Včetně Miro, pokud je relevantní:
 .\ddda.ps1 validate-pr -Pr 74 -WithMiro -Full -CleanupOnFailure
 ```
 
-Příkaz nemění aktivní větev ani working tree. PR načte přes exact head SHA, vytvoří izolovaný candidate package a package-first validation evidence.
+Příkaz nemění aktivní větev ani working tree. Lokálně načte exact head SHA a vytvoří izolovaný candidate package. Ve standardním CI se candidate sestaví pouze jednou v `Platform validation`; `One-command PR validation` stáhne tentýž artifact a zavolá `validate-pr -PackagePath`, takže reportovaný hash patří fyzicky nahranému ZIPu.
 
 ## Governed implementation merge
 
@@ -60,8 +60,11 @@ Dry-run fail-closed ověří:
 - Human Review má lidskou provenance, stejné PR/SHA/package a verdict `pass`;
 - required governance documents existují;
 - impact classification a merge method odpovídají repository merge-strategy policy.
+- pokud existuje právě jeden otevřený release train `DDDA X.Y.Z`, primary CR PR patří do jeho Milestone; PR s pozdějším/TBD scope se fail-closed nemůže dostat do `main`.
 
 Dry-run neprovede merge, release, promotion ani tag.
+
+Standardní CI používá samostatný job `Human Review readiness`. Před Human Review je vlastní `Governed merge dry-run` job `skipped` a jeho stav je `NOT_RUN`; zelený readiness coordinator není důkaz provedeného dry-runu. Po publikaci exact-SHA Human Review se znovu spustí readiness job a jeho dependent dry-run, nikoli candidate build. Dry-run na novém čistém runneru stáhne již existující candidate a validation report ze stejného workflow runu, přepočítá hash a ověří shodu s reportem i Human Review. Dočasná cesta z validačního runneru se nepoužívá.
 
 ### Merge strategy a exact-SHA ancestry
 
@@ -144,7 +147,9 @@ Po explicitním Human Release Decision pro release candidate:
 .\ddda.ps1 promote-pr -Pr <RELEASE_PR> -Version <X.Y.Z> -DryRun
 ```
 
-Public `promote-pr` nejdříve validuje právě jeden authoritativní HRDR a strict Release Scope Gate nad live Milestone, native blockers a GitHub Project V2 projection.
+Public `promote-pr` nejdříve validuje právě jeden authoritativní HRDR a strict Release Scope Gate nad live Milestone, native blockers, GitHub Project V2 projection a skutečným source diffem od posledního canonical SemVer tagu.
+
+Gate vytvoří inventory shipping commitů, PR a jejich právě jednoho primary CR. Každý shipping PR musí patřit do aktuálního Milestone i Project projection `Target Release=X.Y.Z`. Nezmapovaný commit, více primary CR nebo změna mimo scope znamená FAIL. U již integrované out-of-scope změny evidence obsahuje `RECOVERY_DECISION_REQUIRED`; automatizace sama nesmí scope rozšířit, historii přepsat ani změnu odstranit.
 
 Release Scope Gate vyžaduje, aby current release scope byl před skutečným release terminal nebo explicitně deferred mimo release. Toto pravidlo **neplatí jako precondition pro předchozí implementation merges**.
 

--- a/docs/user-guide/validate-and-promote-pr.md
+++ b/docs/user-guide/validate-and-promote-pr.md
@@ -126,6 +126,20 @@ Release Scope Gate vyžaduje, aby current release scope byl před skutečným re
 
 Dry-run neprovede merge release candidate, release ani tag.
 
+Governed wrapper navíc ukládá deterministickou machine-readable evidence pod DDDA state root `promotion/`. Výsledek rozlišuje:
+
+```text
+promotion_preflight_status
+side_effect_assertions_status
+wrapper_status
+source_sha
+candidate_package_sha256
+version
+release_scope_gate_status
+```
+
+Před a po dry-runu se čerstvým GitHub read-backem ověřuje, že PR nebyl mergnut, base SHA se nezměnilo a nevznikl canonical tag ani GitHub Release objekt. Očekávaná `404` pro neexistující tag/release je explicitní úspěšná absence assertion; `401/403`, síťová chyba nebo `5xx` zůstávají FAIL a nesmějí zdědit či kontaminovat výsledek jiné operace.
+
 ## Skutečný release promotion
 
 Vyžaduje novou samostatnou explicitní human authorization:

--- a/knowledge/ddda-platform-development-skill.md
+++ b/knowledge/ddda-platform-development-skill.md
@@ -120,7 +120,7 @@ CI/test pipeline
 11. Mechanical checks are automated; humans decide only judgment-heavy questions.
 12. Client data, credentials and user-specific absolute paths are forbidden in examples and packages.
 13. Chat output is advisory; technical guarantees live in Git, CI, schemas, scripts and tests.
-14. Merge, tag, release and promotion require a separate explicit governance action.
+14. Implementation merge, release promotion and tag creation are distinct governance side effects and each requires its own explicit human authorization when applicable.
 15. Validation evidence must identify the exact commit SHA and candidate-package hash.
 16. Chat and Work are the only supported ChatGPT interfaces for DDDA platform development.
 17. Codex and `/agent` are prohibited by the active development policy.
@@ -135,6 +135,9 @@ CI/test pipeline
 26. Human interaction is requested only for judgment or authorization that cannot be automated, such as HVR, an explicit gate/merge/promotion/release/tag decision, or a true hard blocker with no approved alternate execution path.
 27. Chat/Work must never imply that work continues after a response unless a real external workflow or automation is actually running; otherwise it must state the exact checkpoint and provide a ready-to-copy continuation trigger.
 28. A quota or outage in an optional/local tool channel is not a hard blocker while an approved alternative execution plane can complete the same mechanical step; use the approved alternative before escalating to the human.
+29. A governed implementation PR may be merged after exact-SHA technical evidence, Human Review and explicit merge authorization without evaluating release-scope completeness and without creating a release or tag.
+30. HRDR and Release Scope Gate apply to the actual release candidate boundary, after included implementation work has been integrated/terminal; `promote-pr` is a release command, not the general implementation-PR merge command.
+31. Merge, promotion, release and tag are never inferred from technical PASS, Human Review, FAST-LOOP completion or one another.
 
 ## 4. Change classification
 
@@ -168,6 +171,10 @@ The classification determines tests, ADR, migration and review obligations.
 
 ## 5. Standard lifecycle
 
+DDDA separates implementation integration from release promotion.
+
+### 5.1 Governed implementation PR
+
 ```text
 change request in Chat or Work
 → impact analysis
@@ -177,10 +184,32 @@ change request in Chat or Work
 → GitHub Actions exact-SHA validation
 → push/PR CI
 → validate-pr
-→ human review
+→ Human Review for the same exact SHA/candidate package
+→ merge-pr dry-run
+→ explicit human merge authorization
+→ governed merge into main
+→ NO release package
+→ NO release validation
+→ NO tag
+```
+
+The Human Review and merge authorization are distinct boundaries. A technical PASS cannot create either one. `merge-pr` must not require HRDR or Release Scope Gate and must not call release/tag execution paths.
+
+### 5.2 Release candidate
+
+After all work intended for a release has been integrated and the release-scope Issues are terminal or explicitly deferred outside the release:
+
+```text
+release candidate preparation (typically release/<version> PR or equivalent governed candidate)
+→ exact-SHA candidate validation
+→ release cut / changelog consistency
+→ Human Release Decision Record for the exact release candidate
+→ Release Scope Gate
 → promotion dry-run
-→ explicit promotion decision
-→ merge
+→ explicit Human Release Decision
+→ separate explicit release/promotion authorization
+→ canonical promotion
+→ release-candidate merge when applicable
 → release package
 → generated release-validation workspace
 → ingestion
@@ -189,7 +218,9 @@ change request in Chat or Work
 → tag
 ```
 
-Never recommend merge when a mandatory technical or human gate is not satisfied.
+Release Scope Gate stays strict: incomplete current-release scope is a release failure. It is not evaluated as a prerequisite for merging the individual implementation PRs whose integration is required to make that scope terminal.
+
+Never recommend an implementation merge or release when its mandatory technical or human gate is not satisfied.
 
 ## 6. Required PR content
 
@@ -224,7 +255,7 @@ Use the existing DDDA test taxonomy, not ad hoc names:
 - migration;
 - security/isolation.
 
-A “remediation test” is not a separate test type. The correct term is **remediation validation run**: an orchestration that composes existing guards and suites.
+A “remediation test” is not a separate test type. The correct term is **remediation validation run**: an orchestration that composes existing tests and guards.
 
 Tests that mutate repository state must run in an isolated clone, worktree or fixture. Do not assert that the developer working tree is clean while intentionally using it as the mutable test subject.
 
@@ -255,10 +286,14 @@ Prefer the stable entry point:
 .\ddda.ps1 doctor
 .\ddda.ps1 test -Suite <suite>
 .\ddda.ps1 validate-pr -Pr <PR_NUMBER>
-.\ddda.ps1 promote-pr -Pr <PR_NUMBER> -Version <VERSION> -DryRun
+.\ddda.ps1 merge-pr -Pr <PR_NUMBER> -DryRun
+.\ddda.ps1 review-pr -Pr <RELEASE_PR_NUMBER> -Version <VERSION> ...
+.\ddda.ps1 promote-pr -Pr <RELEASE_PR_NUMBER> -Version <VERSION> -DryRun
 ```
 
-A real merge/promotion requires explicit confirmation and all required evidence for the same SHA.
+Actual implementation merge requires explicit `merge-pr ... -ConfirmMerge` authorization. It performs merge only.
+
+Actual release promotion requires its own explicit authorization and all release-candidate HRDR/Release Scope Gate evidence for the same SHA. A prior implementation merge authorization never implies release or tag authorization.
 
 In Chat/Work-only operation, standard GitHub Actions workflows invoke these contracts. One-off bootstrap workflows are not a normal implementation mechanism and must not be introduced when an existing self-service workflow can be extended.
 
@@ -338,7 +373,7 @@ Required rules:
    push only the validated SHA; never force-push automatically.
 
 8. Handoff
-   return to normal PR CI, review, acceptance and promotion.
+   return to normal PR CI, review, acceptance and the appropriate governed merge/release boundary.
 ```
 
 Rollback requirements:
@@ -415,7 +450,8 @@ A platform change is done only when:
 - mandatory human review is complete;
 - connector/access limitations were disclosed;
 - no prohibited execution interface was used;
-- merge/promotion was not performed without explicit authorization.
+- implementation merge was not performed without explicit merge authorization;
+- release promotion/tag was not performed without its separate explicit authorization.
 
 ## 15. Runtime registration rule
 
@@ -473,7 +509,8 @@ Operating rules:
 3. Ask the human only when a human decision or action is genuinely required: HVR or other judgment-heavy review, explicit merge/promotion/release/tag authorization, unresolved ambiguity that changes approved scope, or a credential/permission/resource blocker for which no approved alternative plane exists.
 4. Optional tooling does not define the critical path. For example, Miro MCP quota or connector unavailability must not stop REST/GitHub-Actions validation when those approved planes remain available.
 5. A technical PASS never substitutes for HVR or another human gate. The autonomous loop stops at the human boundary and reports the exact evidence and review target.
-6. Merge, promotion, release and tag are never inferred from a successful FAST-LOOP; they require their separately defined explicit human authorization.
+6. Implementation merge and release promotion are separate side-effect boundaries. Neither may be inferred from a successful FAST-LOOP or from the other authorization.
+7. Merge, promotion, release and tag are never inferred from technical PASS, Human Review, FAST-LOOP completion or one another.
 
 ### 16.1 Truthful execution-state reporting
 

--- a/knowledge/ddda-platform-development-skill.md
+++ b/knowledge/ddda-platform-development-skill.md
@@ -138,6 +138,7 @@ CI/test pipeline
 29. A governed implementation PR may be merged after exact-SHA technical evidence, Human Review and explicit merge authorization without evaluating release-scope completeness and without creating a release or tag.
 30. HRDR and Release Scope Gate apply to the actual release candidate boundary, after included implementation work has been integrated/terminal; `promote-pr` is a release command, not the general implementation-PR merge command.
 31. Merge, promotion, release and tag are never inferred from technical PASS, Human Review, FAST-LOOP completion or one another.
+32. One exact-SHA validation decision uses one canonical candidate package identity: the package is built once, every validation consumer receives that physical artifact, and report, Human Review and merge preflight must agree on its recalculated SHA-256. A consumer must never rebuild the package to manufacture equivalent evidence.
 
 ## 4. Change classification
 
@@ -216,6 +217,7 @@ release candidate preparation (typically release/<version> PR or equivalent gove
 → smoke + acceptance
 → release report
 → tag
+→ GitHub Release publication of the validated canonical package and portable release evidence
 ```
 
 Release Scope Gate stays strict: incomplete current-release scope is a release failure. It is not evaluated as a prerequisite for merging the individual implementation PRs whose integration is required to make that scope terminal.
@@ -522,3 +524,7 @@ Chat/Work must distinguish an **active external execution** from an **intention 
 - If an external workflow is still running when the response is sent, say exactly that; do not represent future analysis, fixes or retries as already running unless they are actually scheduled or executing.
 
 The intent is operationally strict: **autonomous orchestration while execution is active, truthful stop-state reporting when it is not.**
+
+## Backlog / Project transactional completion
+
+Pro DDDA platform backlog/delivery governance je GitHub Issue/PR mutation a její `DDDA Platform Backlog & Delivery` projection jedna fail-closed transakce. CR/Defect/Enabler/PR creation, state/relationship change nebo implementation authority change není `Ready`/`Done`/governance `PASS`, dokud canonical Project/Milestone reconciliation a repository-wide read-back nevrátí `remaining_mismatches = 0`. Nedostupná Project mutation surface je blocker k dokončení governance transakce, ne důvod projekci odložit nebo ji přenést na člověka k ruční kontrole.

--- a/runtime/miro/ddda_miro/cli.py
+++ b/runtime/miro/ddda_miro/cli.py
@@ -13,6 +13,27 @@ from .render import render_board
 from .sync import sync_project
 
 
+BOARD_IDENTITY_HANDOFF_PREFIX = "DDDA_MIRO_BOARD_ID_HANDOFF:"
+
+
+class _BoardIdentityHandoffClient:
+    """Proxy that emits board identity immediately after successful board creation."""
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    def create_board(self, *args, **kwargs):
+        board = self._inner.create_board(*args, **kwargs)
+        board_id = str((board or {}).get("id") or "").strip()
+        if not board_id:
+            raise ValueError("Miro create_board succeeded without a usable board id")
+        print(f"{BOARD_IDENTITY_HANDOFF_PREFIX}{board_id}", file=sys.stderr, flush=True)
+        return board
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="ddda-miro")
     parser.add_argument("--project", required=True, type=Path, help="DDDA project root")
@@ -54,7 +75,8 @@ def main(argv: list[str] | None = None) -> int:
                     raise ValueError("Board ID is required for --online doctor")
                 result["board"] = MiroClient(config.access_token()).get_board(config.board_id)
         elif args.command == "render":
-            client = None if args.dry_run and not os.environ.get(config.token_env) else MiroClient(config.access_token())
+            raw_client = None if args.dry_run and not os.environ.get(config.token_env) else MiroClient(config.access_token())
+            client = None if raw_client is None else _BoardIdentityHandoffClient(raw_client)
             result = render_board(config, client, create_board=args.create_board, dry_run=args.dry_run)
         elif args.command == "sync":
             result = sync_project(

--- a/runtime/miro/tests/test_cli_board_identity_handoff.py
+++ b/runtime/miro/tests/test_cli_board_identity_handoff.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from ddda_miro.cli import BOARD_IDENTITY_HANDOFF_PREFIX, _BoardIdentityHandoffClient
+
+
+class _FakeClient:
+    def __init__(self):
+        self.calls = []
+
+    def create_board(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return {"id": "uXjV-ImmediateHandoff="}
+
+    def get_board(self, board_id):
+        return {"id": board_id}
+
+
+def test_create_board_proxy_emits_identity_immediately(capsys):
+    inner = _FakeClient()
+    client = _BoardIdentityHandoffClient(inner)
+
+    board = client.create_board("name", "description", team_id="team")
+
+    assert board["id"] == "uXjV-ImmediateHandoff="
+    assert len(inner.calls) == 1
+    assert capsys.readouterr().err.strip() == (
+        f"{BOARD_IDENTITY_HANDOFF_PREFIX}uXjV-ImmediateHandoff="
+    )
+
+
+def test_proxy_delegates_non_create_calls():
+    client = _BoardIdentityHandoffClient(_FakeClient())
+    assert client.get_board("uXjV-Existing=") == {"id": "uXjV-Existing="}

--- a/runtime/platform/release_governance.py
+++ b/runtime/platform/release_governance.py
@@ -55,6 +55,90 @@ def _release_value(value: Any) -> str:
     return str(value or "").strip().removeprefix("DDDA ")
 
 
+def _sha_values(values: Any) -> set[str]:
+    if not isinstance(values, list):
+        return set()
+    return {str(value) for value in values if SHA40.fullmatch(str(value))}
+
+
+def evaluate_recovery_ledger(
+    physical: dict[str, Any],
+    *,
+    expected_version: str,
+    declared_scope: set[int],
+) -> list[str]:
+    """Validate an explicit controlled-release-source provenance ledger.
+
+    A reconstructed source has new commit identities.  It therefore cannot
+    inherit GitHub's original commit-to-PR association implicitly.  The ledger
+    is an explicit, versioned replacement provenance record.  It is accepted
+    only when it covers every reconstructed physical commit (except one
+    metadata-only ledger commit) and the collector has freshly read back the
+    original merged PR/CR authority and exact changed-path hashes.
+    """
+    ledger = physical.get("recovery_ledger")
+    if ledger is None:
+        return []
+    if not isinstance(ledger, dict):
+        return ["RECOVERY_LEDGER_EVIDENCE_INVALID"]
+
+    failures: list[str] = []
+    if ledger.get("schema_version") != 1:
+        failures.append("RECOVERY_LEDGER_SCHEMA_VERSION")
+    if ledger.get("version") != expected_version:
+        failures.append("RECOVERY_LEDGER_VERSION_MISMATCH")
+    if ledger.get("previous_release_tag") != physical.get("previous_release_tag"):
+        failures.append("RECOVERY_LEDGER_PREVIOUS_TAG_MISMATCH")
+
+    physical_commits = _sha_values(physical.get("commit_shas"))
+    if not physical_commits:
+        failures.append("RECOVERY_LEDGER_PHYSICAL_COMMIT_EVIDENCE_MISSING")
+
+    metadata = _sha_values(ledger.get("metadata_commit_shas"))
+    if len(metadata) != 1 or not metadata.issubset(physical_commits):
+        failures.append("RECOVERY_LEDGER_METADATA_COMMIT_INVALID")
+
+    entries = ledger.get("entries")
+    if not isinstance(entries, list) or not entries:
+        return sorted(set(failures + ["RECOVERY_LEDGER_ENTRIES_INVALID"]))
+
+    recovered: set[str] = set()
+    source_prs: set[int] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            failures.append("RECOVERY_LEDGER_ENTRY_SHAPE")
+            continue
+        recovered_sha = str(entry.get("recovered_commit_sha") or "")
+        if not SHA40.fullmatch(recovered_sha) or recovered_sha in recovered:
+            failures.append("RECOVERY_LEDGER_RECOVERED_COMMIT_INVALID")
+            continue
+        recovered.add(recovered_sha)
+        try:
+            source_pr = int(entry.get("source_pr", 0))
+            primary_cr = int(entry.get("primary_cr", 0))
+        except (TypeError, ValueError):
+            source_pr = primary_cr = 0
+        if source_pr <= 0 or source_pr in source_prs:
+            failures.append("RECOVERY_LEDGER_SOURCE_PR_INVALID")
+        source_prs.add(source_pr)
+        if primary_cr <= 0:
+            failures.append("RECOVERY_LEDGER_PRIMARY_CR_INVALID")
+        if entry.get("source_pr_merged") is not True:
+            failures.append(f"RECOVERY_LEDGER_SOURCE_PR_NOT_MERGED:PR#{source_pr}")
+        if entry.get("source_primary_crs") != [primary_cr]:
+            failures.append(f"RECOVERY_LEDGER_SOURCE_PRIMARY_CR_MISMATCH:PR#{source_pr}")
+        if entry.get("source_merge_commit_sha") != entry.get("observed_source_merge_commit_sha"):
+            failures.append(f"RECOVERY_LEDGER_SOURCE_MERGE_SHA_MISMATCH:PR#{source_pr}")
+        if entry.get("changed_path_hashes_match") is not True:
+            failures.append(f"RECOVERY_LEDGER_PATH_HASH_MISMATCH:PR#{source_pr}")
+        if primary_cr not in declared_scope:
+            failures.append(f"RECOVERY_LEDGER_OUT_OF_SCOPE_PRIMARY_CR:PR#{source_pr}:#{primary_cr}")
+
+    if recovered | metadata != physical_commits:
+        failures.append("RECOVERY_LEDGER_COMMIT_COVERAGE_MISMATCH")
+    return sorted(set(failures))
+
+
 def evaluate_physical_release_scope(
     snapshot: dict[str, Any],
     *,
@@ -82,10 +166,18 @@ def evaluate_physical_release_scope(
     if physical.get("compare_status") not in {"ahead", "identical"}:
         failures.append("PHYSICAL_SCOPE_ANCESTRY_INVALID")
 
+    scope = _ints(declared_scope)
+    failures.extend(
+        evaluate_recovery_ledger(
+            physical,
+            expected_version=expected_version,
+            declared_scope=scope,
+        )
+    )
+
     for sha in sorted({str(x) for x in physical.get("unmapped_commit_shas", []) if str(x)}):
         failures.append(f"PHYSICAL_SCOPE_UNMAPPED_COMMIT:{sha}")
 
-    scope = _ints(declared_scope)
     shipping = physical.get("shipping_prs")
     if not isinstance(shipping, list):
         return sorted(set(failures + ["PHYSICAL_SCOPE_SHIPPING_PR_EVIDENCE_MISSING"]))

--- a/runtime/platform/release_governance.py
+++ b/runtime/platform/release_governance.py
@@ -94,7 +94,10 @@ def evaluate_recovery_ledger(
     if not physical_commits:
         failures.append("RECOVERY_LEDGER_PHYSICAL_COMMIT_EVIDENCE_MISSING")
 
-    metadata = _sha_values(ledger.get("metadata_commit_shas"))
+    # The metadata commit is derived from the physical inventory, rather than
+    # declared inside the ledger it creates. Requiring a commit to contain its
+    # own SHA would make a valid ledger impossible to construct.
+    metadata = _sha_values(physical.get("metadata_commit_shas"))
     if len(metadata) != 1 or not metadata.issubset(physical_commits):
         failures.append("RECOVERY_LEDGER_METADATA_COMMIT_INVALID")
 

--- a/runtime/platform/release_governance.py
+++ b/runtime/platform/release_governance.py
@@ -50,6 +50,122 @@ def _keyed(mapping: dict[Any, Any], key: int, default: Any = None) -> Any:
     return default
 
 
+def _release_value(value: Any) -> str:
+    """Normalize Project's planning projection without making it authority."""
+    return str(value or "").strip().removeprefix("DDDA ")
+
+
+def evaluate_physical_release_scope(
+    snapshot: dict[str, Any],
+    *,
+    expected_source_sha: str,
+    expected_version: str,
+    declared_scope: Iterable[int],
+) -> list[str]:
+    """Return fail-closed defects between declared and physical shipping scope.
+
+    ``physical_scope`` is collected from the last canonical SemVer tag through
+    the exact candidate source.  This function intentionally does not select a
+    recovery path or enlarge a Milestone: those are human governance decisions.
+    """
+    failures: list[str] = []
+    physical = snapshot.get("physical_scope")
+    if not isinstance(physical, dict):
+        return ["PHYSICAL_SCOPE_EVIDENCE_MISSING"]
+
+    if physical.get("release_source_sha") != expected_source_sha:
+        failures.append("PHYSICAL_SCOPE_SOURCE_SHA_MISMATCH")
+    if not str(physical.get("previous_release_tag") or "").strip():
+        failures.append("PHYSICAL_SCOPE_PREVIOUS_TAG_MISSING")
+    if not SHA40.fullmatch(str(physical.get("previous_release_sha") or "")):
+        failures.append("PHYSICAL_SCOPE_PREVIOUS_TAG_SHA_INVALID")
+    if physical.get("compare_status") not in {"ahead", "identical"}:
+        failures.append("PHYSICAL_SCOPE_ANCESTRY_INVALID")
+
+    for sha in sorted({str(x) for x in physical.get("unmapped_commit_shas", []) if str(x)}):
+        failures.append(f"PHYSICAL_SCOPE_UNMAPPED_COMMIT:{sha}")
+
+    scope = _ints(declared_scope)
+    shipping = physical.get("shipping_prs")
+    if not isinstance(shipping, list):
+        return sorted(set(failures + ["PHYSICAL_SCOPE_SHIPPING_PR_EVIDENCE_MISSING"]))
+
+    seen_prs: set[int] = set()
+    shipping_crs: set[int] = set()
+    for row in shipping:
+        if not isinstance(row, dict):
+            failures.append("PHYSICAL_SCOPE_SHIPPING_PR_SHAPE")
+            continue
+        try:
+            number = int(row.get("number", 0))
+        except (TypeError, ValueError):
+            number = 0
+        if number <= 0 or number in seen_prs:
+            failures.append("PHYSICAL_SCOPE_SHIPPING_PR_IDENTITY")
+            continue
+        seen_prs.add(number)
+        if row.get("merged") is not True:
+            failures.append(f"PHYSICAL_SCOPE_PR_NOT_MERGED:PR#{number}")
+        primary = row.get("primary_crs")
+        if not isinstance(primary, list) or len(primary) != 1:
+            failures.append(f"PHYSICAL_SCOPE_PRIMARY_CR_AMBIGUOUS:PR#{number}")
+            continue
+        try:
+            cr = int(primary[0])
+        except (TypeError, ValueError):
+            failures.append(f"PHYSICAL_SCOPE_PRIMARY_CR_AMBIGUOUS:PR#{number}")
+            continue
+        shipping_crs.add(cr)
+        if cr not in scope:
+            failures.append(f"PHYSICAL_SCOPE_OUT_OF_SCOPE_PRIMARY_CR:PR#{number}:#{cr}")
+            # This marker makes the mandatory human recovery decision visible
+            # without allowing automation to choose scope expansion/recovery.
+            failures.append("RECOVERY_DECISION_REQUIRED")
+        if _release_value(row.get("target_release")) != expected_version:
+            failures.append(f"PHYSICAL_SCOPE_TARGET_RELEASE_MISMATCH:PR#{number}:#{cr}")
+        if row.get("milestone") != f"DDDA {expected_version}":
+            failures.append(f"PHYSICAL_SCOPE_MILESTONE_MISMATCH:PR#{number}:#{cr}")
+
+    for cr in sorted(scope - shipping_crs):
+        failures.append(f"PHYSICAL_SCOPE_DECLARED_CR_NOT_SHIPPED:#{cr}")
+
+    return sorted(set(failures))
+
+
+def evaluate_merge_release_eligibility(snapshot: dict[str, Any]) -> list[str]:
+    """Enforce releasable-main while an active release train is open.
+
+    The Milestone is the release authority.  Project Target Release is checked
+    as its planning projection, never used to permit an otherwise out-of-scope
+    merge.  Missing/ambiguous evidence is deliberately blocking.
+    """
+    active = snapshot.get("active_release")
+    if active is None:
+        return []
+    if not isinstance(active, dict):
+        return ["MERGE_ELIGIBILITY_ACTIVE_RELEASE_EVIDENCE_INVALID"]
+    version = _release_value(active.get("version"))
+    if not SEMVER.fullmatch(version):
+        return ["MERGE_ELIGIBILITY_ACTIVE_RELEASE_EVIDENCE_INVALID"]
+    primary = snapshot.get("primary_crs")
+    if not isinstance(primary, list) or len(primary) != 1:
+        return ["MERGE_ELIGIBILITY_PRIMARY_CR_AMBIGUOUS"]
+    try:
+        cr = int(primary[0])
+    except (TypeError, ValueError):
+        return ["MERGE_ELIGIBILITY_PRIMARY_CR_AMBIGUOUS"]
+    authority = snapshot.get("primary_cr")
+    if not isinstance(authority, dict):
+        return ["MERGE_ELIGIBILITY_PRIMARY_CR_EVIDENCE_MISSING"]
+    failures: list[str] = []
+    if authority.get("milestone") != f"DDDA {version}":
+        failures.append(f"MERGE_ELIGIBILITY_OUTSIDE_ACTIVE_RELEASE:#{cr}")
+    target = _release_value(authority.get("target_release"))
+    if target and target != version:
+        failures.append(f"MERGE_ELIGIBILITY_TARGET_RELEASE_MISMATCH:#{cr}")
+    return sorted(set(failures))
+
+
 def validate_hrdr_shape(record: dict[str, Any]) -> list[str]:
     failures: list[str] = []
     if record.get("schema_version") != 1:
@@ -235,6 +351,15 @@ def evaluate_release_scope(
         failures.append("PROJECT_PLANNING_VIEW_MISMATCH")
     if project_meta.get("delivery_view_filter") != "is:pr is:open":
         failures.append("PROJECT_DELIVERY_VIEW_MISMATCH")
+
+    failures.extend(
+        evaluate_physical_release_scope(
+            snapshot,
+            expected_source_sha=expected_source_sha,
+            expected_version=expected_version,
+            declared_scope=scope_issues,
+        )
+    )
 
     failures = sorted(set(failures))
     return GovernanceResult(

--- a/runtime/platform/release_governance.py
+++ b/runtime/platform/release_governance.py
@@ -1,0 +1,246 @@
+"""Pure release-governance invariants used by DDDA promotion preflight.
+
+The module intentionally has no network or filesystem side effects. Live GitHub
+and Project V2 state is collected by Test-DDDAReleaseScope.py and converted to
+the snapshot contract evaluated here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+import re
+
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+
+POSITIVE_DECISIONS = {"go", "go_with_accepted_risks"}
+DECISIONS = POSITIVE_DECISIONS | {"pending", "no_go"}
+SEVERITIES = {"green", "amber", "red"}
+
+
+@dataclass(frozen=True)
+class GovernanceResult:
+    status: str
+    failures: tuple[str, ...]
+    scope_issues: tuple[int, ...]
+    accepted_risk_issues: tuple[int, ...]
+    side_effects_allowed: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "release_scope_gate_status": self.status,
+            "failing_invariants": list(self.failures),
+            "scope_issues": list(self.scope_issues),
+            "accepted_risk_issues": list(self.accepted_risk_issues),
+            "side_effects_allowed": self.side_effects_allowed,
+        }
+
+
+def _ints(values: Iterable[Any]) -> set[int]:
+    return {int(v) for v in values}
+
+
+def _keyed(mapping: dict[Any, Any], key: int, default: Any = None) -> Any:
+    if key in mapping:
+        return mapping[key]
+    if str(key) in mapping:
+        return mapping[str(key)]
+    return default
+
+
+def validate_hrdr_shape(record: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if record.get("schema_version") != 1:
+        failures.append("HRDR_SCHEMA_VERSION")
+    if not isinstance(record.get("repository"), str) or "/" not in record.get("repository", ""):
+        failures.append("HRDR_REPOSITORY")
+    try:
+        if int(record.get("pr", 0)) <= 0:
+            failures.append("HRDR_PR")
+    except (TypeError, ValueError):
+        failures.append("HRDR_PR")
+    if not SHA40.fullmatch(str(record.get("source_sha", ""))):
+        failures.append("HRDR_SOURCE_SHA")
+    if not SHA256.fullmatch(str(record.get("candidate_package_sha256", ""))):
+        failures.append("HRDR_PACKAGE_SHA256")
+    if not SEMVER.fullmatch(str(record.get("version", ""))):
+        failures.append("HRDR_VERSION")
+
+    decision = str(record.get("decision", "")).lower()
+    if decision not in DECISIONS:
+        failures.append("HRDR_DECISION")
+    if decision != "pending":
+        if not str(record.get("reviewer", "")).strip():
+            failures.append("HRDR_REVIEWER")
+        if not str(record.get("decision_owner", "")).strip():
+            failures.append("HRDR_DECISION_OWNER")
+        if not str(record.get("decided_at", "")).strip():
+            failures.append("HRDR_DECIDED_AT")
+
+    findings = record.get("findings", [])
+    if not isinstance(findings, list):
+        failures.append("HRDR_FINDINGS")
+        findings = []
+    for finding in findings:
+        if not isinstance(finding, dict) or str(finding.get("severity", "")).lower() not in SEVERITIES:
+            failures.append("HRDR_FINDING_SEVERITY")
+
+    risks = record.get("accepted_risks", [])
+    if not isinstance(risks, list):
+        failures.append("HRDR_ACCEPTED_RISKS")
+        risks = []
+    risk_issues: set[int] = set()
+    risk_ids: set[str] = set()
+    for risk in risks:
+        if not isinstance(risk, dict):
+            failures.append("HRDR_RISK_SHAPE")
+            continue
+        rid = str(risk.get("risk_id", "")).strip()
+        owner = str(risk.get("owner", "")).strip()
+        rationale = str(risk.get("rationale", "")).strip()
+        horizon = str(risk.get("target_horizon", "")).strip()
+        try:
+            issue = int(risk.get("issue", 0))
+        except (TypeError, ValueError):
+            issue = 0
+        if not rid or rid in risk_ids:
+            failures.append("HRDR_RISK_ID")
+        if issue <= 0 or issue in risk_issues:
+            failures.append("HRDR_RISK_ISSUE")
+        if not owner:
+            failures.append("HRDR_RISK_OWNER")
+        if not rationale:
+            failures.append("HRDR_RISK_RATIONALE")
+        if not horizon:
+            failures.append("HRDR_RISK_HORIZON")
+        risk_ids.add(rid)
+        if issue > 0:
+            risk_issues.add(issue)
+
+    if decision == "go" and risks:
+        failures.append("HRDR_GO_HAS_ACCEPTED_RISKS")
+    if decision == "go_with_accepted_risks" and not risks:
+        failures.append("HRDR_GO_WITHOUT_ACCEPTED_RISKS")
+
+    scope = record.get("scope_issues", [])
+    if not isinstance(scope, list) or not scope:
+        failures.append("HRDR_SCOPE_ISSUES")
+    else:
+        try:
+            values = [int(v) for v in scope]
+            if any(v <= 0 for v in values) or len(set(values)) != len(values):
+                failures.append("HRDR_SCOPE_ISSUES")
+        except (TypeError, ValueError):
+            failures.append("HRDR_SCOPE_ISSUES")
+
+    return sorted(set(failures))
+
+
+def evaluate_release_scope(
+    record: dict[str, Any],
+    snapshot: dict[str, Any],
+    *,
+    expected_repository: str,
+    expected_pr: int,
+    expected_source_sha: str,
+    expected_package_sha256: str,
+    expected_version: str,
+) -> GovernanceResult:
+    failures = validate_hrdr_shape(record)
+
+    if record.get("repository") != expected_repository:
+        failures.append("IDENTITY_REPOSITORY_MISMATCH")
+    if int(record.get("pr", 0) or 0) != int(expected_pr):
+        failures.append("IDENTITY_PR_MISMATCH")
+    if record.get("source_sha") != expected_source_sha:
+        failures.append("IDENTITY_SOURCE_SHA_MISMATCH")
+    if record.get("candidate_package_sha256") != expected_package_sha256:
+        failures.append("IDENTITY_PACKAGE_SHA256_MISMATCH")
+    if record.get("version") != expected_version:
+        failures.append("IDENTITY_VERSION_MISMATCH")
+    if snapshot.get("current_pr_head") != expected_source_sha:
+        failures.append("LIVE_PR_HEAD_MISMATCH")
+
+    decision = str(record.get("decision", "")).lower()
+    if decision not in POSITIVE_DECISIONS:
+        failures.append("HUMAN_RELEASE_DECISION_NOT_POSITIVE")
+
+    if any(str(x.get("severity", "")).lower() == "red" for x in record.get("findings", []) if isinstance(x, dict)):
+        failures.append("RED_FINDING_PRESENT")
+
+    scope_issues = _ints(record.get("scope_issues", [])) if isinstance(record.get("scope_issues"), list) else set()
+    milestone_issues = _ints(snapshot.get("milestone_issues", []))
+    if snapshot.get("milestone_title") != f"DDDA {expected_version}":
+        failures.append("MILESTONE_IDENTITY_MISMATCH")
+    if scope_issues != milestone_issues:
+        failures.append("MILESTONE_SCOPE_MISMATCH")
+
+    issue_states = snapshot.get("issue_states", {})
+    blockers = snapshot.get("blockers", {})
+    project_rows = snapshot.get("project_rows", {})
+
+    for issue in sorted(scope_issues):
+        if _keyed(issue_states, issue) != "closed":
+            failures.append(f"SCOPE_ITEM_NOT_TERMINAL:#{issue}")
+        active = _keyed(blockers, issue, []) or []
+        if active:
+            failures.append(f"SCOPE_ITEM_ACTIVE_BLOCKER:#{issue}")
+        row = _keyed(project_rows, issue)
+        if not isinstance(row, dict):
+            failures.append(f"SCOPE_ITEM_MISSING_PROJECT_ROW:#{issue}")
+        else:
+            if row.get("Status") != "Done":
+                failures.append(f"SCOPE_ITEM_PROJECT_STATUS:#{issue}")
+            if row.get("Blocked") != "No":
+                failures.append(f"SCOPE_ITEM_PROJECT_BLOCKED:#{issue}")
+
+    accepted_risks = record.get("accepted_risks", []) if isinstance(record.get("accepted_risks"), list) else []
+    risk_issues = {
+        int(risk.get("issue"))
+        for risk in accepted_risks
+        if isinstance(risk, dict) and str(risk.get("issue", "")).isdigit() and int(risk.get("issue")) > 0
+    }
+    risk_states = snapshot.get("risk_issue_states", {})
+    risk_assignees = snapshot.get("risk_issue_assignees", {})
+    risk_horizons = snapshot.get("risk_issue_horizons", {})
+    for risk in accepted_risks:
+        if not isinstance(risk, dict):
+            continue
+        try:
+            issue = int(risk.get("issue", 0))
+        except (TypeError, ValueError):
+            continue
+        owner = str(risk.get("owner", ""))
+        if issue in milestone_issues:
+            failures.append(f"DEFERRED_RISK_STILL_IN_MILESTONE:#{issue}")
+        if _keyed(risk_states, issue) != "open":
+            failures.append(f"DEFERRED_RISK_NOT_OPEN:#{issue}")
+        assignees = set(_keyed(risk_assignees, issue, []) or [])
+        if owner and owner not in assignees:
+            failures.append(f"DEFERRED_RISK_OWNER_MISMATCH:#{issue}")
+        if not str(_keyed(risk_horizons, issue, "") or "").strip():
+            failures.append(f"DEFERRED_RISK_HORIZON_MISSING:#{issue}")
+
+    if decision == "go" and risk_issues:
+        failures.append("GO_WITH_RESIDUAL_RISKS")
+    if decision == "go_with_accepted_risks" and not risk_issues:
+        failures.append("GO_WITH_ACCEPTED_RISKS_EMPTY")
+
+    project_meta = snapshot.get("project", {})
+    if project_meta.get("title") != "DDDA Platform Backlog & Delivery":
+        failures.append("PROJECT_TITLE_MISMATCH")
+    if project_meta.get("planning_view_filter") != "is:issue":
+        failures.append("PROJECT_PLANNING_VIEW_MISMATCH")
+    if project_meta.get("delivery_view_filter") != "is:pr is:open":
+        failures.append("PROJECT_DELIVERY_VIEW_MISMATCH")
+
+    failures = sorted(set(failures))
+    return GovernanceResult(
+        status="PASS" if not failures else "FAIL",
+        failures=tuple(failures),
+        scope_issues=tuple(sorted(scope_issues)),
+        accepted_risk_issues=tuple(sorted(risk_issues)),
+        side_effects_allowed=not failures,
+    )

--- a/runtime/platform/tests/test_merge_strategy_contract.py
+++ b/runtime/platform/tests/test_merge_strategy_contract.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+POLICY = ROOT / "config/platform/development-policy.yaml"
+MERGE_SCRIPT = ROOT / "scripts/platform/Invoke-DDDAGovernedMergePr.ps1"
+SUPPORT = ROOT / "scripts/platform/DDDAMergeStrategySupport.ps1"
+
+
+def test_merge_policy_is_ancestry_preserving_by_default():
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    strategy = policy["merge_strategy"]
+    assert policy["merge_method"] == "merge"
+    assert strategy["default_method"] == "merge"
+    assert strategy["unknown_impact_allowed_methods"] == ["merge"]
+    assert strategy["impacts"]["HIGH"]["allowed_methods"] == ["merge"]
+    assert strategy["impacts"]["BREAKING"]["allowed_methods"] == ["merge"]
+    for impact in ("LOW", "MEDIUM"):
+        assert strategy["impacts"][impact]["default_method"] == "merge"
+        assert strategy["impacts"][impact]["allowed_methods"] == ["merge", "squash"]
+        assert strategy["impacts"][impact]["squash_requires_human_exception"] is True
+
+
+def test_bootstrap_transition_is_exact_and_prospective():
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    transition = policy["merge_strategy"]["bootstrap_transition"]
+    assert transition["change_issue"] == 70
+    assert transition["legacy_base_sha"] == "297f61f6012f180e70805999df2ac1abe9616a05"
+    assert transition["legacy_merge_method"] == "squash"
+    assert transition["prospective_after_integration"] is True
+
+
+def test_bootstrap_binds_to_change_request_relation_and_precedes_new_default():
+    support = SUPPORT.read_text(encoding="utf-8-sig")
+    assert '$Pr -ne [int]$transition.change_issue' not in support
+    assert 'Implements|Closes' in support
+    assert '$relations.Count -ne 1' in support
+    assert 'Test-DDDABootstrapMergeTransitionCandidate' in support
+    assert support.index('$bootstrapCandidate = Test-DDDABootstrapMergeTransitionCandidate') < support.index('$method = if ([string]::IsNullOrWhiteSpace($RequestedMethod))')
+    assert 'vyžaduje merge method' in support
+
+
+def test_present_malformed_classification_is_not_silently_unknown():
+    support = SUPPORT.read_text(encoding="utf-8-sig")
+    assert '$markerMatches.Count -eq 0' in support
+    assert '$markerMatches.Count -ne 1' in support
+    assert 'marker existuje, ale jeho fenced JSON record chybí' in support
+
+
+def test_governed_merge_fails_strategy_before_irreversible_merge_and_reads_back_ancestry():
+    text = MERGE_SCRIPT.read_text(encoding="utf-8-sig")
+    strategy_pos = text.index("Resolve-DDDAMergeStrategy")
+    merge_pos = text.index("Merge-DDDAGitHubPullRequest")
+    ancestry_pos = text.index("Post-merge ancestry read-back")
+    assert strategy_pos < merge_pos < ancestry_pos
+    assert 'compare/$headSha...$mergeCommit' in text
+    assert 'source_to_result_relation = $sourceToResultRelation' in text
+    assert 'ancestry_verified = $ancestryVerified' in text
+    assert 'release_side_effects = $false' in text
+    assert 'tag_side_effects = $false' in text
+
+
+def test_rebase_is_not_canonical_and_human_exception_cannot_be_automated():
+    support = SUPPORT.read_text(encoding="utf-8-sig")
+    assert 'if ($method -notin @("merge", "squash"))' in support
+    assert "Rebase není povolen" in support
+    assert "Squash exception musí mít lidskou GitHub provenance" in support
+    assert 'CommentAuthorType -eq "Bot"' in support
+    assert "validated_source_head_sha" in support
+    assert "candidate_package_sha256" in support
+
+
+def test_behavioral_merge_strategy_contract():
+    executable = shutil.which("pwsh") or shutil.which("powershell")
+    if executable is None:
+        if os.name == "nt":
+            pytest.fail("Windows platform test runtime must expose PowerShell for merge-strategy regression")
+        pytest.skip("PowerShell is not installed on this non-Windows validation worker")
+    script = ROOT / "tests/powershell/Test-DDDAMergeStrategy.ps1"
+    completed = subprocess.run(
+        [executable, "-NoProfile", "-File", str(script), "-PlatformPath", str(ROOT)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+    assert completed.returncode == 0, completed.stdout + "\n" + completed.stderr
+    assert "DDDA merge strategy contract: PASS" in completed.stdout

--- a/runtime/platform/tests/test_promotion_result_contract.py
+++ b/runtime/platform/tests/test_promotion_result_contract.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import os
+import shutil
+import subprocess
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_promotion_wrapper_has_deterministic_result_contract():
+    wrapper = (ROOT / "scripts/platform/Invoke-DDDAGovernedPromotePr.ps1").read_text(encoding="utf-8-sig")
+    support = (ROOT / "scripts/platform/DDDAPromotionResultSupport.ps1").read_text(encoding="utf-8-sig")
+    for field in (
+        "promotion_preflight_status",
+        "side_effect_assertions_status",
+        "wrapper_status",
+        "source_sha",
+        "candidate_package_sha256",
+        "version",
+        "release_scope_gate_status",
+    ):
+        assert field in wrapper
+    assert "Get-DDDAPromotionDryRunSnapshot" in wrapper
+    assert "Test-DDDAPromotionDryRunSideEffects" in wrapper
+    assert "$LASTEXITCODE" not in wrapper
+    assert "$LASTEXITCODE" not in support
+
+
+def test_expected_absence_is_explicit_and_unexpected_failure_is_not_masked():
+    support = (ROOT / "scripts/platform/DDDAPromotionResultSupport.ps1").read_text(encoding="utf-8-sig")
+    assert 'return "ABSENT"' in support
+    assert 'return "ERROR"' in support
+    assert "ExpectedAbsentStatus = @(404)" in support
+    assert "failed unexpectedly" in support
+
+
+def test_behavioral_promotion_result_contract():
+    executable = shutil.which("pwsh") or shutil.which("powershell")
+    if executable is None:
+        if os.name == "nt":
+            pytest.fail("Windows platform test runtime must expose PowerShell for the promotion result regression")
+        pytest.skip("PowerShell is not installed on this non-Windows validation worker")
+    script = ROOT / "tests/powershell/Test-DDDAPromotionResultContract.ps1"
+    completed = subprocess.run(
+        [executable, "-NoProfile", "-File", str(script), "-PlatformPath", str(ROOT)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+    assert completed.returncode == 0, completed.stdout + "\n" + completed.stderr
+    assert "DDDA promotion result contract: PASS" in completed.stdout

--- a/runtime/platform/tests/test_release_governance.py
+++ b/runtime/platform/tests/test_release_governance.py
@@ -1,6 +1,10 @@
 from copy import deepcopy
 
-from runtime.platform.release_governance import evaluate_release_scope, validate_hrdr_shape
+from runtime.platform.release_governance import (
+    evaluate_merge_release_eligibility,
+    evaluate_release_scope,
+    validate_hrdr_shape,
+)
 
 REPO = "romanhlavac/ddd-accelerator"
 PR = 71
@@ -57,6 +61,23 @@ def snapshot():
             "title": "DDDA Platform Backlog & Delivery",
             "planning_view_filter": "is:issue",
             "delivery_view_filter": "is:pr is:open",
+        },
+        "physical_scope": {
+            "previous_release_tag": "v0.1.0",
+            "previous_release_sha": "c" * 40,
+            "release_source_sha": SHA,
+            "compare_status": "ahead",
+            "unmapped_commit_shas": [],
+            "shipping_prs": [
+                {
+                    "number": number,
+                    "merged": True,
+                    "primary_crs": [cr],
+                    "milestone": "DDDA 0.1.1",
+                    "target_release": "0.1.1",
+                }
+                for number, cr in [(71, 9), (72, 12), (73, 67), (74, 68)]
+            ],
         },
     }
 
@@ -185,3 +206,64 @@ def test_identity_contract_rejects_package_drift():
     )
     assert result.status == "FAIL"
     assert "IDENTITY_PACKAGE_SHA256_MISMATCH" in result.failures
+
+
+def test_physical_scope_rejects_later_release_shipping_pr_and_requires_human_recovery():
+    live = snapshot()
+    live["physical_scope"]["shipping_prs"].append(
+        {
+            "number": 92,
+            "merged": True,
+            "primary_crs": [88],
+            "milestone": None,
+            "target_release": "TBD",
+        }
+    )
+    result = evaluate(live=live)
+    assert result.status == "FAIL"
+    assert "PHYSICAL_SCOPE_OUT_OF_SCOPE_PRIMARY_CR:PR#92:#88" in result.failures
+    assert "RECOVERY_DECISION_REQUIRED" in result.failures
+    assert result.side_effects_allowed is False
+
+
+def test_physical_scope_rejects_unmapped_commit_and_ambiguous_primary_cr():
+    live = snapshot()
+    live["physical_scope"]["unmapped_commit_shas"] = ["d" * 40]
+    live["physical_scope"]["shipping_prs"][0]["primary_crs"] = [9, 12]
+    result = evaluate(live=live)
+    assert "PHYSICAL_SCOPE_UNMAPPED_COMMIT:" + "d" * 40 in result.failures
+    assert "PHYSICAL_SCOPE_PRIMARY_CR_AMBIGUOUS:PR#71" in result.failures
+
+
+def test_physical_scope_rejects_non_ancestor_or_wrong_source_evidence():
+    live = snapshot()
+    live["physical_scope"]["compare_status"] = "diverged"
+    live["physical_scope"]["release_source_sha"] = "e" * 40
+    result = evaluate(live=live)
+    assert "PHYSICAL_SCOPE_ANCESTRY_INVALID" in result.failures
+    assert "PHYSICAL_SCOPE_SOURCE_SHA_MISMATCH" in result.failures
+
+
+def test_physical_scope_rejects_declared_change_missing_from_source():
+    live = snapshot()
+    live["physical_scope"]["shipping_prs"] = [
+        row for row in live["physical_scope"]["shipping_prs"] if row["primary_crs"] != [68]
+    ]
+    result = evaluate(live=live)
+    assert "PHYSICAL_SCOPE_DECLARED_CR_NOT_SHIPPED:#68" in result.failures
+
+
+def test_merge_eligibility_allows_only_active_train_authority():
+    allowed = {
+        "active_release": {"version": "0.1.1"},
+        "primary_crs": [96],
+        "primary_cr": {"milestone": "DDDA 0.1.1", "target_release": "0.1.1"},
+    }
+    assert evaluate_merge_release_eligibility(allowed) == []
+
+    blocked = deepcopy(allowed)
+    blocked["primary_cr"] = {"milestone": None, "target_release": "TBD"}
+    assert evaluate_merge_release_eligibility(blocked) == [
+        "MERGE_ELIGIBILITY_OUTSIDE_ACTIVE_RELEASE:#96",
+        "MERGE_ELIGIBILITY_TARGET_RELEASE_MISMATCH:#96",
+    ]

--- a/runtime/platform/tests/test_release_governance.py
+++ b/runtime/platform/tests/test_release_governance.py
@@ -267,3 +267,96 @@ def test_merge_eligibility_allows_only_active_train_authority():
         "MERGE_ELIGIBILITY_OUTSIDE_ACTIVE_RELEASE:#96",
         "MERGE_ELIGIBILITY_TARGET_RELEASE_MISMATCH:#96",
     ]
+
+
+def test_recovery_ledger_accepts_only_complete_read_back_provenance():
+    live = snapshot()
+    recovered = "d" * 40
+    metadata = "e" * 40
+    live["physical_scope"] = {
+        "previous_release_tag": "v0.1.0",
+        "previous_release_sha": "c" * 40,
+        "release_source_sha": SHA,
+        "compare_status": "ahead",
+        "commit_shas": [recovered, metadata],
+        "unmapped_commit_shas": [],
+        "shipping_prs": [
+            {
+                "number": 71,
+                "merged": True,
+                "primary_crs": [9],
+                "milestone": "DDDA 0.1.1",
+                "target_release": "0.1.1",
+            },
+            {
+                "number": 72,
+                "merged": True,
+                "primary_crs": [12],
+                "milestone": "DDDA 0.1.1",
+                "target_release": "0.1.1",
+            },
+            {
+                "number": 73,
+                "merged": True,
+                "primary_crs": [67],
+                "milestone": "DDDA 0.1.1",
+                "target_release": "0.1.1",
+            },
+            {
+                "number": 74,
+                "merged": True,
+                "primary_crs": [68],
+                "milestone": "DDDA 0.1.1",
+                "target_release": "0.1.1",
+            },
+        ],
+        "recovery_ledger": {
+            "schema_version": 1,
+            "version": VERSION,
+            "previous_release_tag": "v0.1.0",
+            "metadata_commit_shas": [metadata],
+            "entries": [
+                {
+                    "recovered_commit_sha": recovered,
+                    "source_pr": 71,
+                    "primary_cr": 9,
+                    "source_pr_merged": True,
+                    "source_primary_crs": [9],
+                    "source_merge_commit_sha": "f" * 40,
+                    "observed_source_merge_commit_sha": "f" * 40,
+                    "changed_path_hashes_match": True,
+                }
+            ],
+        },
+    }
+    result = evaluate(live=live)
+    assert result.status == "PASS"
+
+
+def test_recovery_ledger_rejects_uncovered_or_tampered_recovery_commit():
+    live = snapshot()
+    recovered = "d" * 40
+    metadata = "e" * 40
+    live["physical_scope"]["commit_shas"] = [recovered, metadata]
+    live["physical_scope"]["recovery_ledger"] = {
+        "schema_version": 1,
+        "version": VERSION,
+        "previous_release_tag": "v0.1.0",
+        "metadata_commit_shas": [metadata],
+        "entries": [
+            {
+                "recovered_commit_sha": recovered,
+                "source_pr": 71,
+                "primary_cr": 9,
+                "source_pr_merged": True,
+                "source_primary_crs": [9],
+                "source_merge_commit_sha": "f" * 40,
+                "observed_source_merge_commit_sha": "0" * 40,
+                "changed_path_hashes_match": False,
+            }
+        ],
+    }
+    result = evaluate(live=live)
+    assert result.status == "FAIL"
+    assert "RECOVERY_LEDGER_SOURCE_MERGE_SHA_MISMATCH:PR#71" in result.failures
+    assert "RECOVERY_LEDGER_PATH_HASH_MISMATCH:PR#71" in result.failures

--- a/runtime/platform/tests/test_release_governance.py
+++ b/runtime/platform/tests/test_release_governance.py
@@ -279,6 +279,7 @@ def test_recovery_ledger_accepts_only_complete_read_back_provenance():
         "release_source_sha": SHA,
         "compare_status": "ahead",
         "commit_shas": [recovered, metadata],
+        "metadata_commit_shas": [metadata],
         "unmapped_commit_shas": [],
         "shipping_prs": [
             {
@@ -314,7 +315,6 @@ def test_recovery_ledger_accepts_only_complete_read_back_provenance():
             "schema_version": 1,
             "version": VERSION,
             "previous_release_tag": "v0.1.0",
-            "metadata_commit_shas": [metadata],
             "entries": [
                 {
                     "recovered_commit_sha": recovered,
@@ -338,11 +338,11 @@ def test_recovery_ledger_rejects_uncovered_or_tampered_recovery_commit():
     recovered = "d" * 40
     metadata = "e" * 40
     live["physical_scope"]["commit_shas"] = [recovered, metadata]
+    live["physical_scope"]["metadata_commit_shas"] = [metadata]
     live["physical_scope"]["recovery_ledger"] = {
         "schema_version": 1,
         "version": VERSION,
         "previous_release_tag": "v0.1.0",
-        "metadata_commit_shas": [metadata],
         "entries": [
             {
                 "recovered_commit_sha": recovered,

--- a/runtime/platform/tests/test_release_governance.py
+++ b/runtime/platform/tests/test_release_governance.py
@@ -1,0 +1,187 @@
+from copy import deepcopy
+
+from runtime.platform.release_governance import evaluate_release_scope, validate_hrdr_shape
+
+REPO = "romanhlavac/ddd-accelerator"
+PR = 71
+SHA = "a" * 40
+PACKAGE = "b" * 64
+VERSION = "0.1.1"
+
+
+def hrdr():
+    return {
+        "schema_version": 1,
+        "repository": REPO,
+        "pr": PR,
+        "branch": "feature/9-release-scope-gate",
+        "source_sha": SHA,
+        "candidate_package_sha256": PACKAGE,
+        "version": VERSION,
+        "reviewer": "romanhlavac",
+        "decision_owner": "romanhlavac",
+        "decision": "go_with_accepted_risks",
+        "decided_at": "2026-08-18T12:00:00Z",
+        "scope_issues": [9, 12, 67, 68],
+        "findings": [{"id": "F-1", "severity": "amber", "summary": "deferred"}],
+        "accepted_risks": [
+            {
+                "risk_id": "R-66",
+                "issue": 66,
+                "owner": "romanhlavac",
+                "rationale": "product depth deferred",
+                "target_horizon": "TBD",
+            }
+        ],
+        "evidence": {},
+    }
+
+
+def snapshot():
+    return {
+        "current_pr_head": SHA,
+        "milestone_title": "DDDA 0.1.1",
+        "milestone_issues": [9, 12, 67, 68],
+        "issue_states": {"9": "closed", "12": "closed", "67": "closed", "68": "closed"},
+        "blockers": {"9": [], "12": [], "67": [], "68": []},
+        "project_rows": {
+            "9": {"Status": "Done", "Blocked": "No"},
+            "12": {"Status": "Done", "Blocked": "No"},
+            "67": {"Status": "Done", "Blocked": "No"},
+            "68": {"Status": "Done", "Blocked": "No"},
+        },
+        "risk_issue_states": {"66": "open"},
+        "risk_issue_assignees": {"66": ["romanhlavac"]},
+        "risk_issue_horizons": {"66": "TBD"},
+        "project": {
+            "title": "DDDA Platform Backlog & Delivery",
+            "planning_view_filter": "is:issue",
+            "delivery_view_filter": "is:pr is:open",
+        },
+    }
+
+
+def evaluate(record=None, live=None):
+    return evaluate_release_scope(
+        record or hrdr(),
+        live or snapshot(),
+        expected_repository=REPO,
+        expected_pr=PR,
+        expected_source_sha=SHA,
+        expected_package_sha256=PACKAGE,
+        expected_version=VERSION,
+    )
+
+
+def test_valid_release_scope_passes():
+    result = evaluate()
+    assert result.status == "PASS"
+    assert result.side_effects_allowed is True
+
+
+def test_open_current_release_issue_fails_before_side_effects():
+    live = snapshot()
+    live["issue_states"]["12"] = "open"
+    result = evaluate(live=live)
+    assert result.status == "FAIL"
+    assert "SCOPE_ITEM_NOT_TERMINAL:#12" in result.failures
+    assert result.side_effects_allowed is False
+
+
+def test_unresolved_blocker_fails_before_side_effects():
+    live = snapshot()
+    live["blockers"]["12"] = [14]
+    result = evaluate(live=live)
+    assert result.status == "FAIL"
+    assert "SCOPE_ITEM_ACTIVE_BLOCKER:#12" in result.failures
+    assert result.side_effects_allowed is False
+
+
+def test_milestone_scope_drift_fails_before_side_effects():
+    live = snapshot()
+    live["milestone_issues"] = [9, 12, 67]
+    result = evaluate(live=live)
+    assert result.status == "FAIL"
+    assert "MILESTONE_SCOPE_MISMATCH" in result.failures
+    assert result.side_effects_allowed is False
+
+
+def test_project_projection_drift_fails():
+    live = snapshot()
+    live["project_rows"]["12"]["Status"] = "Blocked"
+    result = evaluate(live=live)
+    assert result.status == "FAIL"
+    assert "SCOPE_ITEM_PROJECT_STATUS:#12" in result.failures
+
+
+def test_changed_sha_invalidates_human_decision():
+    result = evaluate_release_scope(
+        hrdr(),
+        snapshot(),
+        expected_repository=REPO,
+        expected_pr=PR,
+        expected_source_sha="c" * 40,
+        expected_package_sha256=PACKAGE,
+        expected_version=VERSION,
+    )
+    assert result.status == "FAIL"
+    assert "IDENTITY_SOURCE_SHA_MISMATCH" in result.failures
+
+
+def test_red_finding_blocks_release():
+    record = hrdr()
+    record["findings"].append({"id": "F-RED", "severity": "red", "summary": "blocker"})
+    result = evaluate(record=record)
+    assert result.status == "FAIL"
+    assert "RED_FINDING_PRESENT" in result.failures
+
+
+def test_pending_human_decision_blocks_release():
+    record = hrdr()
+    record["decision"] = "pending"
+    record["decided_at"] = None
+    result = evaluate(record=record)
+    assert result.status == "FAIL"
+    assert "HUMAN_RELEASE_DECISION_NOT_POSITIVE" in result.failures
+
+
+def test_deferred_risk_must_be_outside_milestone():
+    live = snapshot()
+    live["milestone_issues"].append(66)
+    record = hrdr()
+    record["scope_issues"].append(66)
+    live["issue_states"]["66"] = "closed"
+    live["blockers"]["66"] = []
+    live["project_rows"]["66"] = {"Status": "Done", "Blocked": "No"}
+    result = evaluate(record=record, live=live)
+    assert result.status == "FAIL"
+    assert "DEFERRED_RISK_STILL_IN_MILESTONE:#66" in result.failures
+
+
+def test_deferred_risk_owner_must_match_live_assignee():
+    live = snapshot()
+    live["risk_issue_assignees"]["66"] = []
+    result = evaluate(live=live)
+    assert result.status == "FAIL"
+    assert "DEFERRED_RISK_OWNER_MISMATCH:#66" in result.failures
+
+
+def test_go_cannot_silently_accept_risks():
+    record = hrdr()
+    record["decision"] = "go"
+    failures = validate_hrdr_shape(record)
+    assert "HRDR_GO_HAS_ACCEPTED_RISKS" in failures
+
+
+def test_identity_contract_rejects_package_drift():
+    result = evaluate_release_scope(
+        hrdr(),
+        snapshot(),
+        expected_repository=REPO,
+        expected_pr=PR,
+        expected_source_sha=SHA,
+        expected_package_sha256="d" * 64,
+        expected_version=VERSION,
+    )
+    assert result.status == "FAIL"
+    assert "IDENTITY_PACKAGE_SHA256_MISMATCH" in result.failures

--- a/runtime/platform/tests/test_release_scope_collectors.py
+++ b/runtime/platform/tests/test_release_scope_collectors.py
@@ -1,0 +1,92 @@
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCOPE_COLLECTOR = ROOT / "scripts/platform/Test-DDDAReleaseScope.py"
+MERGE_COLLECTOR = ROOT / "scripts/platform/Test-DDDAMergeReleaseEligibility.py"
+
+
+def _scope_namespace():
+    spec = importlib.util.spec_from_file_location("ddda_release_scope_collector_test", SCOPE_COLLECTOR)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_previous_release_tag_selects_latest_older_semver_and_dereferences_annotation():
+    ns = _scope_namespace()
+
+    def fake_get(path, _token):
+        if path.endswith("matching-refs/tags/"):
+            return [
+                {"ref": "refs/tags/v0.1.0", "object": {"sha": "a" * 40, "type": "tag"}},
+                {"ref": "refs/tags/v0.1.1", "object": {"sha": "b" * 40, "type": "commit"}},
+                {"ref": "refs/tags/not-a-release", "object": {"sha": "c" * 40, "type": "commit"}},
+            ]
+        if path.endswith(f"git/tags/{'a' * 40}"):
+            return {"object": {"sha": "d" * 40, "type": "commit"}}
+        raise AssertionError(path)
+
+    ns.rest_get = fake_get
+    assert ns.previous_release_tag("owner/repo", "0.1.2", "token") == {
+        "tag": "v0.1.1",
+        "sha": "b" * 40,
+    }
+    assert ns.previous_release_tag("owner/repo", "0.1.1", "token") == {
+        "tag": "v0.1.0",
+        "sha": "d" * 40,
+    }
+
+
+def test_physical_scope_inventory_keeps_unmapped_commit_and_exact_primary_relation():
+    ns = _scope_namespace()
+    ns.previous_release_tag = lambda *_: {"tag": "v0.1.0", "sha": "a" * 40}
+    ns.compare_commits = lambda *_: (
+        "ahead",
+        [{"sha": "b" * 40}, {"sha": "c" * 40}],
+    )
+
+    def fake_pages(path, _token):
+        if f"commits/{'b' * 40}/pulls" in path:
+            return [{"number": 77}]
+        if f"commits/{'c' * 40}/pulls" in path:
+            return []
+        raise AssertionError(path)
+
+    def fake_get(path, _token):
+        if path.endswith("pulls/77"):
+            return {"merged_at": "2026-08-25T00:00:00Z", "body": "Implements #96\n"}
+        if path.endswith("issues/96"):
+            return {"milestone": {"title": "DDDA 0.1.1"}}
+        raise AssertionError(path)
+
+    ns.rest_pages = fake_pages
+    ns.rest_get = fake_get
+    actual = ns.physical_scope_snapshot(
+        "owner/repo", "0.1.1", "d" * 40, "token", {96: {"Target Release": "0.1.1"}}
+    )
+    assert actual["unmapped_commit_shas"] == ["c" * 40]
+    assert actual["shipping_prs"] == [
+        {
+            "number": 77,
+            "merged": True,
+            "merge_commit_sha": None,
+            "primary_crs": [96],
+            "milestone": "DDDA 0.1.1",
+            "target_release": "0.1.1",
+        }
+    ]
+
+
+def test_merge_collector_recognizes_one_open_release_train_and_tbd_target():
+    spec = importlib.util.spec_from_file_location("ddda_merge_eligibility_collector_test", MERGE_COLLECTOR)
+    assert spec and spec.loader
+    ns = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ns)
+    assert ns.active_release([{"title": "DDDA 0.1.1", "state": "open"}]) == {
+        "version": "0.1.1"
+    }
+    assert ns.primary_changes("Implements #96\nCloses #96\n") == [96]
+    assert ns.target_release("Target Release: `TBD`\n") == "TBD"

--- a/runtime/platform/tests/test_release_scope_collectors.py
+++ b/runtime/platform/tests/test_release_scope_collectors.py
@@ -64,6 +64,7 @@ def test_physical_scope_inventory_keeps_unmapped_commit_and_exact_primary_relati
 
     ns.rest_pages = fake_pages
     ns.rest_get = fake_get
+    ns.recovery_ledger_at_source = lambda *_: None
     actual = ns.physical_scope_snapshot(
         "owner/repo", "0.1.1", "d" * 40, "token", {96: {"Target Release": "0.1.1"}}
     )

--- a/runtime/platform/tests/test_release_tag_identity.py
+++ b/runtime/platform/tests/test_release_tag_identity.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+import os
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[3]
+PROMOTION = ROOT / "scripts" / "platform" / "Invoke-DDDAPromotePr.ps1"
+RECOVERY_DOC = ROOT / "docs" / "developer-guide" / "release-tag-recovery.md"
+
+
+def _run(args, *, env, check=True):
+    return subprocess.run(args, env=env, text=True, capture_output=True, check=check)
+
+
+def test_release_executor_configures_deterministic_repo_local_tagger_before_tag_creation():
+    text = PROMOTION.read_text(encoding="utf-8-sig")
+
+    name_assignment = '$releaseTaggerName = "DDDA Release Tagger"'
+    email_assignment = '$releaseTaggerEmail = "ddda-release-tagger@example.invalid"'
+    name_config = '@("config", "user.name", $releaseTaggerName)'
+    email_config = '@("config", "user.email", $releaseTaggerEmail)'
+    tag_creation = '@("tag", "-a", $tag, $mergeCommit, "-m", "DDDA $Version")'
+
+    for contract in (name_assignment, email_assignment, name_config, email_config, tag_creation):
+        assert contract in text
+
+    assert text.index(name_assignment) < text.index(tag_creation)
+    assert text.index(email_assignment) < text.index(tag_creation)
+    assert text.index(name_config) < text.index(tag_creation)
+    assert text.index(email_config) < text.index(tag_creation)
+    assert '@("push", "origin", $tag)' in text
+
+
+def test_annotated_release_tag_succeeds_without_ambient_git_identity(tmp_path):
+    repo = tmp_path / "repo"
+    empty_global = tmp_path / "empty.gitconfig"
+    empty_global.write_text("", encoding="utf-8")
+
+    clean_env = os.environ.copy()
+    clean_env["GIT_CONFIG_GLOBAL"] = str(empty_global)
+    clean_env["GIT_CONFIG_NOSYSTEM"] = "1"
+    for key in (
+        "GIT_AUTHOR_NAME",
+        "GIT_AUTHOR_EMAIL",
+        "GIT_COMMITTER_NAME",
+        "GIT_COMMITTER_EMAIL",
+    ):
+        clean_env.pop(key, None)
+
+    _run(["git", "init", "-b", "main", str(repo)], env=clean_env)
+    (repo / "fixture.txt").write_text("fixture\n", encoding="utf-8")
+    _run(["git", "-C", str(repo), "add", "."], env=clean_env)
+    _run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=Fixture Committer",
+            "-c",
+            "user.email=fixture@example.invalid",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+        env=clean_env,
+    )
+    commit = _run(["git", "-C", str(repo), "rev-parse", "HEAD"], env=clean_env).stdout.strip()
+
+    assert _run(["git", "-C", str(repo), "config", "--get", "user.name"], env=clean_env, check=False).returncode == 1
+    assert _run(["git", "-C", str(repo), "config", "--get", "user.email"], env=clean_env, check=False).returncode == 1
+
+    _run(["git", "-C", str(repo), "config", "user.name", "DDDA Release Tagger"], env=clean_env)
+    _run(["git", "-C", str(repo), "config", "user.email", "ddda-release-tagger@example.invalid"], env=clean_env)
+    _run(["git", "-C", str(repo), "tag", "-a", "v9.9.9", commit, "-m", "DDDA 9.9.9"], env=clean_env)
+
+    target = _run(["git", "-C", str(repo), "rev-list", "-n", "1", "v9.9.9"], env=clean_env).stdout.strip()
+    record = _run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "for-each-ref",
+            "refs/tags/v9.9.9",
+            "--format=%(taggername)|%(taggeremail)|%(contents)",
+        ],
+        env=clean_env,
+    ).stdout.strip()
+
+    assert target == commit
+    assert record == "DDDA Release Tagger|<ddda-release-tagger@example.invalid>|DDDA 9.9.9"
+
+
+def test_release_tag_recovery_runbook_is_bounded():
+    text = RECOVERY_DOC.read_text(encoding="utf-8")
+    for invariant in (
+        "same version",
+        "same validated release SHA",
+        "same release report",
+        "same release package SHA-256",
+        "separate explicit human recovery authorization",
+        "existing canonical tag",
+        "no history rewrite",
+    ):
+        assert invariant in text

--- a/runtime/platform/tests/test_validate_repository.py
+++ b/runtime/platform/tests/test_validate_repository.py
@@ -155,6 +155,7 @@ def test_failure_report_can_exist_before_package_creation() -> None:
 
     jsonschema.validate(report, schema)
 
+
 def test_validation_report_preserves_deleted_miro_board_evidence() -> None:
     schema = json.loads(
         (REPOSITORY_ROOT / "schemas" / "validation-report.schema.json").read_text(
@@ -351,18 +352,18 @@ def test_release_contracts_detect_auth_provider_order_drift(tmp_path: Path) -> N
     assert any("inconsistent GitHub auth provider order" in failure for failure in failures)
 
 
-def test_release_contracts_detect_unreleased_release_items(tmp_path: Path) -> None:
+def test_release_contracts_allow_unreleased_items_during_development(tmp_path: Path) -> None:
     write_release_contract_fixture(tmp_path)
     changelog = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
     changelog = changelog.replace(
         "Development notes belong here without release bullets.\n",
-        "- not assigned to a release.\n",
+        "### Added\n\n- not assigned to a release yet.\n",
     )
     (tmp_path / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
 
     failures = MODULE.validate_release_contracts(tmp_path)
 
-    assert any("[Unreleased] contains release items" in failure for failure in failures)
+    assert failures == []
 
 
 def test_release_contracts_detect_invalid_release_date(tmp_path: Path) -> None:

--- a/runtime/platform/validate_repository.py
+++ b/runtime/platform/validate_repository.py
@@ -100,7 +100,6 @@ def tracked_or_distributed_files(root: Path) -> list[Path]:
     ]
 
 
-
 def _section_body(text: str, heading_match: re.Match[str]) -> str:
     start = heading_match.end()
     next_heading = re.search(r"^##\s+", text[start:], re.MULTILINE)
@@ -190,10 +189,9 @@ def validate_release_contracts(root: Path) -> list[str]:
         failures.append(
             f"CHANGELOG.md must contain exactly one '## [Unreleased]' heading, found {len(unreleased_matches)}"
         )
-    elif RELEASE_ITEM_PATTERN.search(_section_body(changelog, unreleased_matches[0])):
-        failures.append(
-            "CHANGELOG.md [Unreleased] contains release items; cut them into a versioned release before promotion"
-        )
+    # Development changes intentionally live under Unreleased. Requiring that
+    # section to be empty belongs to promotion-time Assert-DDDAPlatformChangelogRelease,
+    # not ordinary PR/source repository validation.
 
     release_matches = list(RELEASE_HEADING_PATTERN.finditer(changelog))
     if not release_matches:
@@ -241,6 +239,7 @@ def validate_release_contracts(root: Path) -> list[str]:
             )
 
     return failures
+
 
 def validate_lint(root: Path) -> list[str]:
     failures: list[str] = []

--- a/schemas/human-release-decision.schema.json
+++ b/schemas/human-release-decision.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ddda.local/schemas/human-release-decision.schema.json",
+  "title": "DDDA Human Release Decision Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "repository",
+    "pr",
+    "branch",
+    "source_sha",
+    "candidate_package_sha256",
+    "version",
+    "reviewer",
+    "decision_owner",
+    "decision",
+    "decided_at",
+    "scope_issues",
+    "findings",
+    "accepted_risks"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "repository": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+    "pr": { "type": "integer", "minimum": 1 },
+    "branch": { "type": "string", "minLength": 1 },
+    "source_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "candidate_package_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "version": { "type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$" },
+    "reviewer": { "type": "string" },
+    "decision_owner": { "type": "string" },
+    "decision": { "enum": ["pending", "go", "go_with_accepted_risks", "no_go"] },
+    "decided_at": { "type": ["string", "null"], "format": "date-time" },
+    "scope_issues": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "integer", "minimum": 1 }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "severity", "summary"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "severity": { "enum": ["green", "amber", "red"] },
+          "summary": { "type": "string", "minLength": 1 },
+          "evidence": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "accepted_risks": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["risk_id", "issue", "owner", "rationale", "target_horizon"],
+        "properties": {
+          "risk_id": { "type": "string", "minLength": 1 },
+          "issue": { "type": "integer", "minimum": 1 },
+          "owner": { "type": "string", "minLength": 1 },
+          "rationale": { "type": "string", "minLength": 1 },
+          "target_horizon": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "evidence": { "type": "object", "additionalProperties": true }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "decision": { "const": "pending" } }, "required": ["decision"] },
+      "then": { "properties": { "decided_at": { "type": "null" } } },
+      "else": {
+        "properties": {
+          "reviewer": { "type": "string", "minLength": 1 },
+          "decision_owner": { "type": "string", "minLength": 1 },
+          "decided_at": { "type": "string", "format": "date-time" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "decision": { "const": "go" } }, "required": ["decision"] },
+      "then": { "properties": { "accepted_risks": { "maxItems": 0 } } }
+    },
+    {
+      "if": { "properties": { "decision": { "const": "go_with_accepted_risks" } }, "required": ["decision"] },
+      "then": { "properties": { "accepted_risks": { "minItems": 1 } } }
+    }
+  ]
+}

--- a/schemas/release-source-recovery-ledger.schema.json
+++ b/schemas/release-source-recovery-ledger.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ddda.example.invalid/schemas/release-source-recovery-ledger.schema.json",
+  "title": "DDDA controlled release-source recovery ledger",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "version", "previous_release_tag", "metadata_commit_shas", "entries"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "version": {"type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"},
+    "previous_release_tag": {"type": "string", "pattern": "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"},
+    "metadata_commit_shas": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["recovered_commit_sha", "source_pr", "source_merge_commit_sha", "primary_cr"],
+        "properties": {
+          "recovered_commit_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+          "source_pr": {"type": "integer", "minimum": 1},
+          "source_merge_commit_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+          "primary_cr": {"type": "integer", "minimum": 1}
+        }
+      }
+    }
+  }
+}

--- a/schemas/release-source-recovery-ledger.schema.json
+++ b/schemas/release-source-recovery-ledger.schema.json
@@ -4,17 +4,11 @@
   "title": "DDDA controlled release-source recovery ledger",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "version", "previous_release_tag", "metadata_commit_shas", "entries"],
+  "required": ["schema_version", "version", "previous_release_tag", "entries"],
   "properties": {
     "schema_version": {"const": 1},
     "version": {"type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"},
     "previous_release_tag": {"type": "string", "pattern": "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"},
-    "metadata_commit_shas": {
-      "type": "array",
-      "minItems": 1,
-      "maxItems": 1,
-      "items": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
-    },
     "entries": {
       "type": "array",
       "minItems": 1,

--- a/scripts/platform/DDDAMergeStrategySupport.ps1
+++ b/scripts/platform/DDDAMergeStrategySupport.ps1
@@ -1,0 +1,230 @@
+﻿Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:DDDAChangeClassificationMarker = "<!-- ddda:change-classification:v1 -->"
+$script:DDDASquashExceptionMarker = "<!-- ddda:squash-exception:v1 -->"
+
+function Get-DDDAMarkedJsonRecord {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [Parameter(Mandatory = $true)][string]$Marker,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [switch]$AllowMissing
+    )
+
+    $escapedMarker = [regex]::Escape($Marker)
+    $markerMatches = [regex]::Matches($Text, $escapedMarker, [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
+    if ($markerMatches.Count -eq 0) {
+        if ($AllowMissing) { return $null }
+        throw "$Label marker chybí."
+    }
+    if ($markerMatches.Count -ne 1) {
+        throw "$Label marker musí být právě jeden. Nalezeno: $($markerMatches.Count)."
+    }
+
+    $pattern = '(?s)' + $escapedMarker + '\s*```json\s*(?<json>\{.*?\})\s*```'
+    $matches = [regex]::Matches($Text, $pattern, [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
+    if ($matches.Count -ne 1) {
+        throw "$Label marker existuje, ale jeho fenced JSON record chybí nebo je neplatně strukturován."
+    }
+
+    try {
+        return $matches[0].Groups["json"].Value | ConvertFrom-Json
+    }
+    catch {
+        throw "$Label JSON nelze parse: $($_.Exception.Message)"
+    }
+}
+
+function Get-DDDAChangeImpactFromPrBody {
+    param([AllowEmptyString()][string]$Body = "")
+
+    $record = Get-DDDAMarkedJsonRecord `
+        -Text $Body `
+        -Marker $script:DDDAChangeClassificationMarker `
+        -Label "Change classification" `
+        -AllowMissing
+    if ($null -eq $record) {
+        return "UNKNOWN"
+    }
+    if ([int]$record.schema_version -ne 1) {
+        throw "Change classification má nepodporovaný schema_version."
+    }
+    $impact = ([string]$record.impact).ToUpperInvariant()
+    if ($impact -notin @("LOW", "MEDIUM", "HIGH", "BREAKING")) {
+        throw "Change classification impact '$impact' není podporovaný."
+    }
+    return $impact
+}
+
+function Test-DDDABootstrapMergeTransitionCandidate {
+    param(
+        [Parameter(Mandatory = $true)][object]$MergeStrategy,
+        [Parameter(Mandatory = $true)][string]$BaseSha,
+        [AllowEmptyString()][string]$PrBody = "",
+        [Parameter(Mandatory = $true)][string]$Impact
+    )
+
+    $property = $MergeStrategy.PSObject.Properties["bootstrap_transition"]
+    if ($null -eq $property -or $null -eq $property.Value) {
+        return $false
+    }
+    $transition = $property.Value
+    if (-not [bool]$transition.prospective_after_integration) { return $false }
+    if ($BaseSha -ne [string]$transition.legacy_base_sha) { return $false }
+    if ($Impact -notin @("HIGH", "BREAKING")) { return $false }
+
+    $changeIssue = [int]$transition.change_issue
+    $relationPattern = "(?im)^\s*(?:Implements|Closes)\s+#$changeIssue\s*$"
+    $relations = [regex]::Matches($PrBody, $relationPattern)
+    if ($relations.Count -ne 1) { return $false }
+
+    return $true
+}
+
+function Resolve-DDDAMergeStrategy {
+    param(
+        [Parameter(Mandatory = $true)][object]$Policy,
+        [Parameter(Mandatory = $true)][string]$Impact,
+        [AllowEmptyString()][string]$RequestedMethod = "",
+        [Parameter(Mandatory = $true)][int]$Pr,
+        [Parameter(Mandatory = $true)][string]$BaseSha,
+        [AllowEmptyString()][string]$PrBody = ""
+    )
+
+    $mergeStrategyProperty = $Policy.PSObject.Properties["merge_strategy"]
+    if ($null -eq $mergeStrategyProperty -or $null -eq $mergeStrategyProperty.Value) {
+        throw "Platform development policy neobsahuje merge_strategy contract."
+    }
+    $strategy = $mergeStrategyProperty.Value
+    if ([int]$strategy.schema_version -ne 1) {
+        throw "Nepodporovaný merge_strategy schema_version."
+    }
+
+    $impactValue = $Impact.ToUpperInvariant()
+    $bootstrapCandidate = Test-DDDABootstrapMergeTransitionCandidate `
+        -MergeStrategy $strategy `
+        -BaseSha $BaseSha `
+        -PrBody $PrBody `
+        -Impact $impactValue
+
+    if ($bootstrapCandidate) {
+        $legacyMethod = ([string]$strategy.bootstrap_transition.legacy_merge_method).ToLowerInvariant()
+        if ($legacyMethod -notin @("merge", "squash")) {
+            throw "Bootstrap transition legacy merge method '$legacyMethod' není podporovaný."
+        }
+        $bootstrapMethod = if ([string]::IsNullOrWhiteSpace($RequestedMethod)) {
+            $legacyMethod
+        }
+        else {
+            $RequestedMethod.ToLowerInvariant()
+        }
+        if ($bootstrapMethod -ne $legacyMethod) {
+            throw "Exact #$([int]$strategy.bootstrap_transition.change_issue) bootstrap candidate se řídí pre-existing policy a vyžaduje merge method '$legacyMethod'; požadováno '$bootstrapMethod'."
+        }
+        return [pscustomobject][ordered]@{
+            impact = $impactValue
+            merge_method = $legacyMethod
+            human_squash_exception_required = $false
+            bootstrap_transition = $true
+        }
+    }
+
+    $method = if ([string]::IsNullOrWhiteSpace($RequestedMethod)) {
+        [string]$strategy.default_method
+    }
+    else {
+        $RequestedMethod.ToLowerInvariant()
+    }
+    if ($method -notin @("merge", "squash")) {
+        throw "Canonical DDDA merge method '$method' není podporovaný. Rebase není povolen, protože nezachovává exact validated PR HEAD identity."
+    }
+
+    if ($impactValue -eq "UNKNOWN") {
+        $allowed = @($strategy.unknown_impact_allowed_methods | ForEach-Object { ([string]$_).ToLowerInvariant() })
+        if ($method -notin $allowed) {
+            throw "PR bez autoritativní impact classification smí použít pouze: $($allowed -join ', ')."
+        }
+        return [pscustomobject][ordered]@{
+            impact = $impactValue
+            merge_method = $method
+            human_squash_exception_required = $false
+            bootstrap_transition = $false
+        }
+    }
+
+    $impactProperty = $strategy.impacts.PSObject.Properties[$impactValue]
+    if ($null -eq $impactProperty) {
+        throw "Merge strategy neobsahuje pravidlo pro impact '$impactValue'."
+    }
+    $rule = $impactProperty.Value
+    $allowedMethods = @($rule.allowed_methods | ForEach-Object { ([string]$_).ToLowerInvariant() })
+    if ($method -notin $allowedMethods) {
+        throw "Merge method '$method' není povolen pro impact '$impactValue'. Povolené: $($allowedMethods -join ', ')."
+    }
+
+    $requiresException = (
+        $method -eq "squash" -and
+        [bool]$rule.squash_requires_human_exception
+    )
+    return [pscustomobject][ordered]@{
+        impact = $impactValue
+        merge_method = $method
+        human_squash_exception_required = $requiresException
+        bootstrap_transition = $false
+    }
+}
+
+function ConvertFrom-DDDASquashExceptionComment {
+    param([Parameter(Mandatory = $true)][object]$Comment)
+
+    return Get-DDDAMarkedJsonRecord `
+        -Text ([string]$Comment.body) `
+        -Marker $script:DDDASquashExceptionMarker `
+        -Label "Squash exception"
+}
+
+function Assert-DDDASquashExceptionRecord {
+    param(
+        [Parameter(Mandatory = $true)][object]$Record,
+        [Parameter(Mandatory = $true)][string]$CommentAuthor,
+        [Parameter(Mandatory = $true)][string]$CommentAuthorType,
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][int]$Pr,
+        [Parameter(Mandatory = $true)][string]$HeadSha,
+        [Parameter(Mandatory = $true)][string]$CandidatePackageSha256,
+        [Parameter(Mandatory = $true)][string]$Impact
+    )
+
+    if ([string]::IsNullOrWhiteSpace($CommentAuthor) -or $CommentAuthorType -eq "Bot" -or $CommentAuthor -match '\[bot\]$') {
+        throw "Squash exception musí mít lidskou GitHub provenance."
+    }
+    if ([int]$Record.schema_version -ne 1 -or [string]$Record.kind -ne "squash_exception") {
+        throw "Squash exception má nepodporovaný contract."
+    }
+    if ([string]$Record.repository -ne $Repository -or [int]$Record.pr -ne $Pr) {
+        throw "Squash exception repository/PR identity neodpovídá aktuálnímu PR."
+    }
+    if ([string]$Record.validated_source_head_sha -ne $HeadSha) {
+        throw "Squash exception validated_source_head_sha neodpovídá current PR head."
+    }
+    if ([string]$Record.candidate_package_sha256 -ne $CandidatePackageSha256) {
+        throw "Squash exception candidate package hash neodpovídá validate-pr evidence."
+    }
+    if (([string]$Record.impact).ToUpperInvariant() -ne $Impact.ToUpperInvariant()) {
+        throw "Squash exception impact neodpovídá PR classification."
+    }
+    if ([string]$Record.reviewer -ne $CommentAuthor) {
+        throw "Squash exception reviewer neodpovídá human comment authorovi."
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$Record.reason)) {
+        throw "Squash exception vyžaduje neprázdný reason."
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$Record.approved_at)) {
+        throw "Squash exception vyžaduje approved_at."
+    }
+    $approvedAt = [DateTimeOffset]::MinValue
+    if (-not [DateTimeOffset]::TryParse([string]$Record.approved_at, [ref]$approvedAt)) {
+        throw "Squash exception approved_at není platný timestamp."
+    }
+}

--- a/scripts/platform/DDDAMiroEvidenceSupport.ps1
+++ b/scripts/platform/DDDAMiroEvidenceSupport.ps1
@@ -24,6 +24,36 @@ function Get-DDDAMiroEvidencePropertyValue {
     return $property.Value
 }
 
+function Get-DDDAMiroBoardIdentityHandoff {
+    param([object[]]$ChildOutput = @())
+
+    $text = (($ChildOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine)
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    $matches = [regex]::Matches($text, '(?m)^DDDA_MIRO_BOARD_ID_HANDOFF:(?<id>[^\r\n]+?)\s*$')
+    if ($matches.Count -eq 0) {
+        return $null
+    }
+
+    $ids = @(
+        $matches |
+            ForEach-Object { [string]$_.Groups['id'].Value.Trim() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Select-Object -Unique
+    )
+    if ($ids.Count -ne 1) {
+        throw "Miro board identity handoff je nejednoznačný. Nalezené identity: $($ids -join ', ')"
+    }
+
+    return [pscustomobject][ordered]@{
+        board_id = [string]$ids[0]
+        board_url = "https://miro.com/app/board/$($ids[0])/"
+        source = "create_board_stderr_handoff"
+    }
+}
+
 function New-DDDANotRunMiroEvidence {
     param(
         [string]$Workspace,

--- a/scripts/platform/DDDAPromotionResultSupport.ps1
+++ b/scripts/platform/DDDAPromotionResultSupport.ps1
@@ -1,0 +1,139 @@
+﻿Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-DDDAGitHubProbeStatus {
+    param(
+        [Parameter(Mandatory = $true)][bool]$Succeeded,
+        [AllowNull()][object]$HttpStatus,
+        [int[]]$ExpectedAbsentStatus = @(404)
+    )
+
+    if ($Succeeded) {
+        return "PRESENT"
+    }
+    if ($null -ne $HttpStatus) {
+        $status = [int]$HttpStatus
+        if ($status -in $ExpectedAbsentStatus) {
+            return "ABSENT"
+        }
+    }
+    return "ERROR"
+}
+
+function Invoke-DDDAGitHubGetProbe {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Token,
+        [int[]]$ExpectedAbsentStatus = @(404)
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Token)) {
+        throw "GitHub probe token is empty."
+    }
+    $uri = if ($Path -match '^https://') { $Path } else { "https://api.github.com/" + $Path.TrimStart('/') }
+    $headers = @{
+        Authorization = "Bearer $Token"
+        Accept = "application/vnd.github+json"
+        "X-GitHub-Api-Version" = "2022-11-28"
+        "User-Agent" = "DDDA-Platform-Promotion-Probe"
+    }
+
+    try {
+        $value = Invoke-RestMethod -Method GET -Uri $uri -Headers $headers -ErrorAction Stop
+        return [pscustomobject]@{
+            status = "PRESENT"
+            http_status = 200
+            value = $value
+            error = $null
+        }
+    }
+    catch {
+        $httpStatus = $null
+        try {
+            if ($null -ne $_.Exception.Response) {
+                $httpStatus = [int]$_.Exception.Response.StatusCode
+            }
+        }
+        catch {
+        }
+        $classification = Resolve-DDDAGitHubProbeStatus -Succeeded $false -HttpStatus $httpStatus -ExpectedAbsentStatus $ExpectedAbsentStatus
+        if ($classification -eq "ABSENT") {
+            return [pscustomobject]@{
+                status = "ABSENT"
+                http_status = [int]$httpStatus
+                value = $null
+                error = $null
+            }
+        }
+        $statusText = if ($null -eq $httpStatus) { "unknown" } else { [string]$httpStatus }
+        throw "GitHub probe GET $Path failed unexpectedly. HTTP: $statusText. $($_.Exception.Message)"
+    }
+}
+
+function Get-DDDAPromotionDryRunSnapshot {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositorySlug,
+        [Parameter(Mandatory = $true)][int]$Pr,
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string]$Token
+    )
+
+    $prInfo = Get-DDDAGitHubPullRequest -RepositorySlug $RepositorySlug -Pr $Pr -Token $Token
+    $baseBranch = [string]$prInfo.base.ref
+    if ($baseBranch -notmatch '^[A-Za-z0-9._/-]+$') {
+        throw "Unsupported base branch name returned by GitHub: $baseBranch"
+    }
+    if ($Tag -notmatch '^v[0-9A-Za-z._+-]+$') {
+        throw "Unsupported release tag for dry-run probe: $Tag"
+    }
+
+    $baseProbe = Invoke-DDDAGitHubGetProbe -Path "repos/$RepositorySlug/git/ref/heads/$baseBranch" -Token $Token -ExpectedAbsentStatus @()
+    if ([string]$baseProbe.status -ne "PRESENT" -or [string]::IsNullOrWhiteSpace([string]$baseProbe.value.object.sha)) {
+        throw "Base branch ref probe did not return a SHA for $baseBranch."
+    }
+    $tagProbe = Invoke-DDDAGitHubGetProbe -Path "repos/$RepositorySlug/git/ref/tags/$Tag" -Token $Token -ExpectedAbsentStatus @(404)
+    $releaseProbe = Invoke-DDDAGitHubGetProbe -Path "repos/$RepositorySlug/releases/tags/$Tag" -Token $Token -ExpectedAbsentStatus @(404)
+
+    return [pscustomobject]@{
+        pr_merged = [bool]$prInfo.merged
+        head_sha = [string]$prInfo.head.sha
+        base_branch = $baseBranch
+        base_sha = [string]$baseProbe.value.object.sha
+        tag_status = [string]$tagProbe.status
+        tag_http_status = $tagProbe.http_status
+        github_release_status = [string]$releaseProbe.status
+        github_release_http_status = $releaseProbe.http_status
+    }
+}
+
+function Test-DDDAPromotionDryRunSideEffects {
+    param(
+        [Parameter(Mandatory = $true)]$Before,
+        [Parameter(Mandatory = $true)]$After,
+        [Parameter(Mandatory = $true)][string]$ExpectedHeadSha
+    )
+
+    $failures = [System.Collections.Generic.List[string]]::new()
+    if ([bool]$Before.pr_merged) { $failures.Add("pr_already_merged_before_dry_run") }
+    if ([bool]$After.pr_merged) { $failures.Add("pr_merged_by_dry_run") }
+    if ([string]$Before.head_sha -ne $ExpectedHeadSha) { $failures.Add("pr_head_mismatch_before_dry_run") }
+    if ([string]$After.head_sha -ne $ExpectedHeadSha) { $failures.Add("pr_head_changed_by_dry_run") }
+    if ([string]$Before.base_sha -ne [string]$After.base_sha) { $failures.Add("base_sha_changed_by_dry_run") }
+    if ([string]$Before.tag_status -ne "ABSENT") { $failures.Add("tag_not_absent_before_dry_run") }
+    if ([string]$After.tag_status -ne "ABSENT") { $failures.Add("tag_created_by_dry_run") }
+    if ([string]$Before.github_release_status -ne "ABSENT") { $failures.Add("github_release_not_absent_before_dry_run") }
+    if ([string]$After.github_release_status -ne "ABSENT") { $failures.Add("github_release_created_by_dry_run") }
+
+    return [pscustomobject]@{
+        status = if ($failures.Count -eq 0) { "PASS" } else { "FAIL" }
+        failures = @($failures)
+        assertions = [ordered]@{
+            pr_not_merged = (-not [bool]$After.pr_merged)
+            pr_head_unchanged = ([string]$Before.head_sha -eq $ExpectedHeadSha -and [string]$After.head_sha -eq $ExpectedHeadSha)
+            base_sha_unchanged = ([string]$Before.base_sha -eq [string]$After.base_sha)
+            tag_absent = ([string]$Before.tag_status -eq "ABSENT" -and [string]$After.tag_status -eq "ABSENT")
+            github_release_absent = ([string]$Before.github_release_status -eq "ABSENT" -and [string]$After.github_release_status -eq "ABSENT")
+            promotion_mutation_absent = ($failures.Count -eq 0)
+        }
+    }
+}

--- a/scripts/platform/DDDAReleaseGovernanceSupport.ps1
+++ b/scripts/platform/DDDAReleaseGovernanceSupport.ps1
@@ -1,0 +1,204 @@
+﻿Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:DDDAHrdrMarker = "<!-- ddda:human-release-decision:v1 -->"
+$script:DDDAHumanPrReviewMarker = "<!-- ddda:human-pr-review:v1 -->"
+
+function Get-DDDACandidateValidationEvidence {
+    param(
+        [Parameter(Mandatory = $true)][int]$Pr,
+        [Parameter(Mandatory = $true)][string]$HeadSha
+    )
+
+    $validationRoot = Join-Path (Get-DDDAPlatformStateRoot) ("validation-reports/pr-$Pr-$HeadSha")
+    $validationReports = @()
+    if (Test-Path -LiteralPath $validationRoot) {
+        $validationReports = @(
+            Get-ChildItem -LiteralPath $validationRoot -Filter "result.json" -File -Recurse -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTimeUtc -Descending
+        )
+    }
+    if ($validationReports.Count -eq 0) {
+        throw "Nenalezen PASS validate-pr report pro PR #$Pr a SHA $HeadSha."
+    }
+
+    foreach ($candidate in $validationReports) {
+        $candidateReport = Get-Content -LiteralPath $candidate.FullName -Raw -Encoding UTF8 | ConvertFrom-Json
+        if (
+            [string]$candidateReport.status -ne "PASS" -or
+            [string]$candidateReport.source.commit -ne $HeadSha -or
+            [int]$candidateReport.source.pr -ne $Pr -or
+            $null -eq $candidateReport.package
+        ) {
+            continue
+        }
+        $packagePath = [string]$candidateReport.package.path
+        if (-not (Test-Path -LiteralPath $packagePath -PathType Leaf)) {
+            continue
+        }
+        $actualHash = Get-DDDAPlatformFileHash -Path $packagePath
+        if ($actualHash -ne [string]$candidateReport.package.sha256) {
+            throw "Candidate package hash neodpovídá validation reportu: $packagePath"
+        }
+        return [pscustomobject]@{
+            ReportPath = $candidate.FullName
+            Report = $candidateReport
+            PackagePath = $packagePath
+            PackageSha256 = $actualHash
+        }
+    }
+    throw "Žádný validation report nemá PASS pro aktuální PR head SHA $HeadSha a validní candidate package."
+}
+
+function Get-DDDAReleaseMilestoneScope {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositorySlug,
+        [Parameter(Mandatory = $true)][string]$Version,
+        [Parameter(Mandatory = $true)][string]$Token
+    )
+
+    $wantedTitle = "DDDA $Version"
+    $milestones = [System.Collections.Generic.List[object]]::new()
+    for ($page = 1; ; $page++) {
+        $batch = @(Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/milestones?state=all&per_page=100&page=$page" -Token $Token)
+        foreach ($row in $batch) { $milestones.Add($row) }
+        if ($batch.Count -lt 100) { break }
+    }
+    $matches = @($milestones | Where-Object { [string]$_.title -eq $wantedTitle })
+    if ($matches.Count -ne 1) {
+        throw "Očekáván právě jeden Milestone '$wantedTitle', nalezeno: $($matches.Count)."
+    }
+    $milestone = $matches[0]
+
+    $issues = [System.Collections.Generic.List[int]]::new()
+    for ($page = 1; ; $page++) {
+        $batch = @(Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/issues?state=all&milestone=$([int]$milestone.number)&per_page=100&page=$page" -Token $Token)
+        foreach ($row in $batch) {
+            if ($null -eq $row.PSObject.Properties["pull_request"]) {
+                $issues.Add([int]$row.number)
+            }
+        }
+        if ($batch.Count -lt 100) { break }
+    }
+
+    return [pscustomobject]@{
+        Number = [int]$milestone.number
+        Title = [string]$milestone.title
+        Issues = @($issues | Sort-Object -Unique)
+    }
+}
+
+function Get-DDDAHrdrComments {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositorySlug,
+        [Parameter(Mandatory = $true)][int]$Pr,
+        [Parameter(Mandatory = $true)][string]$Token
+    )
+
+    $matches = [System.Collections.Generic.List[object]]::new()
+    for ($page = 1; ; $page++) {
+        $batch = @(Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/issues/$Pr/comments?per_page=100&page=$page" -Token $Token)
+        foreach ($comment in $batch) {
+            if ([string]$comment.body -like "*$script:DDDAHrdrMarker*") {
+                $matches.Add($comment)
+            }
+        }
+        if ($batch.Count -lt 100) { break }
+    }
+    return @($matches)
+}
+
+function Get-DDDAHumanPrReviewComments {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositorySlug,
+        [Parameter(Mandatory = $true)][int]$Pr,
+        [Parameter(Mandatory = $true)][string]$Token
+    )
+
+    $matches = [System.Collections.Generic.List[object]]::new()
+    for ($page = 1; ; $page++) {
+        $batch = @(Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/issues/$Pr/comments?per_page=100&page=$page" -Token $Token)
+        foreach ($comment in $batch) {
+            if ([string]$comment.body -like "*$script:DDDAHumanPrReviewMarker*") {
+                $matches.Add($comment)
+            }
+        }
+        if ($batch.Count -lt 100) { break }
+    }
+    return @($matches)
+}
+
+function ConvertFrom-DDDAHrdrComment {
+    param([Parameter(Mandatory = $true)][object]$Comment)
+
+    $body = [string]$Comment.body
+    $pattern = '(?s)```json\s*(?<json>\{.*?\})\s*```'
+    $match = [regex]::Match($body, $pattern, [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
+    if (-not $match.Success) {
+        throw "Authoritativní HRDR comment neobsahuje právě očekávaný fenced JSON objekt."
+    }
+    try {
+        $record = $match.Groups["json"].Value | ConvertFrom-Json
+    }
+    catch {
+        throw "Authoritativní HRDR JSON nelze parse: $($_.Exception.Message)"
+    }
+    return $record
+}
+
+function ConvertFrom-DDDAHumanPrReviewComment {
+    param([Parameter(Mandatory = $true)][object]$Comment)
+
+    $body = [string]$Comment.body
+    $pattern = '(?s)```json\s*(?<json>\{.*?\})\s*```'
+    $match = [regex]::Match($body, $pattern, [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
+    if (-not $match.Success) {
+        throw "Authoritativní Human Review comment neobsahuje očekávaný fenced JSON objekt."
+    }
+    try {
+        $record = $match.Groups["json"].Value | ConvertFrom-Json
+    }
+    catch {
+        throw "Authoritativní Human Review JSON nelze parse: $($_.Exception.Message)"
+    }
+    return $record
+}
+
+function Format-DDDAHrdrComment {
+    param(
+        [Parameter(Mandatory = $true)][object]$Record,
+        [string]$Heading = "DDDA Human Release Decision Record"
+    )
+
+    $json = ConvertTo-Json -InputObject $Record -Depth 30
+    return @"
+$script:DDDAHrdrMarker
+## $Heading
+
+> Automation may scaffold and validate this record. Only an explicit human action may change `decision` from `pending` to a release decision or alter accepted risks.
+
+```json
+$json
+```
+"@
+}
+
+function Set-DDDAHrdrComment {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositorySlug,
+        [Parameter(Mandatory = $true)][int]$Pr,
+        [Parameter(Mandatory = $true)][string]$Token,
+        [Parameter(Mandatory = $true)][object]$Record
+    )
+
+    $existing = @(Get-DDDAHrdrComments -RepositorySlug $RepositorySlug -Pr $Pr -Token $Token)
+    if ($existing.Count -gt 1) {
+        throw "PR #$Pr obsahuje více než jeden authoritativní HRDR marker. Fail closed."
+    }
+    $body = Format-DDDAHrdrComment -Record $Record
+    if ($existing.Count -eq 0) {
+        return Invoke-DDDAGitHubApi -Method POST -Path "repos/$RepositorySlug/issues/$Pr/comments" -Token $Token -Body @{ body = $body }
+    }
+    $id = [int64]$existing[0].id
+    return Invoke-DDDAGitHubApi -Method PATCH -Path "repos/$RepositorySlug/issues/comments/$id" -Token $Token -Body @{ body = $body }
+}

--- a/scripts/platform/DDDAReleasePublicationSupport.ps1
+++ b/scripts/platform/DDDAReleasePublicationSupport.ps1
@@ -1,0 +1,190 @@
+﻿Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-DDDAReleasePublicationAssetDescriptors {
+    param(
+        [Parameter(Mandatory = $true)][string]$Version,
+        [Parameter(Mandatory = $true)][string]$PackagePath,
+        [Parameter(Mandatory = $true)][string]$ReportJsonPath,
+        [Parameter(Mandatory = $true)][string]$ReportMarkdownPath
+    )
+
+    foreach ($item in @(
+        [pscustomobject]@{ role = "package"; path = $PackagePath; name = "ddda-$Version.zip"; content_type = "application/zip" },
+        [pscustomobject]@{ role = "release_report_json"; path = $ReportJsonPath; name = "ddda-$Version-release-report.json"; content_type = "application/json" },
+        [pscustomobject]@{ role = "release_report_markdown"; path = $ReportMarkdownPath; name = "ddda-$Version-release-report.md"; content_type = "text/markdown" }
+    )) {
+        if (-not (Test-Path -LiteralPath $item.path -PathType Leaf)) {
+            throw "Release publication asset '$($item.role)' neexistuje: $($item.path)"
+        }
+        [pscustomobject]@{
+            role = $item.role
+            path = (Resolve-Path -LiteralPath $item.path).Path
+            name = $item.name
+            content_type = $item.content_type
+            sha256 = Get-DDDAPlatformFileHash -Path $item.path
+        }
+    }
+}
+
+function Get-DDDAGitHubReleaseByTag {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositorySlug,
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string]$Token
+    )
+
+    try {
+        return Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/releases/tags/$Tag" -Token $Token
+    }
+    catch {
+        if ($_.Exception.Message -match 'HTTP:\s*404') { return $null }
+        throw
+    }
+}
+
+function Assert-DDDACanonicalReleaseTagReadBack {
+    param(
+        [Parameter(Mandatory = $true)][string]$OriginUrl,
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string]$ExpectedCommit
+    )
+
+    $lines = @(Invoke-DDDAPlatformNative -Command "git" -Arguments @("ls-remote", "--tags", $OriginUrl, "refs/tags/$Tag", "refs/tags/$Tag^{}"))
+    $peeled = @($lines | Where-Object { $_ -match ("refs/tags/" + [regex]::Escape($Tag) + "\\^\\{\\}$") }) | Select-Object -First 1
+    if ($null -eq $peeled) {
+        throw "Fresh remote read-back neprokázal annotated canonical tag $Tag."
+    }
+    $actualCommit = ([string]$peeled -split "\s+")[0].Trim()
+    if ($actualCommit -ne $ExpectedCommit) {
+        throw "Canonical tag $Tag ukazuje na $actualCommit, očekáváno $ExpectedCommit."
+    }
+    return $actualCommit
+}
+
+function Assert-DDDAGitHubReleaseIdentity {
+    param(
+        [Parameter(Mandatory = $true)]$Release,
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string]$Title
+    )
+
+    if ([string]$Release.tag_name -ne $Tag) { throw "GitHub Release tag neodpovídá $Tag." }
+    if ([string]$Release.name -ne $Title) { throw "GitHub Release title neodpovídá '$Title'." }
+    if ([bool]$Release.draft -or [bool]$Release.prerelease) { throw "GitHub Release musí být publikovaný finální release." }
+}
+
+function Test-DDDAGitHubReleaseAssetHash {
+    param(
+        [Parameter(Mandatory = $true)]$Asset,
+        [Parameter(Mandatory = $true)][string]$ExpectedSha256,
+        [Parameter(Mandatory = $true)][string]$Token
+    )
+
+    $digest = [string]$Asset.digest
+    if ($digest -match '^sha256:(?<hash>[0-9a-fA-F]{64})$') {
+        return $Matches['hash'].ToLowerInvariant() -eq $ExpectedSha256.ToLowerInvariant()
+    }
+
+    $downloadPath = [System.IO.Path]::GetTempFileName()
+    try {
+        Invoke-WebRequest -Method GET -Uri ([string]$Asset.browser_download_url) -Headers @{ Authorization = "Bearer $Token"; Accept = "application/octet-stream"; "User-Agent" = "DDDA-Platform-Release-Publication" } -OutFile $downloadPath -ErrorAction Stop | Out-Null
+        return (Get-DDDAPlatformFileHash -Path $downloadPath) -eq $ExpectedSha256
+    }
+    finally {
+        Remove-Item -LiteralPath $downloadPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Publish-DDDAGitHubReleaseAsset {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositorySlug,
+        [Parameter(Mandatory = $true)][int64]$ReleaseId,
+        [Parameter(Mandatory = $true)]$Descriptor,
+        [Parameter(Mandatory = $true)][string]$Token
+    )
+
+    $escapedName = [uri]::EscapeDataString([string]$Descriptor.name)
+    $uri = "https://uploads.github.com/repos/$RepositorySlug/releases/$ReleaseId/assets?name=$escapedName"
+    $headers = @{ Authorization = "Bearer $Token"; Accept = "application/vnd.github+json"; "X-GitHub-Api-Version" = "2022-11-28"; "User-Agent" = "DDDA-Platform-Release-Publication" }
+    return Invoke-RestMethod -Method POST -Uri $uri -Headers $headers -ContentType ([string]$Descriptor.content_type) -InFile ([string]$Descriptor.path) -ErrorAction Stop
+}
+
+function Publish-DDDACanonicalGitHubRelease {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositorySlug,
+        [Parameter(Mandatory = $true)][string]$OriginUrl,
+        [Parameter(Mandatory = $true)][string]$Version,
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string]$ReleaseSourceSha,
+        [Parameter(Mandatory = $true)][string]$PackagePath,
+        [Parameter(Mandatory = $true)][string]$ReportJsonPath,
+        [Parameter(Mandatory = $true)][string]$ReportMarkdownPath,
+        [Parameter(Mandatory = $true)][string]$Token,
+        [Parameter(Mandatory = $true)][string]$PublicationEvidencePath
+    )
+
+    if ($ReleaseSourceSha -notmatch '^[0-9a-f]{40}$') { throw "Release source SHA není platný." }
+    $title = "DDDA $Version"
+    $tagCommit = Assert-DDDACanonicalReleaseTagReadBack -OriginUrl $OriginUrl -Tag $Tag -ExpectedCommit $ReleaseSourceSha
+    $assets = @(Get-DDDAReleasePublicationAssetDescriptors -Version $Version -PackagePath $PackagePath -ReportJsonPath $ReportJsonPath -ReportMarkdownPath $ReportMarkdownPath)
+    $report = Get-Content -LiteralPath $ReportJsonPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    if ([string]$report.status -ne "PASS" -or [string]$report.source.kind -ne "release" -or [string]$report.source.repository -ne $RepositorySlug -or [string]$report.source.commit -ne $ReleaseSourceSha) {
+        throw "Release report není PASS evidence pro exact canonical release source."
+    }
+    $package = @($assets | Where-Object { $_.role -eq "package" })[0]
+    if ([string]$report.package.sha256 -ne [string]$package.sha256) { throw "Release package SHA-256 neodpovídá release reportu." }
+
+    $release = Get-DDDAGitHubReleaseByTag -RepositorySlug $RepositorySlug -Tag $Tag -Token $Token
+    if ($null -eq $release) {
+        $release = Invoke-DDDAGitHubApi -Method POST -Path "repos/$RepositorySlug/releases" -Token $Token -Body @{
+            tag_name = $Tag
+            target_commitish = $ReleaseSourceSha
+            name = $title
+            body = "Canonical DDDA product package and release evidence for `$Tag. GitHub automatic source archives are convenience source archives, not the canonical DDDA product package."
+            draft = $false
+            prerelease = $false
+            generate_release_notes = $false
+        }
+    }
+    Assert-DDDAGitHubReleaseIdentity -Release $release -Tag $Tag -Title $title
+
+    foreach ($descriptor in $assets) {
+        $existing = @($release.assets | Where-Object { [string]$_.name -eq [string]$descriptor.name })
+        if ($existing.Count -gt 1) { throw "GitHub Release obsahuje více assets se jménem $($descriptor.name)." }
+        if ($existing.Count -eq 1) {
+            if (-not (Test-DDDAGitHubReleaseAssetHash -Asset $existing[0] -ExpectedSha256 $descriptor.sha256 -Token $Token)) {
+                throw "Existující GitHub Release asset $($descriptor.name) nemá očekávaný SHA-256; asset se nesmí přepsat."
+            }
+            continue
+        }
+        $null = Publish-DDDAGitHubReleaseAsset -RepositorySlug $RepositorySlug -ReleaseId ([int64]$release.id) -Descriptor $descriptor -Token $Token
+    }
+
+    $readBack = Get-DDDAGitHubReleaseByTag -RepositorySlug $RepositorySlug -Tag $Tag -Token $Token
+    if ($null -eq $readBack) { throw "Fresh GitHub read-back nenašel Release pro $Tag." }
+    Assert-DDDAGitHubReleaseIdentity -Release $readBack -Tag $Tag -Title $title
+    $evidenceAssets = [ordered]@{}
+    foreach ($descriptor in $assets) {
+        $asset = @($readBack.assets | Where-Object { [string]$_.name -eq [string]$descriptor.name })
+        if ($asset.Count -ne 1 -or -not (Test-DDDAGitHubReleaseAssetHash -Asset $asset[0] -ExpectedSha256 $descriptor.sha256 -Token $Token)) {
+            throw "Fresh read-back neprokázal správný obsah assetu $($descriptor.name)."
+        }
+        $evidenceAssets[$descriptor.role] = [ordered]@{ name = [string]$asset[0].name; sha256 = [string]$descriptor.sha256; id = [int64]$asset[0].id; url = [string]$asset[0].browser_download_url }
+    }
+    $evidence = [ordered]@{
+        schema_version = 1
+        repository = $RepositorySlug
+        version = $Version
+        release_source_sha = $ReleaseSourceSha
+        tag = $Tag
+        tag_read_back_sha = $tagCommit
+        github_release = [ordered]@{ id = [int64]$readBack.id; url = [string]$readBack.html_url; title = $title }
+        assets = $evidenceAssets
+        publication_timestamp = (Get-Date).ToUniversalTime().ToString('o')
+        publication_status = "PASS"
+        server_read_back_status = "PASS"
+    }
+    Write-DDDAPlatformJson -Value $evidence -Path $PublicationEvidencePath -Depth 30
+    return [pscustomobject]$evidence
+}

--- a/scripts/platform/Invoke-DDDAGovernedMergePr.ps1
+++ b/scripts/platform/Invoke-DDDAGovernedMergePr.ps1
@@ -2,6 +2,7 @@
 param(
     [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
     [Parameter(Mandatory = $true)][ValidateRange(1, 2147483647)][int]$Pr,
+    [ValidateSet("merge", "squash")][string]$MergeMethod,
     [switch]$ConfirmMerge,
     [switch]$DryRun
 )
@@ -11,6 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "DDDAPlatformSupport.ps1")
 . (Join-Path $PSScriptRoot "DDDAGitHubSupport.ps1")
 . (Join-Path $PSScriptRoot "DDDAReleaseGovernanceSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAMergeStrategySupport.ps1")
 
 $platformRoot = Get-DDDAPlatformGitRoot -Path $PlatformPath
 if ($platformRoot -ne [System.IO.Path]::GetFullPath($PlatformPath).TrimEnd('\', '/')) {
@@ -40,6 +42,10 @@ if ([bool]$prInfo.draft) {
 $baseRefName = [string]$prInfo.base.ref
 if ($baseRefName -ne [string]$policy.base_branch) {
     throw "PR #$Pr míří do '$baseRefName', očekáváno '$($policy.base_branch)'."
+}
+$baseSha = [string]$prInfo.base.sha
+if ($baseSha -notmatch '^[0-9a-f]{40}$') {
+    throw "GitHub nevrátil platný base SHA."
 }
 $mergeStateStatus = ([string]$prInfo.mergeable_state).ToUpperInvariant()
 if ($mergeStateStatus -notin @("CLEAN", "HAS_HOOKS", "UNSTABLE")) {
@@ -119,19 +125,56 @@ foreach ($relative in @($policy.required_documents)) {
     }
 }
 
-$mergeMethod = [string]$policy.merge_method
-if ($mergeMethod -notin @("squash", "merge", "rebase")) {
-    throw "Nepodporovaná merge_method v policy: $mergeMethod"
+$impact = Get-DDDAChangeImpactFromPrBody -Body ([string]$prInfo.body)
+$requestedMergeMethod = if ([string]::IsNullOrWhiteSpace($MergeMethod)) { "" } else { $MergeMethod }
+$strategyDecision = Resolve-DDDAMergeStrategy `
+    -Policy $policy `
+    -Impact $impact `
+    -RequestedMethod $requestedMergeMethod `
+    -Pr $Pr `
+    -BaseSha $baseSha `
+    -PrBody ([string]$prInfo.body)
+$effectiveMergeMethod = [string]$strategyDecision.merge_method
+
+$squashException = $null
+if ([bool]$strategyDecision.human_squash_exception_required) {
+    $exceptionComments = [System.Collections.Generic.List[object]]::new()
+    for ($page = 1; ; $page++) {
+        $batch = @(Invoke-DDDAGitHubApi -Method GET -Path "repos/$repositorySlug/issues/$Pr/comments?per_page=100&page=$page" -Token $githubAuth.Token)
+        foreach ($comment in $batch) {
+            if ([string]$comment.body -like "*$script:DDDASquashExceptionMarker*") {
+                $exceptionComments.Add($comment)
+            }
+        }
+        if ($batch.Count -lt 100) { break }
+    }
+    if ($exceptionComments.Count -ne 1) {
+        throw "LOW/MEDIUM squash vyžaduje právě jeden authoritativní human squash exception marker. Nalezeno: $($exceptionComments.Count)."
+    }
+    $exceptionComment = $exceptionComments[0]
+    $squashException = ConvertFrom-DDDASquashExceptionComment -Comment $exceptionComment
+    Assert-DDDASquashExceptionRecord `
+        -Record $squashException `
+        -CommentAuthor ([string]$exceptionComment.user.login) `
+        -CommentAuthorType ([string]$exceptionComment.user.type) `
+        -Repository $repositorySlug `
+        -Pr $Pr `
+        -HeadSha $headSha `
+        -CandidatePackageSha256 ([string]$validation.PackageSha256) `
+        -Impact $impact
 }
 
 Write-Host "=== DDDA governed implementation merge preflight ==="
 Write-Host "Repository:        $repositorySlug"
 Write-Host "PR:                $Pr"
 Write-Host "Head SHA:          $headSha"
+Write-Host "Base SHA:          $baseSha"
 Write-Host "Candidate SHA-256: $($validation.PackageSha256)"
 Write-Host "CI checks:         PASS ($($checkSummary.CheckRunCount) check runs)"
 Write-Host "Human Review:      PASS ($commentAuthor)"
-Write-Host "Merge method:      $mergeMethod"
+Write-Host "Impact:            $impact"
+Write-Host "Merge method:      $effectiveMergeMethod"
+Write-Host "Bootstrap transition: $([bool]$strategyDecision.bootstrap_transition)"
 Write-Host "Release Scope Gate: NOT APPLICABLE (implementation merge)"
 Write-Host "Release/tag side effects: DISABLED"
 
@@ -152,7 +195,7 @@ $mergeResult = Merge-DDDAGitHubPullRequest `
     -RepositorySlug $repositorySlug `
     -Pr $Pr `
     -HeadSha $headSha `
-    -MergeMethod $mergeMethod `
+    -MergeMethod $effectiveMergeMethod `
     -Token $githubAuth.Token
 
 $mergeCommit = [string]$mergeResult.sha
@@ -165,22 +208,67 @@ if (-not [bool]$postMerge.merged) {
     throw "GitHub nepotvrdil merge PR #$Pr."
 }
 
+$sourceToResultRelation = $null
+$ancestryVerified = $false
+if ($effectiveMergeMethod -eq "merge") {
+    $mergeCommitInfo = Invoke-DDDAGitHubApi -Method GET -Path "repos/$repositorySlug/commits/$mergeCommit" -Token $githubAuth.Token
+    $parentShas = @($mergeCommitInfo.parents | ForEach-Object { [string]$_.sha })
+    if ($headSha -notin $parentShas) {
+        throw "Post-merge ancestry read-back selhal: validated PR HEAD $headSha není parent výsledného merge commit $mergeCommit."
+    }
+    $compare = Invoke-DDDAGitHubApi -Method GET -Path "repos/$repositorySlug/compare/$headSha...$mergeCommit" -Token $githubAuth.Token
+    if ([string]$compare.merge_base_commit.sha -ne $headSha) {
+        throw "Post-merge ancestry read-back selhal: validated PR HEAD není ancestor výsledného main state."
+    }
+    $sourceToResultRelation = "ancestor"
+    $ancestryVerified = $true
+}
+elseif ($effectiveMergeMethod -eq "squash") {
+    $sourceToResultRelation = "explicit_squash_mapping"
+}
+else {
+    throw "Neočekávaný merge method po merge: $effectiveMergeMethod"
+}
+
+$exceptionEvidence = $null
+if ($null -ne $squashException) {
+    $exceptionEvidence = [ordered]@{
+        type = "human_low_medium_exception"
+        reason = [string]$squashException.reason
+        reviewer = [string]$squashException.reviewer
+        approved_at = [string]$squashException.approved_at
+    }
+}
+elseif ([bool]$strategyDecision.bootstrap_transition) {
+    $transition = $policy.merge_strategy.bootstrap_transition
+    $exceptionEvidence = [ordered]@{
+        type = "prospective_policy_bootstrap"
+        change_issue = [int]$transition.change_issue
+        legacy_base_sha = [string]$transition.legacy_base_sha
+        reason = [string]$transition.reason
+    }
+}
+
 $evidenceRoot = Join-Path (Get-DDDAPlatformStateRoot) ("merge-reports/pr-$Pr-$headSha")
 New-Item -ItemType Directory -Path $evidenceRoot -Force | Out-Null
 $evidencePath = Join-Path $evidenceRoot "result.json"
-Write-DDDAPlatformJson -Path $evidencePath -Depth 20 -Value ([ordered]@{
-    schema_version = 1
+Write-DDDAPlatformJson -Path $evidencePath -Depth 30 -Value ([ordered]@{
+    schema_version = 2
     repository = $repositorySlug
     pr = $Pr
-    source_sha = $headSha
+    impact = $impact
+    validated_source_head_sha = $headSha
     candidate_package_sha256 = [string]$validation.PackageSha256
     human_review = [ordered]@{
         reviewer = $commentAuthor
         reviewed_at = [string]$review.reviewed_at
         verdict = "pass"
     }
-    merge_method = $mergeMethod
-    merge_sha = $mergeCommit
+    merge_method = $effectiveMergeMethod
+    resulting_merge_sha = $mergeCommit
+    source_to_result_relation = $sourceToResultRelation
+    ancestry_verified = $ancestryVerified
+    squash_exception = $exceptionEvidence
     merged = $true
     release_scope_gate = "NOT_APPLICABLE"
     release_side_effects = $false
@@ -191,5 +279,6 @@ Write-DDDAPlatformJson -Path $evidencePath -Depth 20 -Value ([ordered]@{
 Write-Host ""
 Write-Host "DDDA merge-pr: PASS"
 Write-Host "PR #$Pr merged as $mergeCommit."
+Write-Host "Source→result: $sourceToResultRelation"
 Write-Host "Evidence: $evidencePath"
 Write-Host "Nebyl vytvořen release package, release validation ani tag."

--- a/scripts/platform/Invoke-DDDAGovernedMergePr.ps1
+++ b/scripts/platform/Invoke-DDDAGovernedMergePr.ps1
@@ -1,0 +1,195 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
+    [Parameter(Mandatory = $true)][ValidateRange(1, 2147483647)][int]$Pr,
+    [switch]$ConfirmMerge,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "DDDAPlatformSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAGitHubSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAReleaseGovernanceSupport.ps1")
+
+$platformRoot = Get-DDDAPlatformGitRoot -Path $PlatformPath
+if ($platformRoot -ne [System.IO.Path]::GetFullPath($PlatformPath).TrimEnd('\', '/')) {
+    throw "PlatformPath musí být Git root DDDA platformy."
+}
+Assert-DDDAPlatformCleanGit -Repository $platformRoot
+
+$originUrl = Get-DDDAPlatformRepositoryUrl -Repository $platformRoot
+$repositorySlug = Get-DDDAPlatformRepositorySlug -RepositoryUrl $originUrl
+$githubAuth = Get-DDDAGitHubAuthentication
+$policyPath = Join-Path $platformRoot "config/platform/development-policy.yaml"
+if (-not (Test-Path -LiteralPath $policyPath -PathType Leaf)) {
+    throw "Chybí platform development policy: $policyPath"
+}
+$policy = Get-Content -LiteralPath $policyPath -Raw -Encoding UTF8 | ConvertFrom-Json
+if ($policy.schema_version -ne 1) {
+    throw "Nepodporovaná platform development policy."
+}
+
+$prInfo = Get-DDDAGitHubPullRequest -RepositorySlug $repositorySlug -Pr $Pr -Token $githubAuth.Token
+if ([string]$prInfo.state -ne "open") {
+    throw "PR #$Pr není otevřený."
+}
+if ([bool]$prInfo.draft) {
+    throw "PR #$Pr je draft. Governed implementation merge vyžaduje Ready for review."
+}
+$baseRefName = [string]$prInfo.base.ref
+if ($baseRefName -ne [string]$policy.base_branch) {
+    throw "PR #$Pr míří do '$baseRefName', očekáváno '$($policy.base_branch)'."
+}
+$mergeStateStatus = ([string]$prInfo.mergeable_state).ToUpperInvariant()
+if ($mergeStateStatus -notin @("CLEAN", "HAS_HOOKS", "UNSTABLE")) {
+    throw "PR #$Pr není připraven k merge. mergeable_state=$([string]$prInfo.mergeable_state)"
+}
+$headSha = [string]$prInfo.head.sha
+if ($headSha -notmatch '^[0-9a-f]{40}$') {
+    throw "GitHub nevrátil platný PR head SHA."
+}
+
+try {
+    $checkSummary = Assert-DDDAGitHubChecksPassed -RepositorySlug $repositorySlug -Commit $headSha -Token $githubAuth.Token
+}
+catch {
+    throw "CI kontroly PR #$Pr nejsou všechny PASS:`n$($_.Exception.Message)"
+}
+
+$minimumApprovals = [int]$policy.minimum_approvals
+$approvedUsers = @()
+if ($minimumApprovals -gt 0) {
+    $approvedUsers = @(Get-DDDAGitHubApprovedUsers -RepositorySlug $repositorySlug -Pr $Pr -Token $githubAuth.Token)
+    if ($approvedUsers.Count -lt $minimumApprovals) {
+        throw "PR #$Pr nemá požadovaný počet GitHub approvals. Požadováno: $minimumApprovals; nalezeno: $($approvedUsers.Count)."
+    }
+}
+
+$validation = Get-DDDACandidateValidationEvidence -Pr $Pr -HeadSha $headSha
+
+$reviewComments = @(Get-DDDAHumanPrReviewComments -RepositorySlug $repositorySlug -Pr $Pr -Token $githubAuth.Token)
+if ($reviewComments.Count -ne 1) {
+    throw "Governed implementation merge vyžaduje právě jeden authoritativní Human Review marker. Nalezeno: $($reviewComments.Count)."
+}
+$reviewComment = $reviewComments[0]
+$commentAuthor = [string]$reviewComment.user.login
+$commentAuthorType = [string]$reviewComment.user.type
+if (
+    [string]::IsNullOrWhiteSpace($commentAuthor) -or
+    $commentAuthorType -eq "Bot" -or
+    $commentAuthor -match '\[bot\]$'
+) {
+    throw "Human Review musí mít lidskou GitHub provenance."
+}
+$review = ConvertFrom-DDDAHumanPrReviewComment -Comment $reviewComment
+if ([int]$review.schema_version -ne 1 -or [string]$review.kind -ne "implementation_pr_review") {
+    throw "Human Review má nepodporovaný contract."
+}
+if ([int]$review.pr -ne $Pr) {
+    throw "Human Review PR identity neodpovídá PR #$Pr."
+}
+if ([string]$review.reviewed_sha -ne $headSha) {
+    throw "Human Review SHA '$([string]$review.reviewed_sha)' neodpovídá current PR head '$headSha'."
+}
+if ([string]$review.candidate_package_sha256 -ne [string]$validation.PackageSha256) {
+    throw "Human Review candidate package hash neodpovídá exact-SHA validate-pr evidence."
+}
+if ([string]$review.reviewer -ne $commentAuthor) {
+    throw "Human Review reviewer '$([string]$review.reviewer)' neodpovídá human comment authorovi '$commentAuthor'."
+}
+if ([string]$review.verdict -ne "pass") {
+    throw "Human Review není PASS. verdict=$([string]$review.verdict)"
+}
+if ([string]::IsNullOrWhiteSpace([string]$review.reviewed_at)) {
+    throw "Human Review neobsahuje reviewed_at."
+}
+$reviewedAt = [DateTimeOffset]::MinValue
+if (-not [DateTimeOffset]::TryParse([string]$review.reviewed_at, [ref]$reviewedAt)) {
+    throw "Human Review reviewed_at není platný timestamp."
+}
+
+foreach ($relative in @($policy.required_documents)) {
+    $contentsPath = "repos/$repositorySlug/contents/$relative?ref=$headSha"
+    try {
+        $null = Invoke-DDDAGitHubApi -Method GET -Path $contentsPath -Token $githubAuth.Token
+    }
+    catch {
+        throw "PR #$Pr neobsahuje povinný governance dokument '$relative' na exact SHA $headSha."
+    }
+}
+
+$mergeMethod = [string]$policy.merge_method
+if ($mergeMethod -notin @("squash", "merge", "rebase")) {
+    throw "Nepodporovaná merge_method v policy: $mergeMethod"
+}
+
+Write-Host "=== DDDA governed implementation merge preflight ==="
+Write-Host "Repository:        $repositorySlug"
+Write-Host "PR:                $Pr"
+Write-Host "Head SHA:          $headSha"
+Write-Host "Candidate SHA-256: $($validation.PackageSha256)"
+Write-Host "CI checks:         PASS ($($checkSummary.CheckRunCount) check runs)"
+Write-Host "Human Review:      PASS ($commentAuthor)"
+Write-Host "Merge method:      $mergeMethod"
+Write-Host "Release Scope Gate: NOT APPLICABLE (implementation merge)"
+Write-Host "Release/tag side effects: DISABLED"
+
+if ($DryRun) {
+    Write-Host ""
+    Write-Host "DDDA merge-pr dry-run: PASS"
+    Write-Host "Nebyl proveden merge, release, promotion ani tag."
+    exit 0
+}
+
+if ([bool]$policy.require_explicit_confirmation -and -not $ConfirmMerge) {
+    throw "Implementation merge vyžaduje explicitní -ConfirmMerge."
+}
+
+# This command is intentionally merge-only. It does not call HRDR, Release Scope Gate,
+# release package, release validation or tag execution paths.
+$mergeResult = Merge-DDDAGitHubPullRequest `
+    -RepositorySlug $repositorySlug `
+    -Pr $Pr `
+    -HeadSha $headSha `
+    -MergeMethod $mergeMethod `
+    -Token $githubAuth.Token
+
+$mergeCommit = [string]$mergeResult.sha
+if ($mergeCommit -notmatch '^[0-9a-f]{40}$') {
+    throw "GitHub nevrátil platný merge commit SHA."
+}
+
+$postMerge = Get-DDDAGitHubPullRequest -RepositorySlug $repositorySlug -Pr $Pr -Token $githubAuth.Token
+if (-not [bool]$postMerge.merged) {
+    throw "GitHub nepotvrdil merge PR #$Pr."
+}
+
+$evidenceRoot = Join-Path (Get-DDDAPlatformStateRoot) ("merge-reports/pr-$Pr-$headSha")
+New-Item -ItemType Directory -Path $evidenceRoot -Force | Out-Null
+$evidencePath = Join-Path $evidenceRoot "result.json"
+Write-DDDAPlatformJson -Path $evidencePath -Depth 20 -Value ([ordered]@{
+    schema_version = 1
+    repository = $repositorySlug
+    pr = $Pr
+    source_sha = $headSha
+    candidate_package_sha256 = [string]$validation.PackageSha256
+    human_review = [ordered]@{
+        reviewer = $commentAuthor
+        reviewed_at = [string]$review.reviewed_at
+        verdict = "pass"
+    }
+    merge_method = $mergeMethod
+    merge_sha = $mergeCommit
+    merged = $true
+    release_scope_gate = "NOT_APPLICABLE"
+    release_side_effects = $false
+    tag_side_effects = $false
+    completed_at = (Get-Date).ToUniversalTime().ToString("o")
+})
+
+Write-Host ""
+Write-Host "DDDA merge-pr: PASS"
+Write-Host "PR #$Pr merged as $mergeCommit."
+Write-Host "Evidence: $evidencePath"
+Write-Host "Nebyl vytvořen release package, release validation ani tag."

--- a/scripts/platform/Invoke-DDDAGovernedMergePr.ps1
+++ b/scripts/platform/Invoke-DDDAGovernedMergePr.ps1
@@ -2,6 +2,8 @@
 param(
     [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
     [Parameter(Mandatory = $true)][ValidateRange(1, 2147483647)][int]$Pr,
+    [string]$PackagePath,
+    [string]$ValidationReportPath,
     [ValidateSet("merge", "squash")][string]$MergeMethod,
     [switch]$ConfirmMerge,
     [switch]$DryRun
@@ -57,7 +59,13 @@ if ($headSha -notmatch '^[0-9a-f]{40}$') {
 }
 
 try {
-    $checkSummary = Assert-DDDAGitHubChecksPassed -RepositorySlug $repositorySlug -Commit $headSha -Token $githubAuth.Token
+    $ignoredCheckRunNames = if ($DryRun -and -not [string]::IsNullOrWhiteSpace([string]$env:DDDA_CURRENT_CHECK_NAME)) {
+        @([string]$env:DDDA_CURRENT_CHECK_NAME)
+    }
+    else {
+        @()
+    }
+    $checkSummary = Assert-DDDAGitHubChecksPassed -RepositorySlug $repositorySlug -Commit $headSha -Token $githubAuth.Token -IgnoredCheckRunNames $ignoredCheckRunNames
 }
 catch {
     throw "CI kontroly PR #$Pr nejsou všechny PASS:`n$($_.Exception.Message)"
@@ -72,22 +80,60 @@ if ($minimumApprovals -gt 0) {
     }
 }
 
-$validation = Get-DDDACandidateValidationEvidence -Pr $Pr -HeadSha $headSha
+$validationArguments = @{
+    Pr = $Pr
+    HeadSha = $headSha
+}
+if (-not [string]::IsNullOrWhiteSpace($PackagePath)) { $validationArguments["PackagePath"] = $PackagePath }
+if (-not [string]::IsNullOrWhiteSpace($ValidationReportPath)) { $validationArguments["ValidationReportPath"] = $ValidationReportPath }
+$validation = Get-DDDACandidateValidationEvidence @validationArguments
+Invoke-DDDAPlatformChildPowerShell -ScriptPath (Join-Path $platformRoot "scripts/platform/Test-DDDAPlatformPackage.ps1") -Arguments @(
+    "-PackagePath", [string]$validation.PackagePath,
+    "-ExpectedCommit", $headSha,
+    "-ExpectedKind", "candidate"
+) -SuppressOutput
+
+# CR #96: implementation merge remains distinct from the Release Scope Gate,
+# but must not introduce a later/TBD Change Request into an already open train.
+# The collector is read-only and fails closed; it cannot alter scope authority.
+$eligibilityRoot = Join-Path (Get-DDDAPlatformStateRoot) ("merge-eligibility/pr-$Pr-$headSha")
+New-Item -ItemType Directory -Path $eligibilityRoot -Force | Out-Null
+$eligibilityPath = Join-Path $eligibilityRoot "release-eligibility.json"
+$eligibilityCollector = Join-Path $platformRoot "scripts/platform/Test-DDDAMergeReleaseEligibility.py"
+if (-not (Test-Path -LiteralPath $eligibilityCollector -PathType Leaf)) {
+    throw "Releasable-main merge eligibility collector neexistuje: $eligibilityCollector"
+}
+$python = Get-DDDAPlatformPythonCommand
+$previousGhToken = $env:GH_TOKEN
+$previousGithubToken = $env:GITHUB_TOKEN
+try {
+    $env:GH_TOKEN = $githubAuth.Token
+    Invoke-DDDAPlatformNative -Command $python -Arguments @(
+        $eligibilityCollector,
+        "--repository", $repositorySlug,
+        "--pr", [string]$Pr,
+        "--expected-sha", $headSha,
+        "--output", $eligibilityPath
+    ) -WorkingDirectory $platformRoot | Out-Null
+}
+finally {
+    $env:GH_TOKEN = $previousGhToken
+    $env:GITHUB_TOKEN = $previousGithubToken
+}
+if (-not (Test-Path -LiteralPath $eligibilityPath -PathType Leaf)) {
+    throw "Releasable-main merge eligibility nevytvořil evidence report."
+}
+$mergeEligibility = Get-Content -LiteralPath $eligibilityPath -Raw -Encoding UTF8 | ConvertFrom-Json
+if ([string]$mergeEligibility.status -ne "PASS" -or -not [bool]$mergeEligibility.side_effects_allowed) {
+    $failures = @($mergeEligibility.failing_invariants | ForEach-Object { [string]$_ })
+    throw "Releasable-main merge eligibility FAIL:`n$($failures -join "`n")"
+}
 
 $reviewComments = @(Get-DDDAHumanPrReviewComments -RepositorySlug $repositorySlug -Pr $Pr -Token $githubAuth.Token)
 if ($reviewComments.Count -ne 1) {
     throw "Governed implementation merge vyžaduje právě jeden authoritativní Human Review marker. Nalezeno: $($reviewComments.Count)."
 }
 $reviewComment = $reviewComments[0]
-$commentAuthor = [string]$reviewComment.user.login
-$commentAuthorType = [string]$reviewComment.user.type
-if (
-    [string]::IsNullOrWhiteSpace($commentAuthor) -or
-    $commentAuthorType -eq "Bot" -or
-    $commentAuthor -match '\[bot\]$'
-) {
-    throw "Human Review musí mít lidskou GitHub provenance."
-}
 $review = ConvertFrom-DDDAHumanPrReviewComment -Comment $reviewComment
 if ([int]$review.schema_version -ne 1 -or [string]$review.kind -ne "implementation_pr_review") {
     throw "Human Review má nepodporovaný contract."
@@ -101,9 +147,7 @@ if ([string]$review.reviewed_sha -ne $headSha) {
 if ([string]$review.candidate_package_sha256 -ne [string]$validation.PackageSha256) {
     throw "Human Review candidate package hash neodpovídá exact-SHA validate-pr evidence."
 }
-if ([string]$review.reviewer -ne $commentAuthor) {
-    throw "Human Review reviewer '$([string]$review.reviewer)' neodpovídá human comment authorovi '$commentAuthor'."
-}
+$commentAuthor = Assert-DDDAHumanPrReviewCommentProvenance -Comment $reviewComment -Review $review
 if ([string]$review.verdict -ne "pass") {
     throw "Human Review není PASS. verdict=$([string]$review.verdict)"
 }
@@ -116,7 +160,7 @@ if (-not [DateTimeOffset]::TryParse([string]$review.reviewed_at, [ref]$reviewedA
 }
 
 foreach ($relative in @($policy.required_documents)) {
-    $contentsPath = "repos/$repositorySlug/contents/$relative?ref=$headSha"
+    $contentsPath = "repos/{0}/contents/{1}?ref={2}" -f $repositorySlug, $relative, $headSha
     try {
         $null = Invoke-DDDAGitHubApi -Method GET -Path $contentsPath -Token $githubAuth.Token
     }
@@ -174,6 +218,7 @@ Write-Host "CI checks:         PASS ($($checkSummary.CheckRunCount) check runs)"
 Write-Host "Human Review:      PASS ($commentAuthor)"
 Write-Host "Impact:            $impact"
 Write-Host "Merge method:      $effectiveMergeMethod"
+Write-Host "Releasable-main:  PASS"
 Write-Host "Bootstrap transition: $([bool]$strategyDecision.bootstrap_transition)"
 Write-Host "Release Scope Gate: NOT APPLICABLE (implementation merge)"
 Write-Host "Release/tag side effects: DISABLED"
@@ -259,6 +304,12 @@ Write-DDDAPlatformJson -Path $evidencePath -Depth 30 -Value ([ordered]@{
     impact = $impact
     validated_source_head_sha = $headSha
     candidate_package_sha256 = [string]$validation.PackageSha256
+    releasable_main = [ordered]@{
+        status = [string]$mergeEligibility.status
+        active_release = $mergeEligibility.active_release
+        primary_crs = @($mergeEligibility.primary_crs)
+        evidence_path = $eligibilityPath
+    }
     human_review = [ordered]@{
         reviewer = $commentAuthor
         reviewed_at = [string]$review.reviewed_at

--- a/scripts/platform/Invoke-DDDAGovernedPromotePr.ps1
+++ b/scripts/platform/Invoke-DDDAGovernedPromotePr.ps1
@@ -1,0 +1,136 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
+    [Parameter(Mandatory = $true)][ValidateRange(1, 2147483647)][int]$Pr,
+    [Parameter(Mandatory = $true)][string]$Version,
+    [switch]$ConfirmMerge,
+    [switch]$WithMiro,
+    [switch]$Full,
+    [switch]$CleanupOnFailure,
+    [switch]$KeepArtifacts,
+    [switch]$KeepReviewBoard,
+    [string]$MiroTeamId,
+    [switch]$NonInteractive,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "DDDAPlatformSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAGitHubSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAReleaseGovernanceSupport.ps1")
+
+Assert-DDDAPlatformSemanticVersion -Version $Version
+$platformRoot = Get-DDDAPlatformGitRoot -Path $PlatformPath
+Assert-DDDAPlatformCleanGit -Repository $platformRoot
+$originUrl = Get-DDDAPlatformRepositoryUrl -Repository $platformRoot
+$repositorySlug = Get-DDDAPlatformRepositorySlug -RepositoryUrl $originUrl
+$githubAuth = Get-DDDAGitHubAuthentication
+
+$prInfo = Get-DDDAGitHubPullRequest -RepositorySlug $repositorySlug -Pr $Pr -Token $githubAuth.Token
+if ([string]$prInfo.state -ne "open") {
+    throw "PR #$Pr není otevřený."
+}
+if ([bool]$prInfo.draft) {
+    throw "PR #$Pr je draft; Release Scope Gate nelze použít pro promotion."
+}
+$headSha = [string]$prInfo.head.sha
+if ($headSha -notmatch '^[0-9a-f]{40}$') {
+    throw "GitHub nevrátil platný PR head SHA."
+}
+
+$validation = Get-DDDACandidateValidationEvidence -Pr $Pr -HeadSha $headSha
+
+$comments = @(Get-DDDAHrdrComments -RepositorySlug $repositorySlug -Pr $Pr -Token $githubAuth.Token)
+if ($comments.Count -ne 1) {
+    throw "Promotion vyžaduje právě jeden authoritativní HRDR comment marker. Nalezeno: $($comments.Count)."
+}
+$comment = $comments[0]
+$commentAuthor = [string]$comment.user.login
+$commentAuthorType = [string]$comment.user.type
+if (
+    [string]::IsNullOrWhiteSpace($commentAuthor) -or
+    $commentAuthorType -eq "Bot" -or
+    $commentAuthor -match '\[bot\]$'
+) {
+    throw "Authoritativní HRDR decision musí mít lidskou GitHub provenance."
+}
+$hrdr = ConvertFrom-DDDAHrdrComment -Comment $comment
+if ([string]$hrdr.decision_owner -ne $commentAuthor) {
+    throw "HRDR decision owner '$([string]$hrdr.decision_owner)' neodpovídá human comment authorovi '$commentAuthor'."
+}
+
+$gateRoot = Join-Path (Get-DDDAPlatformStateRoot) ("release-scope-gates/pr-$Pr-$headSha")
+New-Item -ItemType Directory -Path $gateRoot -Force | Out-Null
+$hrdrPath = Join-Path $gateRoot "human-release-decision.json"
+$gatePath = Join-Path $gateRoot "release-scope-gate.json"
+Write-DDDAPlatformJson -Value $hrdr -Path $hrdrPath -Depth 30
+
+if ([string]::IsNullOrWhiteSpace($env:DDDA_GITHUB_PROJECT_TOKEN)) {
+    throw "Release Scope Gate vyžaduje DDDA_GITHUB_PROJECT_TOKEN pro autoritativní Project V2 read-back."
+}
+
+$python = Get-DDDAPlatformPythonCommand
+$collector = Join-Path $platformRoot "scripts/platform/Test-DDDAReleaseScope.py"
+if (-not (Test-Path -LiteralPath $collector -PathType Leaf)) {
+    throw "Release Scope Gate collector neexistuje: $collector"
+}
+
+$previousGhToken = $env:GH_TOKEN
+$previousGithubToken = $env:GITHUB_TOKEN
+try {
+    $env:GH_TOKEN = $githubAuth.Token
+    $collectorOutput = Invoke-DDDAPlatformNative -Command $python -Arguments @(
+        $collector,
+        "--repository", $repositorySlug,
+        "--pr", [string]$Pr,
+        "--source-sha", $headSha,
+        "--candidate-sha256", [string]$validation.PackageSha256,
+        "--version", $Version,
+        "--hrdr", $hrdrPath,
+        "--output", $gatePath
+    ) -WorkingDirectory $platformRoot
+}
+finally {
+    $env:GH_TOKEN = $previousGhToken
+    $env:GITHUB_TOKEN = $previousGithubToken
+}
+
+if (-not (Test-Path -LiteralPath $gatePath -PathType Leaf)) {
+    throw "Release Scope Gate nevytvořil evidence report."
+}
+$gate = Get-Content -LiteralPath $gatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+if ([string]$gate.release_scope_gate_status -ne "PASS" -or -not [bool]$gate.side_effects_allowed) {
+    $failures = @($gate.failing_invariants | ForEach-Object { [string]$_ })
+    throw "Release Scope Gate FAIL:`n$($failures -join "`n")"
+}
+
+Write-Host "=== DDDA governed promotion preflight ==="
+Write-Host "Repository:          $repositorySlug"
+Write-Host "PR:                  $Pr"
+Write-Host "Head SHA:            $headSha"
+Write-Host "Candidate SHA-256:   $($validation.PackageSha256)"
+Write-Host "Version:             $Version"
+Write-Host "HRDR decision:       $([string]$hrdr.decision)"
+Write-Host "Decision owner:      $([string]$hrdr.decision_owner)"
+Write-Host "Release Scope Gate:  PASS"
+Write-Host "Gate evidence:       $gatePath"
+
+$arguments = @(
+    "-PlatformPath", $platformRoot,
+    "-Pr", [string]$Pr,
+    "-Version", $Version
+)
+if ($ConfirmMerge) { $arguments += "-ConfirmMerge" }
+if ($WithMiro) { $arguments += "-WithMiro" }
+if ($Full) { $arguments += "-Full" }
+if ($CleanupOnFailure) { $arguments += "-CleanupOnFailure" }
+if ($KeepArtifacts) { $arguments += "-KeepArtifacts" }
+if ($KeepReviewBoard) { $arguments += "-KeepReviewBoard" }
+if (-not [string]::IsNullOrWhiteSpace($MiroTeamId)) { $arguments += @("-MiroTeamId", $MiroTeamId) }
+if ($NonInteractive) { $arguments += "-NonInteractive" }
+if ($DryRun) { $arguments += "-DryRun" }
+
+# This is the only call into the legacy release executor. No merge/release/tag
+# code is reachable until the read-only Release Scope Gate returned PASS.
+Invoke-DDDAPlatformChildPowerShell -ScriptPath (Join-Path $PSScriptRoot "Invoke-DDDAPromotePr.ps1") -Arguments $arguments

--- a/scripts/platform/Invoke-DDDAGovernedPromotePr.ps1
+++ b/scripts/platform/Invoke-DDDAGovernedPromotePr.ps1
@@ -19,6 +19,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "DDDAPlatformSupport.ps1")
 . (Join-Path $PSScriptRoot "DDDAGitHubSupport.ps1")
 . (Join-Path $PSScriptRoot "DDDAReleaseGovernanceSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAPromotionResultSupport.ps1")
 
 Assert-DDDAPlatformSemanticVersion -Version $Version
 $platformRoot = Get-DDDAPlatformGitRoot -Path $PlatformPath
@@ -133,4 +134,92 @@ if ($DryRun) { $arguments += "-DryRun" }
 
 # This is the only call into the legacy release executor. No merge/release/tag
 # code is reachable until the read-only Release Scope Gate returned PASS.
-Invoke-DDDAPlatformChildPowerShell -ScriptPath (Join-Path $PSScriptRoot "Invoke-DDDAPromotePr.ps1") -Arguments $arguments
+$executorPath = Join-Path $PSScriptRoot "Invoke-DDDAPromotePr.ps1"
+if (-not $DryRun) {
+    Invoke-DDDAPlatformChildPowerShell -ScriptPath $executorPath -Arguments $arguments
+    return
+}
+
+# Issue #67: promotion dry-run result is operation-local and machine-readable.
+# Expected 404 responses for absent tag/GitHub Release are classified as successful
+# absence assertions; auth/network/5xx failures remain FAIL without ambient process state.
+$resultRoot = Join-Path (Get-DDDAPlatformStateRoot) ("promotion/pr-$Pr-$headSha/$Version")
+New-Item -ItemType Directory -Path $resultRoot -Force | Out-Null
+$resultPath = Join-Path $resultRoot "dry-run-result.json"
+$tag = "v$Version"
+$beforeSnapshot = $null
+$afterSnapshot = $null
+$sideEffectResult = $null
+$promotionPreflightStatus = "NOT_RUN"
+$sideEffectAssertionsStatus = "NOT_RUN"
+$wrapperStatus = "FAIL"
+$errorMessage = $null
+
+try {
+    $beforeSnapshot = Get-DDDAPromotionDryRunSnapshot -RepositorySlug $repositorySlug -Pr $Pr -Tag $tag -Token $githubAuth.Token
+    if ([bool]$beforeSnapshot.pr_merged) {
+        throw "Dry-run precondition failed: PR #$Pr is already merged."
+    }
+    if ([string]$beforeSnapshot.head_sha -ne $headSha) {
+        throw "Dry-run precondition failed: PR head changed before executor invocation."
+    }
+    if ([string]$beforeSnapshot.tag_status -ne "ABSENT") {
+        throw "Dry-run precondition failed: canonical tag $tag already exists."
+    }
+    if ([string]$beforeSnapshot.github_release_status -ne "ABSENT") {
+        throw "Dry-run precondition failed: GitHub Release for $tag already exists."
+    }
+
+    try {
+        Invoke-DDDAPlatformChildPowerShell -ScriptPath $executorPath -Arguments $arguments
+        $promotionPreflightStatus = "PASS"
+    }
+    catch {
+        $promotionPreflightStatus = "FAIL"
+        throw
+    }
+
+    $afterSnapshot = Get-DDDAPromotionDryRunSnapshot -RepositorySlug $repositorySlug -Pr $Pr -Tag $tag -Token $githubAuth.Token
+    $sideEffectResult = Test-DDDAPromotionDryRunSideEffects -Before $beforeSnapshot -After $afterSnapshot -ExpectedHeadSha $headSha
+    $sideEffectAssertionsStatus = [string]$sideEffectResult.status
+    if ($sideEffectAssertionsStatus -ne "PASS") {
+        throw "Promotion dry-run side-effect assertions failed: $(@($sideEffectResult.failures) -join ', ')"
+    }
+    $wrapperStatus = "PASS"
+}
+catch {
+    $errorMessage = $_.Exception.Message
+    if ($promotionPreflightStatus -eq "PASS" -and $sideEffectAssertionsStatus -eq "NOT_RUN") {
+        $sideEffectAssertionsStatus = "FAIL"
+    }
+}
+finally {
+    $result = [ordered]@{
+        schema_version = 1
+        repository = $repositorySlug
+        pr = $Pr
+        source_sha = $headSha
+        candidate_package_sha256 = [string]$validation.PackageSha256
+        version = $Version
+        release_scope_gate_status = [string]$gate.release_scope_gate_status
+        promotion_preflight_status = $promotionPreflightStatus
+        side_effect_assertions_status = $sideEffectAssertionsStatus
+        wrapper_status = $wrapperStatus
+        assertions = if ($null -eq $sideEffectResult) { $null } else { $sideEffectResult.assertions }
+        failing_assertions = if ($null -eq $sideEffectResult) { @() } else { @($sideEffectResult.failures) }
+        before = $beforeSnapshot
+        after = $afterSnapshot
+        error = $errorMessage
+        evidence_path = $resultPath
+    }
+    Write-DDDAPlatformJson -Value $result -Path $resultPath -Depth 30
+    Write-Host "Promotion dry-run evidence: $resultPath"
+}
+
+if ($wrapperStatus -ne "PASS") {
+    throw "Governed promotion dry-run FAIL. Evidence: $resultPath. $errorMessage"
+}
+Write-Host "DDDA governed promotion dry-run: PASS"
+Write-Host "Promotion preflight:       $promotionPreflightStatus"
+Write-Host "Side-effect assertions:    $sideEffectAssertionsStatus"
+Write-Host "Wrapper status:            $wrapperStatus"

--- a/scripts/platform/Invoke-DDDAMiroAcceptanceEvidence.ps1
+++ b/scripts/platform/Invoke-DDDAMiroAcceptanceEvidence.ps1
@@ -151,6 +151,12 @@ try {
             $ErrorActionPreference = $previousPreference
         }
 
+        $handoff = Get-DDDAMiroBoardIdentityHandoff -ChildOutput $childOutput
+        if ($null -ne $handoff) {
+            $boardId = [string]$handoff.board_id
+            $boardUrl = [string]$handoff.board_url
+        }
+
         $childOutput | ForEach-Object { Write-Host $_ }
         foreach ($line in $childOutput) {
             $text = [string]$line
@@ -166,8 +172,12 @@ try {
         $report = Get-Content -LiteralPath $reportPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $workspace = [string]$report.workspace
         $projectPath = [string]$report.project
-        $boardId = [string]$report.miro_board_id
-        if (-not [string]::IsNullOrWhiteSpace($boardId)) {
+        $reportBoardId = [string]$report.miro_board_id
+        if (-not [string]::IsNullOrWhiteSpace($reportBoardId)) {
+            if (-not [string]::IsNullOrWhiteSpace($boardId) -and $boardId -ne $reportBoardId) {
+                throw "Miro board identity handoff '$boardId' neodpovídá child reportu '$reportBoardId'."
+            }
+            $boardId = $reportBoardId
             $boardUrl = "https://miro.com/app/board/$boardId/"
         }
 

--- a/scripts/platform/Invoke-DDDAPlatformTest.ps1
+++ b/scripts/platform/Invoke-DDDAPlatformTest.ps1
@@ -213,6 +213,9 @@ function Invoke-OneSuite {
             $null = Invoke-DDDAPlatformNative -Command $miroPython -Arguments @("-m", "pytest", "-q", (Join-Path $platformRoot "runtime/miro/tests")) -WorkingDirectory $platformRoot
         }
         "component" {
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAValidationReport.ps1" -Arguments @("-PlatformPath", $platformRoot)
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAPromotionGuards.ps1" -Arguments @("-PlatformPath", $platformRoot)
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAReleasePublication.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroAutomation.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroEvidence.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAProjectSteering.ps1" -Arguments @("-PlatformPath", $platformRoot)
@@ -233,6 +236,7 @@ function Invoke-OneSuite {
         }
         "regression" {
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAFirstRun.ps1" -Arguments @("-PlatformPath", $platformRoot)
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAReleasePublication.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAProjectSteering.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroAutomation.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroEvidence.ps1" -Arguments @("-PlatformPath", $platformRoot)

--- a/scripts/platform/Invoke-DDDAPlatformTest.ps1
+++ b/scripts/platform/Invoke-DDDAPlatformTest.ps1
@@ -12,6 +12,7 @@ param(
     [string]$MiroTeamId,
     [string]$MiroEvidenceOutputPath,
     [switch]$NonInteractive,
+    [switch]$PrePromotionCandidate,
     [switch]$Json
 )
 
@@ -214,7 +215,9 @@ function Invoke-OneSuite {
         }
         "component" {
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAValidationReport.ps1" -Arguments @("-PlatformPath", $platformRoot)
-            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAPromotionGuards.ps1" -Arguments @("-PlatformPath", $platformRoot)
+            $promotionGuardArguments = @("-PlatformPath", $platformRoot)
+            if ($PrePromotionCandidate) { $promotionGuardArguments += "-PrePromotionCandidate" }
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAPromotionGuards.ps1" -Arguments $promotionGuardArguments
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAReleasePublication.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroAutomation.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroEvidence.ps1" -Arguments @("-PlatformPath", $platformRoot)

--- a/scripts/platform/Invoke-DDDAPromotePr.ps1
+++ b/scripts/platform/Invoke-DDDAPromotePr.ps1
@@ -18,6 +18,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "DDDAPlatformSupport.ps1")
 . (Join-Path $PSScriptRoot "DDDAGitHubSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAReleasePublicationSupport.ps1")
 
 Assert-DDDAPlatformSemanticVersion -Version $Version
 $platformRoot = Get-DDDAPlatformGitRoot -Path $PlatformPath
@@ -382,6 +383,8 @@ finally {
         Diagnostics = @($releaseDiagnostics)
         StartedAt = $releaseStartedAt
         CompletedAt = (Get-Date).ToUniversalTime()
+        PortablePaths = $true
+        RedactedRoots = @($stateRoot, $promotionRoot)
     }
     if (Test-Path -LiteralPath $releasePackagePath -PathType Leaf) {
         $releaseReportArguments["PackagePath"] = $releasePackagePath
@@ -420,6 +423,18 @@ if (-not [string]::IsNullOrWhiteSpace($existingTagAfterValidation)) {
 }
 $null = Invoke-DDDAPlatformGit -Repository $releaseSource -Arguments @("tag", "-a", $tag, $mergeCommit, "-m", "DDDA $Version")
 $null = Invoke-DDDAPlatformGit -Repository $releaseSource -Arguments @("push", "origin", $tag)
+$publicationEvidencePath = Join-Path $releaseReports "publication.json"
+$publication = Publish-DDDACanonicalGitHubRelease `
+    -RepositorySlug $repositorySlug `
+    -OriginUrl $originUrl `
+    -Version $Version `
+    -Tag $tag `
+    -ReleaseSourceSha $mergeCommit `
+    -PackagePath $releasePackagePath `
+    -ReportJsonPath $releaseReportJson `
+    -ReportMarkdownPath $releaseReportMarkdown `
+    -Token $githubAuth.Token `
+    -PublicationEvidencePath $publicationEvidencePath
 
 if (-not $KeepArtifacts -and -not $KeepReviewBoard -and (Test-Path -LiteralPath $promotionRoot)) {
     Remove-Item -LiteralPath $promotionRoot -Recurse -Force -ErrorAction SilentlyContinue
@@ -434,4 +449,6 @@ Write-Host "Release version: $Version"
 Write-Host "Release package: $releasePackagePath"
 Write-Host "Release report:  $releaseReports"
 Write-Host "Tag:             $tag"
+Write-Host "GitHub Release:  $($publication.github_release.url)"
+Write-Host "Publication:     $publicationEvidencePath"
 Write-Host "========================================"

--- a/scripts/platform/Invoke-DDDAPromotePr.ps1
+++ b/scripts/platform/Invoke-DDDAPromotePr.ps1
@@ -273,6 +273,20 @@ try {
     $null = Invoke-DDDAPlatformNative -Command "git" -Arguments @(
         "clone", "--branch", [string]$policy.base_branch, "--single-branch", $originUrl, $releaseSource
     )
+
+    # Release tags are annotated objects and require a tagger identity. Configure it
+    # only in the isolated release-source clone so clean runners never depend on
+    # ambient/global Git identity and no user-specific metadata leaks into the tag.
+    $releaseTaggerName = "DDDA Release Tagger"
+    $releaseTaggerEmail = "ddda-release-tagger@example.invalid"
+    $null = Invoke-DDDAPlatformGit -Repository $releaseSource -Arguments @("config", "user.name", $releaseTaggerName)
+    $null = Invoke-DDDAPlatformGit -Repository $releaseSource -Arguments @("config", "user.email", $releaseTaggerEmail)
+    $configuredTaggerName = Invoke-DDDAPlatformGit -Repository $releaseSource -Arguments @("config", "--get", "user.name")
+    $configuredTaggerEmail = Invoke-DDDAPlatformGit -Repository $releaseSource -Arguments @("config", "--get", "user.email")
+    if ($configuredTaggerName -ne $releaseTaggerName -or $configuredTaggerEmail -ne $releaseTaggerEmail) {
+        throw "Release-source Git tagger identity could not be configured deterministically."
+    }
+
     $releaseHead = Invoke-DDDAPlatformGit -Repository $releaseSource -Arguments @("rev-parse", "HEAD")
     if ($releaseHead -ne $mergeCommit) {
         throw "Aktuální main HEAD '$releaseHead' neodpovídá merge commit '$mergeCommit'."

--- a/scripts/platform/Invoke-DDDARecoverGitHubRelease.ps1
+++ b/scripts/platform/Invoke-DDDARecoverGitHubRelease.ps1
@@ -1,0 +1,46 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
+    [Parameter(Mandatory = $true)][string]$Version,
+    [Parameter(Mandatory = $true)][string]$ReleaseSourceSha,
+    [Parameter(Mandatory = $true)][string]$ReleasePackagePath,
+    [Parameter(Mandatory = $true)][string]$ReleaseReportJsonPath,
+    [Parameter(Mandatory = $true)][string]$ReleaseReportMarkdownPath,
+    [switch]$ConfirmRecovery
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "DDDAPlatformSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAGitHubSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAReleasePublicationSupport.ps1")
+
+if (-not $ConfirmRecovery) {
+    throw "GitHub Release recovery vyžaduje explicitní -ConfirmRecovery authorization."
+}
+Assert-DDDAPlatformSemanticVersion -Version $Version
+if ($ReleaseSourceSha -notmatch '^[0-9a-f]{40}$') { throw "ReleaseSourceSha není plný SHA." }
+$platformRoot = Get-DDDAPlatformGitRoot -Path $PlatformPath
+Assert-DDDAPlatformCleanGit -Repository $platformRoot
+$originUrl = Get-DDDAPlatformRepositoryUrl -Repository $platformRoot
+$repositorySlug = Get-DDDAPlatformRepositorySlug -RepositoryUrl $originUrl
+$githubAuth = Get-DDDAGitHubAuthentication
+$tag = "v$Version"
+$evidenceRoot = Join-Path (Get-DDDAPlatformStateRoot) ("release-publication-recovery/$Version/" + (Get-DDDAPlatformTimestamp))
+New-Item -ItemType Directory -Path $evidenceRoot -Force | Out-Null
+
+$publication = Publish-DDDACanonicalGitHubRelease `
+    -RepositorySlug $repositorySlug `
+    -OriginUrl $originUrl `
+    -Version $Version `
+    -Tag $tag `
+    -ReleaseSourceSha $ReleaseSourceSha `
+    -PackagePath $ReleasePackagePath `
+    -ReportJsonPath $ReleaseReportJsonPath `
+    -ReportMarkdownPath $ReleaseReportMarkdownPath `
+    -Token $githubAuth.Token `
+    -PublicationEvidencePath (Join-Path $evidenceRoot "publication.json")
+
+Write-Host "DDDA GitHub Release recovery: PASS"
+Write-Host "Release: $($publication.github_release.url)"
+Write-Host "Evidence: $(Join-Path $evidenceRoot 'publication.json')"

--- a/scripts/platform/Invoke-DDDAReviewPr.ps1
+++ b/scripts/platform/Invoke-DDDAReviewPr.ps1
@@ -1,0 +1,120 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
+    [Parameter(Mandatory = $true)][ValidateRange(1, 2147483647)][int]$Pr,
+    [Parameter(Mandatory = $true)][string]$Version,
+    [string]$Reviewer,
+    [string]$DecisionOwner,
+    [switch]$PublishScaffold,
+    [switch]$Json
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "DDDAPlatformSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAGitHubSupport.ps1")
+. (Join-Path $PSScriptRoot "DDDAReleaseGovernanceSupport.ps1")
+
+Assert-DDDAPlatformSemanticVersion -Version $Version
+$platformRoot = Get-DDDAPlatformGitRoot -Path $PlatformPath
+Assert-DDDAPlatformCleanGit -Repository $platformRoot
+$originUrl = Get-DDDAPlatformRepositoryUrl -Repository $platformRoot
+$repositorySlug = Get-DDDAPlatformRepositorySlug -RepositoryUrl $originUrl
+$githubAuth = Get-DDDAGitHubAuthentication
+
+$prInfo = Get-DDDAGitHubPullRequest -RepositorySlug $repositorySlug -Pr $Pr -Token $githubAuth.Token
+if ([string]$prInfo.state -ne "open") {
+    throw "PR #$Pr není otevřený."
+}
+$headSha = [string]$prInfo.head.sha
+if ($headSha -notmatch '^[0-9a-f]{40}$') {
+    throw "GitHub nevrátil platný PR head SHA."
+}
+
+$validation = Get-DDDACandidateValidationEvidence -Pr $Pr -HeadSha $headSha
+$scope = Get-DDDAReleaseMilestoneScope -RepositorySlug $repositorySlug -Version $Version -Token $githubAuth.Token
+
+$record = [ordered]@{
+    schema_version = 1
+    repository = $repositorySlug
+    pr = $Pr
+    branch = [string]$prInfo.head.ref
+    source_sha = $headSha
+    candidate_package_sha256 = [string]$validation.PackageSha256
+    version = $Version
+    reviewer = if ([string]::IsNullOrWhiteSpace($Reviewer)) { "" } else { $Reviewer }
+    decision_owner = if ([string]::IsNullOrWhiteSpace($DecisionOwner)) { "" } else { $DecisionOwner }
+    decision = "pending"
+    decided_at = $null
+    scope_issues = @($scope.Issues)
+    findings = @()
+    accepted_risks = @()
+    evidence = [ordered]@{
+        validation_report = [string]$validation.ReportPath
+        candidate_package = [string]$validation.PackagePath
+        milestone = [string]$scope.Title
+    }
+}
+
+$reviewRoot = Join-Path (Get-DDDAPlatformStateRoot) ("human-reviews/pr-$Pr-$headSha")
+New-Item -ItemType Directory -Path $reviewRoot -Force | Out-Null
+$jsonPath = Join-Path $reviewRoot "human-release-decision.json"
+$markdownPath = Join-Path $reviewRoot "human-release-decision.md"
+Write-DDDAPlatformJson -Value $record -Path $jsonPath -Depth 30
+
+$markdown = @"
+# Human Release Decision Record — PR #$Pr
+
+- Repository: $repositorySlug
+- Branch: $([string]$prInfo.head.ref)
+- Exact SHA: $headSha
+- Candidate SHA-256: $([string]$validation.PackageSha256)
+- Proposed version: $Version
+- Milestone: $([string]$scope.Title)
+- Scope Issues: $(@($scope.Issues | ForEach-Object { "#$_" }) -join ", ")
+- Decision: **PENDING HUMAN DECISION**
+- Reviewer: $(if ([string]::IsNullOrWhiteSpace($Reviewer)) { "<human fills>" } else { $Reviewer })
+- Decision owner: $(if ([string]::IsNullOrWhiteSpace($DecisionOwner)) { "<human fills>" } else { $DecisionOwner })
+
+Automation created only a scaffold. It did not issue a release decision and did not accept any risk.
+
+Authoritative machine-readable working copy: $jsonPath
+"@
+Write-DDDAPlatformText -Value ($markdown + [Environment]::NewLine) -Path $markdownPath
+
+$comment = $null
+if ($PublishScaffold) {
+    $comment = Set-DDDAHrdrComment -RepositorySlug $repositorySlug -Pr $Pr -Token $githubAuth.Token -Record $record
+}
+
+$result = [ordered]@{
+    status = "PENDING_HUMAN_DECISION"
+    repository = $repositorySlug
+    pr = $Pr
+    branch = [string]$prInfo.head.ref
+    source_sha = $headSha
+    candidate_package_sha256 = [string]$validation.PackageSha256
+    version = $Version
+    milestone = [string]$scope.Title
+    scope_issues = @($scope.Issues)
+    json_path = $jsonPath
+    markdown_path = $markdownPath
+    published_comment_id = if ($null -eq $comment) { $null } else { [int64]$comment.id }
+}
+
+if ($Json) {
+    $result | ConvertTo-Json -Depth 20
+}
+else {
+    Write-Host "DDDA review-pr scaffold: PASS"
+    Write-Host "PR:                $Pr"
+    Write-Host "Head SHA:          $headSha"
+    Write-Host "Candidate hash:    $($validation.PackageSha256)"
+    Write-Host "Version:           $Version"
+    Write-Host "Milestone:         $($scope.Title)"
+    Write-Host "Decision:          PENDING_HUMAN_DECISION"
+    Write-Host "Working HRDR:      $jsonPath"
+    if ($null -ne $comment) {
+        Write-Host "Authoritative comment scaffold: $([int64]$comment.id)"
+    }
+}

--- a/scripts/platform/Invoke-DDDAValidatePr.ps1
+++ b/scripts/platform/Invoke-DDDAValidatePr.ps1
@@ -8,7 +8,8 @@ param(
     [switch]$KeepArtifacts,
     [switch]$KeepReviewBoard,
     [string]$MiroTeamId,
-    [switch]$NonInteractive
+    [switch]$NonInteractive,
+    [switch]$PrePromotionCandidate
 )
 
 Set-StrictMode -Version Latest
@@ -199,10 +200,12 @@ try {
     Assert-DDDAPlatformCleanGit -Repository $packageRoot -Label "Rozbalený candidate package"
 
     $commonArguments = @("-PackagePath", $packagePath)
+    $componentArguments = @("component")
+    if ($PrePromotionCandidate) { $componentArguments += "-PrePromotionCandidate" }
     Invoke-ValidationSuite -Name "lint" -Arguments @("lint")
     Invoke-ValidationSuite -Name "schema" -Arguments @("schema")
     Invoke-ValidationSuite -Name "unit" -Arguments @("unit")
-    Invoke-ValidationSuite -Name "component" -Arguments @("component")
+    Invoke-ValidationSuite -Name "component" -Arguments $componentArguments
     Invoke-ValidationSuite -Name "integration" -Arguments (@("integration") + $commonArguments)
     Invoke-ValidationSuite -Name "smoke" -Arguments (@("smoke") + $commonArguments)
     Invoke-ValidationSuite -Name "regression" -Arguments @("regression")

--- a/scripts/platform/Test-DDDAMergeReleaseEligibility.py
+++ b/scripts/platform/Test-DDDAMergeReleaseEligibility.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Read-only releasable-main guard for governed implementation merges.
+
+The active train is the single open ``DDDA X.Y.Z`` Milestone.  While it
+exists, a PR may merge to main only when its one primary Change Request is in
+that Milestone.  The script never changes a Milestone, Project field or PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNTIME = ROOT / "runtime" / "platform"
+if str(RUNTIME) not in sys.path:
+    sys.path.insert(0, str(RUNTIME))
+
+from release_governance import evaluate_merge_release_eligibility  # noqa: E402
+
+
+API_ROOT = "https://api.github.com"
+MILESTONE_RE = re.compile(r"^DDDA (?P<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$")
+PRIMARY_RE = re.compile(r"(?im)^\s*(?:[-*]\s*)?(?:Implements|Closes)\s+#(\d+)\s*$")
+TARGET_RE = re.compile(
+    r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?Target\s+Release(?:\*\*)?\s*:\s*`?([^`\r\n]+)"
+)
+
+
+class GitHubReadError(RuntimeError):
+    pass
+
+
+def request_json(path: str, token: str) -> Any:
+    request = Request(
+        f"{API_ROOT}/{path.lstrip('/')}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "DDDA-Merge-Release-Eligibility",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        details = exc.read().decode("utf-8", errors="replace")[:500]
+        raise GitHubReadError(f"GitHub GET {path} failed: HTTP {exc.code}: {details}") from exc
+    except URLError as exc:
+        raise GitHubReadError(f"GitHub GET {path} failed: {exc}") from exc
+
+
+def pages(path: str, token: str) -> list[Any]:
+    result: list[Any] = []
+    for page in range(1, 101):
+        separator = "&" if "?" in path else "?"
+        rows = request_json(f"{path}{separator}per_page=100&page={page}", token)
+        if not isinstance(rows, list):
+            raise GitHubReadError(f"Expected a list from {path}")
+        result.extend(rows)
+        if len(rows) < 100:
+            return result
+    raise GitHubReadError(f"Pagination limit exceeded for {path}")
+
+
+def active_release(milestones: list[dict[str, Any]]) -> dict[str, str] | None:
+    matches = []
+    for milestone in milestones:
+        match = MILESTONE_RE.fullmatch(str(milestone.get("title") or ""))
+        if match and milestone.get("state") == "open":
+            matches.append(match.group("version"))
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise GitHubReadError(f"Expected at most one active DDDA release train, found {sorted(matches)}")
+    return {"version": matches[0]}
+
+
+def primary_changes(body: str) -> list[int]:
+    return sorted({int(x) for x in PRIMARY_RE.findall(body or "")})
+
+
+def target_release(body: str) -> str | None:
+    match = TARGET_RE.search(body or "")
+    return match.group(1).strip() if match else None
+
+
+def collect(repository: str, pr_number: int, expected_sha: str, token: str) -> dict[str, Any]:
+    pr = request_json(f"repos/{repository}/pulls/{pr_number}", token)
+    head = str(((pr or {}).get("head") or {}).get("sha") or "")
+    if head != expected_sha:
+        raise GitHubReadError("PR head changed before merge eligibility evaluation")
+    primary = primary_changes(str((pr or {}).get("body") or ""))
+    issue: dict[str, Any] = {}
+    if len(primary) == 1:
+        issue = request_json(f"repos/{repository}/issues/{primary[0]}", token) or {}
+    return {
+        "repository": repository,
+        "pr": pr_number,
+        "source_sha": head,
+        "active_release": active_release(pages(f"repos/{repository}/milestones?state=all", token)),
+        "primary_crs": primary,
+        "primary_cr": {
+            "milestone": ((issue.get("milestone") or {}).get("title")),
+            "target_release": target_release(str(issue.get("body") or "")),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--pr", required=True, type=int)
+    parser.add_argument("--expected-sha", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("Merge eligibility FAIL: GH_TOKEN or GITHUB_TOKEN is required.", file=sys.stderr)
+        return 2
+    try:
+        snapshot = collect(args.repository, args.pr, args.expected_sha, token)
+        failures = evaluate_merge_release_eligibility(snapshot)
+        result = {
+            "schema_version": 1,
+            **snapshot,
+            "status": "PASS" if not failures else "FAIL",
+            "failing_invariants": failures,
+            "side_effects_allowed": not failures,
+        }
+        text = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
+        if args.output:
+            output = Path(args.output)
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(text, encoding="utf-8")
+        print(text, end="")
+        return 0 if not failures else 1
+    except (GitHubReadError, OSError, ValueError) as exc:
+        print(f"Merge eligibility FAIL: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/platform/Test-DDDAReleaseScope.py
+++ b/scripts/platform/Test-DDDAReleaseScope.py
@@ -35,6 +35,10 @@ DELIVERY_VIEW = "Implementace a Delivery"
 TARGET_RELEASE_RE = re.compile(
     r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?Target\s+(?:Release|resolution|horizon)(?:\*\*)?\s*:\s*`?([^`\r\n]+)"
 )
+SEMVER_TAG_RE = re.compile(r"^v(?P<version>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$")
+PRIMARY_CHANGE_RE = re.compile(
+    r"(?im)^\s*(?:[-*]\s*)?(?:Implements|Closes)\s+#(\d+)\s*$"
+)
 
 
 class GitHubReadError(RuntimeError):
@@ -248,6 +252,117 @@ def risk_horizon(body: str) -> str:
     return match.group(1).strip() if match else ""
 
 
+def _tag_version(name: str) -> tuple[int, int, int] | None:
+    match = SEMVER_TAG_RE.fullmatch(name)
+    if not match:
+        return None
+    return (int(match.group("version")), int(match.group("minor")), int(match.group("patch")))
+
+
+def _dereference_tag(repository: str, sha: str, object_type: str, token: str) -> str:
+    """Resolve annotated tags without accepting an ambiguous non-commit object."""
+    current_sha, current_type = sha, object_type
+    for _ in range(4):
+        if current_type == "commit":
+            return current_sha
+        if current_type != "tag":
+            break
+        tag = rest_get(f"repos/{repository}/git/tags/{current_sha}", token)
+        obj = (tag or {}).get("object") or {}
+        current_sha, current_type = str(obj.get("sha") or ""), str(obj.get("type") or "")
+    raise GitHubReadError("Release tag does not resolve to a commit")
+
+
+def previous_release_tag(repository: str, version: str, token: str) -> dict[str, str]:
+    current = _tag_version(f"v{version}")
+    if current is None:
+        raise GitHubReadError(f"Release version is not stable SemVer: {version}")
+    refs = rest_get(f"repos/{repository}/git/matching-refs/tags/", token)
+    candidates: list[tuple[tuple[int, int, int], str, str, str]] = []
+    for ref in refs or []:
+        name = str(ref.get("ref") or "").removeprefix("refs/tags/")
+        parsed = _tag_version(name)
+        obj = ref.get("object") or {}
+        if parsed is not None and parsed < current:
+            candidates.append((parsed, name, str(obj.get("sha") or ""), str(obj.get("type") or "")))
+    if not candidates:
+        raise GitHubReadError(f"No canonical previous SemVer tag exists before v{version}")
+    _, name, sha, object_type = max(candidates)
+    return {"tag": name, "sha": _dereference_tag(repository, sha, object_type, token)}
+
+
+def compare_commits(repository: str, base: str, head: str, token: str) -> tuple[str, list[dict[str, Any]]]:
+    first = rest_get(f"repos/{repository}/compare/{base}...{head}?per_page=100&page=1", token)
+    status = str((first or {}).get("status") or "")
+    total = int((first or {}).get("total_commits") or 0)
+    commits = list((first or {}).get("commits") or [])
+    page = 2
+    while len(commits) < total:
+        more = rest_get(f"repos/{repository}/compare/{base}...{head}?per_page=100&page={page}", token)
+        batch = list((more or {}).get("commits") or [])
+        if not batch:
+            raise GitHubReadError("Compare pagination ended before all physical source commits were read")
+        commits.extend(batch)
+        page += 1
+    if len(commits) != total:
+        raise GitHubReadError("Compare returned an ambiguous physical source commit count")
+    return status, commits
+
+
+def primary_change_requests(body: str) -> list[int]:
+    return sorted({int(value) for value in PRIMARY_CHANGE_RE.findall(body or "")})
+
+
+def physical_scope_snapshot(
+    repository: str,
+    version: str,
+    source_sha: str,
+    token: str,
+    project_rows: dict[int, dict[str, Any]],
+) -> dict[str, Any]:
+    previous = previous_release_tag(repository, version, token)
+    compare_status, commits = compare_commits(repository, previous["tag"], source_sha, token)
+    pr_numbers: set[int] = set()
+    unmapped: set[str] = set()
+    for commit in commits:
+        sha = str(commit.get("sha") or "")
+        linked = rest_pages(f"repos/{repository}/commits/{sha}/pulls", token)
+        numbers = {int(row["number"]) for row in linked if row.get("number") is not None}
+        if not numbers:
+            unmapped.add(sha)
+        pr_numbers.update(numbers)
+
+    shipping: list[dict[str, Any]] = []
+    for number in sorted(pr_numbers):
+        pr = rest_get(f"repos/{repository}/pulls/{number}", token)
+        primary = primary_change_requests(str((pr or {}).get("body") or ""))
+        authority: dict[str, Any] = {}
+        if len(primary) == 1:
+            authority = rest_get(f"repos/{repository}/issues/{primary[0]}", token) or {}
+        milestone = (authority.get("milestone") or {}).get("title")
+        project = project_rows.get(primary[0], {}) if len(primary) == 1 else {}
+        shipping.append(
+            {
+                "number": number,
+                "merged": bool((pr or {}).get("merged_at")),
+                "merge_commit_sha": (pr or {}).get("merge_commit_sha"),
+                "primary_crs": primary,
+                "milestone": milestone,
+                "target_release": project.get("Target Release"),
+            }
+        )
+
+    return {
+        "previous_release_tag": previous["tag"],
+        "previous_release_sha": previous["sha"],
+        "release_source_sha": source_sha,
+        "compare_status": compare_status,
+        "commit_count": len(commits),
+        "unmapped_commit_shas": sorted(unmapped),
+        "shipping_prs": shipping,
+    }
+
+
 def collect_snapshot(
     record: dict[str, Any],
     *,
@@ -296,6 +411,13 @@ def collect_snapshot(
     owner = repository.split("/", 1)[0]
     proj_number = project_number(owner, project_token)
     project_meta, project_rows = project_snapshot(owner, proj_number, project_token)
+    physical_scope = physical_scope_snapshot(
+        repository,
+        version,
+        current_head,
+        api_token,
+        project_rows,
+    )
 
     return {
         "current_pr_head": current_head,
@@ -310,6 +432,7 @@ def collect_snapshot(
         "risk_issue_states": risk_states,
         "risk_issue_assignees": risk_assignees,
         "risk_issue_horizons": risk_horizons,
+        "physical_scope": physical_scope,
     }
 
 
@@ -378,6 +501,7 @@ def main() -> int:
             ],
             "residual_risks": record.get("accepted_risks", []),
             "hrdr_risk_set": result.as_dict()["accepted_risk_issues"],
+            "physical_scope": snapshot.get("physical_scope"),
             **result.as_dict(),
             "snapshot": snapshot,
         }

--- a/scripts/platform/Test-DDDAReleaseScope.py
+++ b/scripts/platform/Test-DDDAReleaseScope.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Collect live GitHub/Project release-scope state and evaluate the DDDA Release Scope Gate.
+
+This script is deliberately read-only. It uses GitHub REST for PR/milestone/Issue
+state and Project V2 GraphQL for the operational planning projection. All
+business invariants are evaluated by runtime/platform/release_governance.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[2]
+PLATFORM_RUNTIME = REPO_ROOT / "runtime" / "platform"
+if str(PLATFORM_RUNTIME) not in sys.path:
+    sys.path.insert(0, str(PLATFORM_RUNTIME))
+
+from release_governance import evaluate_release_scope  # noqa: E402
+
+
+API_ROOT = "https://api.github.com"
+GRAPHQL_URL = "https://api.github.com/graphql"
+PROJECT_TITLE = "DDDA Platform Backlog & Delivery"
+PLANNING_VIEW = "Plánování a Backlog"
+DELIVERY_VIEW = "Implementace a Delivery"
+TARGET_RELEASE_RE = re.compile(
+    r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?Target\s+(?:Release|resolution|horizon)(?:\*\*)?\s*:\s*`?([^`\r\n]+)"
+)
+
+
+class GitHubReadError(RuntimeError):
+    pass
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "DDDA-Release-Scope-Gate",
+    }
+
+
+def _request_json(
+    url: str,
+    token: str,
+    *,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+) -> tuple[Any, dict[str, str]]:
+    data = None
+    headers = _headers(token)
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = Request(url, data=data, method=method, headers=headers)
+    try:
+        with urlopen(request, timeout=30) as response:
+            payload = response.read().decode("utf-8")
+            return (json.loads(payload) if payload.strip() else None, dict(response.headers.items()))
+    except HTTPError as exc:
+        details = exc.read().decode("utf-8", errors="replace")[:1000]
+        raise GitHubReadError(f"GitHub {method} {url} failed: HTTP {exc.code}: {details}") from exc
+    except URLError as exc:
+        raise GitHubReadError(f"GitHub {method} {url} failed: {exc}") from exc
+
+
+def rest_get(path: str, token: str) -> Any:
+    payload, _ = _request_json(f"{API_ROOT}/{path.lstrip('/')}", token)
+    return payload
+
+
+def rest_pages(path: str, token: str) -> list[Any]:
+    rows: list[Any] = []
+    page = 1
+    separator = "&" if "?" in path else "?"
+    while True:
+        batch = rest_get(f"{path}{separator}per_page=100&page={page}", token) or []
+        if not isinstance(batch, list):
+            raise GitHubReadError(f"Paginated endpoint did not return a list: {path}")
+        rows.extend(batch)
+        if len(batch) < 100:
+            return rows
+        page += 1
+
+
+def graphql(query: str, variables: dict[str, Any], token: str) -> dict[str, Any]:
+    payload, _ = _request_json(
+        GRAPHQL_URL,
+        token,
+        method="POST",
+        body={"query": query, "variables": variables},
+    )
+    if not isinstance(payload, dict):
+        raise GitHubReadError("GitHub GraphQL returned a non-object payload")
+    if payload.get("errors"):
+        raise GitHubReadError("GitHub GraphQL failed: " + json.dumps(payload["errors"], ensure_ascii=False))
+    return payload.get("data") or {}
+
+
+def project_number(owner: str, project_token: str) -> int:
+    query = """
+    query($login:String!,$after:String){
+      user(login:$login){
+        projectsV2(first:100,after:$after){
+          pageInfo{hasNextPage endCursor}
+          nodes{number title closed}
+        }
+      }
+    }
+    """
+    after = None
+    matches: list[int] = []
+    while True:
+        data = graphql(query, {"login": owner, "after": after}, project_token)
+        user = data.get("user")
+        if not user:
+            raise GitHubReadError(f"Project owner not found: {owner}")
+        block = user["projectsV2"]
+        for node in block["nodes"]:
+            if node.get("title") == PROJECT_TITLE and not node.get("closed"):
+                matches.append(int(node["number"]))
+        if not block["pageInfo"]["hasNextPage"]:
+            break
+        after = block["pageInfo"]["endCursor"]
+    if len(matches) != 1:
+        raise GitHubReadError(
+            f"Expected exactly one open Project named '{PROJECT_TITLE}', found {matches}"
+        )
+    return matches[0]
+
+
+Q_PROJECT = """
+query($login:String!,$number:Int!,$after:String){
+  user(login:$login){
+    projectV2(number:$number){
+      title
+      views(first:50){nodes{name layout filter}}
+      items(first:100,after:$after){
+        pageInfo{hasNextPage endCursor}
+        nodes{
+          content{
+            __typename
+            ... on Issue{number state}
+          }
+          fieldValues(first:50){nodes{
+            __typename
+            ... on ProjectV2ItemFieldSingleSelectValue{
+              name
+              field{... on ProjectV2FieldCommon{name}}
+            }
+            ... on ProjectV2ItemFieldTextValue{
+              text
+              field{... on ProjectV2FieldCommon{name}}
+            }
+          }}
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _project_values(item: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for node in (item.get("fieldValues") or {}).get("nodes", []):
+        field = node.get("field") or {}
+        name = field.get("name")
+        if not name:
+            continue
+        result[name] = node.get("name") if node.get("name") is not None else node.get("text")
+    return result
+
+
+def project_snapshot(owner: str, number: int, token: str) -> tuple[dict[str, Any], dict[int, dict[str, Any]]]:
+    after = None
+    rows: dict[int, dict[str, Any]] = {}
+    meta: dict[str, Any] | None = None
+    while True:
+        data = graphql(Q_PROJECT, {"login": owner, "number": number, "after": after}, token)
+        user = data.get("user")
+        project = (user or {}).get("projectV2")
+        if not project:
+            raise GitHubReadError(f"Project #{number} not found for owner {owner}")
+        if meta is None:
+            views = project.get("views", {}).get("nodes", [])
+            by_name = {v.get("name"): v for v in views}
+            meta = {
+                "title": project.get("title"),
+                "planning_view_filter": (by_name.get(PLANNING_VIEW) or {}).get("filter") or "",
+                "delivery_view_filter": (by_name.get(DELIVERY_VIEW) or {}).get("filter") or "",
+            }
+        block = project["items"]
+        for item in block["nodes"]:
+            content = item.get("content") or {}
+            if content.get("__typename") != "Issue":
+                continue
+            number_value = content.get("number")
+            if number_value is None:
+                continue
+            rows[int(number_value)] = _project_values(item)
+        if not block["pageInfo"]["hasNextPage"]:
+            break
+        after = block["pageInfo"]["endCursor"]
+    assert meta is not None
+    return meta, rows
+
+
+def find_milestone(repository: str, version: str, token: str) -> dict[str, Any]:
+    wanted = f"DDDA {version}"
+    milestones = rest_pages(f"repos/{repository}/milestones?state=all", token)
+    matches = [m for m in milestones if m.get("title") == wanted]
+    if len(matches) != 1:
+        raise GitHubReadError(f"Expected exactly one milestone '{wanted}', found {len(matches)}")
+    return matches[0]
+
+
+def milestone_issue_rows(repository: str, milestone_number: int, token: str) -> list[dict[str, Any]]:
+    all_rows = rest_pages(
+        f"repos/{repository}/issues?state=all&milestone={milestone_number}", token
+    )
+    return [row for row in all_rows if "pull_request" not in row]
+
+
+def active_blockers(repository: str, issue: int, token: str) -> list[int]:
+    rows = rest_pages(
+        f"repos/{repository}/issues/{issue}/dependencies/blocked_by", token
+    )
+    return sorted(
+        int(row["number"])
+        for row in rows
+        if row.get("state") != "closed" and row.get("number") is not None
+    )
+
+
+def risk_horizon(body: str) -> str:
+    match = TARGET_RELEASE_RE.search(body or "")
+    return match.group(1).strip() if match else ""
+
+
+def collect_snapshot(
+    record: dict[str, Any],
+    *,
+    repository: str,
+    pr: int,
+    version: str,
+    api_token: str,
+    project_token: str,
+) -> dict[str, Any]:
+    pr_info = rest_get(f"repos/{repository}/pulls/{pr}", api_token)
+    current_head = ((pr_info or {}).get("head") or {}).get("sha")
+
+    milestone = find_milestone(repository, version, api_token)
+    scope_rows = milestone_issue_rows(repository, int(milestone["number"]), api_token)
+    milestone_issues = sorted(int(row["number"]) for row in scope_rows)
+
+    issue_states = {int(row["number"]): row.get("state") for row in scope_rows}
+    blockers = {
+        issue: active_blockers(repository, issue, api_token)
+        for issue in milestone_issues
+    }
+
+    risk_states: dict[int, str] = {}
+    risk_assignees: dict[int, list[str]] = {}
+    risk_horizons: dict[int, str] = {}
+    for risk in record.get("accepted_risks", []):
+        if not isinstance(risk, dict):
+            continue
+        try:
+            issue = int(risk.get("issue", 0))
+        except (TypeError, ValueError):
+            continue
+        if issue <= 0:
+            continue
+        data = rest_get(f"repos/{repository}/issues/{issue}", api_token)
+        if "pull_request" in data:
+            raise GitHubReadError(f"Accepted-risk reference #{issue} is a pull request, not an Issue")
+        risk_states[issue] = str(data.get("state", ""))
+        risk_assignees[issue] = [
+            str(x.get("login"))
+            for x in data.get("assignees", [])
+            if x.get("login")
+        ]
+        risk_horizons[issue] = risk_horizon(str(data.get("body") or ""))
+
+    owner = repository.split("/", 1)[0]
+    proj_number = project_number(owner, project_token)
+    project_meta, project_rows = project_snapshot(owner, proj_number, project_token)
+
+    return {
+        "current_pr_head": current_head,
+        "milestone_title": milestone.get("title"),
+        "milestone_number": int(milestone["number"]),
+        "milestone_issues": milestone_issues,
+        "issue_states": issue_states,
+        "blockers": blockers,
+        "project": project_meta,
+        "project_number": proj_number,
+        "project_rows": project_rows,
+        "risk_issue_states": risk_states,
+        "risk_issue_assignees": risk_assignees,
+        "risk_issue_horizons": risk_horizons,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--pr", required=True, type=int)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--candidate-sha256", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--hrdr", required=True)
+    parser.add_argument("--output")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    api_token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    project_token = os.environ.get("DDDA_GITHUB_PROJECT_TOKEN")
+    if not api_token:
+        print("Release Scope Gate FAIL: GH_TOKEN or GITHUB_TOKEN is required for read-only GitHub evidence.", file=sys.stderr)
+        return 2
+    if not project_token:
+        print("Release Scope Gate FAIL: DDDA_GITHUB_PROJECT_TOKEN is required for authoritative Project V2 read-back.", file=sys.stderr)
+        return 2
+
+    try:
+        record = json.loads(Path(args.hrdr).read_text(encoding="utf-8-sig"))
+        snapshot = collect_snapshot(
+            record,
+            repository=args.repository,
+            pr=args.pr,
+            version=args.version,
+            api_token=api_token,
+            project_token=project_token,
+        )
+        result = evaluate_release_scope(
+            record,
+            snapshot,
+            expected_repository=args.repository,
+            expected_pr=args.pr,
+            expected_source_sha=args.source_sha,
+            expected_package_sha256=args.candidate_sha256,
+            expected_version=args.version,
+        )
+        evidence = {
+            "schema_version": 1,
+            "repository": args.repository,
+            "pr": args.pr,
+            "source_sha": args.source_sha,
+            "candidate_package_sha256": args.candidate_sha256,
+            "version": args.version,
+            "scope_source": "GitHub Milestone + Issue/native dependency + Project V2 live read-back",
+            "milestone": snapshot.get("milestone_title"),
+            "scope_items": result.as_dict()["scope_issues"],
+            "terminal_items": sorted(
+                int(k) for k, state in snapshot.get("issue_states", {}).items() if state == "closed"
+            ),
+            "deferred_items": result.as_dict()["accepted_risk_issues"],
+            "unresolved_blockers": snapshot.get("blockers"),
+            "project_mismatches": [
+                failure for failure in result.failures if "PROJECT" in failure
+            ],
+            "milestone_mismatches": [
+                failure for failure in result.failures if "MILESTONE" in failure
+            ],
+            "residual_risks": record.get("accepted_risks", []),
+            "hrdr_risk_set": result.as_dict()["accepted_risk_issues"],
+            **result.as_dict(),
+            "snapshot": snapshot,
+        }
+        text = json.dumps(evidence, ensure_ascii=False, indent=2) + "\n"
+        if args.output:
+            out = Path(args.output)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(text, encoding="utf-8")
+        print(text, end="")
+        return 0 if result.status == "PASS" else 1
+    except (OSError, ValueError, GitHubReadError) as exc:
+        print(f"Release Scope Gate FAIL: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/platform/Test-DDDAReleaseScope.py
+++ b/scripts/platform/Test-DDDAReleaseScope.py
@@ -9,6 +9,7 @@ business invariants are evaluated by runtime/platform/release_governance.py.
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 from pathlib import Path
@@ -30,6 +31,7 @@ from release_governance import evaluate_release_scope  # noqa: E402
 API_ROOT = "https://api.github.com"
 GRAPHQL_URL = "https://api.github.com/graphql"
 PROJECT_TITLE = "DDDA Platform Backlog & Delivery"
+RECOVERY_LEDGER_PATH = "config/governance/release-source-recovery-ledger.json"
 PLANNING_VIEW = "Plánování a Backlog"
 DELIVERY_VIEW = "Implementace a Delivery"
 TARGET_RELEASE_RE = re.compile(
@@ -313,6 +315,63 @@ def primary_change_requests(body: str) -> list[int]:
     return sorted({int(value) for value in PRIMARY_CHANGE_RE.findall(body or "")})
 
 
+def recovery_ledger_at_source(repository: str, source_sha: str, token: str) -> dict[str, Any] | None:
+    """Read an optional ledger from the exact candidate source, never default main."""
+    try:
+        payload = rest_get(
+            f"repos/{repository}/contents/{RECOVERY_LEDGER_PATH}?ref={source_sha}", token
+        )
+    except GitHubReadError as exc:
+        if "HTTP 404" in str(exc):
+            return None
+        raise
+    if not isinstance(payload, dict) or payload.get("encoding") != "base64":
+        return {"invalid": "CONTENT_SHAPE"}
+    try:
+        raw = base64.b64decode(str(payload.get("content") or ""), validate=False)
+        decoded = json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        return {"invalid": f"JSON:{exc.__class__.__name__}"}
+    return decoded if isinstance(decoded, dict) else {"invalid": "ROOT_SHAPE"}
+
+
+def commit_path_hashes(repository: str, sha: str, token: str) -> dict[str, str | None] | None:
+    """Return the exact file-result hashes reported for one commit, fail closed on ambiguity."""
+    data = rest_get(f"repos/{repository}/commits/{sha}", token)
+    files = (data or {}).get("files") if isinstance(data, dict) else None
+    if not isinstance(files, list):
+        return None
+    result: dict[str, str | None] = {}
+    for row in files:
+        if not isinstance(row, dict) or not isinstance(row.get("filename"), str):
+            return None
+        path = row["filename"]
+        if path in result:
+            return None
+        result[path] = None if row.get("status") == "removed" else str(row.get("sha") or "")
+        if result[path] == "":
+            return None
+    return result
+
+
+def shipping_row(repository: str, number: int, token: str, project_rows: dict[int, dict[str, Any]]) -> dict[str, Any]:
+    pr = rest_get(f"repos/{repository}/pulls/{number}", token) or {}
+    primary = primary_change_requests(str(pr.get("body") or ""))
+    authority: dict[str, Any] = {}
+    if len(primary) == 1:
+        authority = rest_get(f"repos/{repository}/issues/{primary[0]}", token) or {}
+    milestone = (authority.get("milestone") or {}).get("title")
+    project = project_rows.get(primary[0], {}) if len(primary) == 1 else {}
+    return {
+        "number": number,
+        "merged": bool(pr.get("merged_at")),
+        "merge_commit_sha": pr.get("merge_commit_sha"),
+        "primary_crs": primary,
+        "milestone": milestone,
+        "target_release": project.get("Target Release"),
+    }
+
+
 def physical_scope_snapshot(
     repository: str,
     version: str,
@@ -322,10 +381,50 @@ def physical_scope_snapshot(
 ) -> dict[str, Any]:
     previous = previous_release_tag(repository, version, token)
     compare_status, commits = compare_commits(repository, previous["tag"], source_sha, token)
+    ledger = recovery_ledger_at_source(repository, source_sha, token)
+    ledger_entries = (ledger or {}).get("entries") if isinstance(ledger, dict) else None
+    entries_by_commit: dict[str, dict[str, Any]] = {}
+    ordered_entries: list[tuple[str, dict[str, Any]]] = []
+    metadata_commits: set[str] = set()
+    ledger_evidence: dict[str, Any] | None = None
+    if ledger is not None:
+        if not isinstance(ledger_entries, list):
+            ledger_evidence = {"invalid": "ENTRIES"}
+        else:
+            for row in ledger_entries:
+                if isinstance(row, dict) and isinstance(row.get("recovered_commit_sha"), str):
+                    entries_by_commit[row["recovered_commit_sha"]] = row
+                    ordered_entries.append((row["recovered_commit_sha"], row))
+            raw_metadata = ledger.get("metadata_commit_shas") if isinstance(ledger, dict) else []
+            if isinstance(raw_metadata, list):
+                metadata_commits = {str(value) for value in raw_metadata}
+            ledger_evidence = {
+                "schema_version": ledger.get("schema_version"),
+                "version": ledger.get("version"),
+                "previous_release_tag": ledger.get("previous_release_tag"),
+                "metadata_commit_shas": sorted(metadata_commits),
+                "entries": [],
+            }
+
     pr_numbers: set[int] = set()
     unmapped: set[str] = set()
+    metadata_only: set[str] = set()
     for commit in commits:
         sha = str(commit.get("sha") or "")
+        if sha in metadata_commits:
+            paths = commit_path_hashes(repository, sha, token)
+            if paths is not None and set(paths) == {RECOVERY_LEDGER_PATH}:
+                metadata_only.add(sha)
+                continue
+        entry = entries_by_commit.get(sha)
+        if entry is not None:
+            try:
+                number = int(entry.get("source_pr", 0))
+            except (TypeError, ValueError):
+                number = 0
+            if number > 0:
+                pr_numbers.add(number)
+            continue
         linked = rest_pages(f"repos/{repository}/commits/{sha}/pulls", token)
         numbers = {int(row["number"]) for row in linked if row.get("number") is not None}
         if not numbers:
@@ -334,23 +433,32 @@ def physical_scope_snapshot(
 
     shipping: list[dict[str, Any]] = []
     for number in sorted(pr_numbers):
-        pr = rest_get(f"repos/{repository}/pulls/{number}", token)
-        primary = primary_change_requests(str((pr or {}).get("body") or ""))
-        authority: dict[str, Any] = {}
-        if len(primary) == 1:
-            authority = rest_get(f"repos/{repository}/issues/{primary[0]}", token) or {}
-        milestone = (authority.get("milestone") or {}).get("title")
-        project = project_rows.get(primary[0], {}) if len(primary) == 1 else {}
-        shipping.append(
-            {
-                "number": number,
-                "merged": bool((pr or {}).get("merged_at")),
-                "merge_commit_sha": (pr or {}).get("merge_commit_sha"),
-                "primary_crs": primary,
-                "milestone": milestone,
-                "target_release": project.get("Target Release"),
-            }
-        )
+        shipping.append(shipping_row(repository, number, token, project_rows))
+
+    if ledger_evidence is not None and "entries" in ledger_evidence:
+        for sha, entry in sorted(ordered_entries):
+            try:
+                number = int(entry.get("source_pr", 0))
+                primary = int(entry.get("primary_cr", 0))
+            except (TypeError, ValueError):
+                number = primary = 0
+            source = shipping_row(repository, number, token, project_rows) if number > 0 else {}
+            source_sha = str(entry.get("source_merge_commit_sha") or "")
+            source_paths = commit_path_hashes(repository, source_sha, token) if source_sha else None
+            recovered_paths = commit_path_hashes(repository, sha, token)
+            ledger_evidence["entries"].append(
+                {
+                    "recovered_commit_sha": sha,
+                    "source_pr": number,
+                    "primary_cr": primary,
+                    "source_pr_merged": source.get("merged"),
+                    "source_primary_crs": source.get("primary_crs"),
+                    "source_merge_commit_sha": source_sha,
+                    "observed_source_merge_commit_sha": source.get("merge_commit_sha"),
+                    "changed_path_hashes_match": source_paths is not None and source_paths == recovered_paths,
+                }
+            )
+        ledger_evidence["metadata_commit_shas"] = sorted(metadata_only)
 
     return {
         "previous_release_tag": previous["tag"],
@@ -358,8 +466,10 @@ def physical_scope_snapshot(
         "release_source_sha": source_sha,
         "compare_status": compare_status,
         "commit_count": len(commits),
+        "commit_shas": [str(commit.get("sha") or "") for commit in commits],
         "unmapped_commit_shas": sorted(unmapped),
         "shipping_prs": shipping,
+        "recovery_ledger": ledger_evidence,
     }
 
 

--- a/tests/powershell/Test-DDDAMergeStrategy.ps1
+++ b/tests/powershell/Test-DDDAMergeStrategy.ps1
@@ -1,0 +1,148 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PlatformPath "scripts/platform/DDDAMergeStrategySupport.ps1")
+
+function Assert-Equal {
+    param([AllowNull()]$Actual, [AllowNull()]$Expected, [Parameter(Mandatory = $true)][string]$Message)
+    if ([string]$Actual -ne [string]$Expected) { throw "$Message Expected '$Expected', actual '$Actual'." }
+}
+function Assert-True {
+    param([bool]$Condition, [Parameter(Mandatory = $true)][string]$Message)
+    if (-not $Condition) { throw $Message }
+}
+function Assert-Throws {
+    param([Parameter(Mandatory = $true)][scriptblock]$Action, [Parameter(Mandatory = $true)][string]$Message)
+    $thrown = $false
+    try { & $Action } catch { $thrown = $true }
+    if (-not $thrown) { throw $Message }
+}
+
+$policy = Get-Content -LiteralPath (Join-Path $PlatformPath "config/platform/development-policy.yaml") -Raw -Encoding UTF8 | ConvertFrom-Json
+$baseSha = "1111111111111111111111111111111111111111"
+$highBody = @'
+Implements #999
+<!-- ddda:change-classification:v1 -->
+```json
+{"schema_version":1,"impact":"HIGH"}
+```
+'@
+$lowBody = @'
+Implements #998
+<!-- ddda:change-classification:v1 -->
+```json
+{"schema_version":1,"impact":"LOW"}
+```
+'@
+
+Assert-Equal (Get-DDDAChangeImpactFromPrBody -Body $highBody) "HIGH" "Impact marker parsing failed."
+Assert-Equal (Get-DDDAChangeImpactFromPrBody -Body "Implements #1") "UNKNOWN" "Missing classification must be UNKNOWN."
+Assert-Throws -Action {
+    Get-DDDAChangeImpactFromPrBody -Body "<!-- ddda:change-classification:v1 -->`nnot-json" | Out-Null
+} -Message "Present malformed classification marker must fail closed."
+Assert-Throws -Action {
+    Get-DDDAChangeImpactFromPrBody -Body ($highBody + "`n" + $highBody) | Out-Null
+} -Message "Duplicate classification markers must fail closed."
+
+$highDefault = Resolve-DDDAMergeStrategy -Policy $policy -Impact "HIGH" -Pr 999 -BaseSha $baseSha -PrBody $highBody
+Assert-Equal $highDefault.merge_method "merge" "HIGH must default to merge commit."
+Assert-Throws -Action {
+    Resolve-DDDAMergeStrategy -Policy $policy -Impact "HIGH" -RequestedMethod "squash" -Pr 999 -BaseSha $baseSha -PrBody $highBody | Out-Null
+} -Message "HIGH squash must fail closed."
+Assert-Throws -Action {
+    Resolve-DDDAMergeStrategy -Policy $policy -Impact "BREAKING" -RequestedMethod "squash" -Pr 999 -BaseSha $baseSha -PrBody $highBody | Out-Null
+} -Message "BREAKING squash must fail closed."
+Assert-Throws -Action {
+    Resolve-DDDAMergeStrategy -Policy $policy -Impact "UNKNOWN" -RequestedMethod "squash" -Pr 999 -BaseSha $baseSha -PrBody "" | Out-Null
+} -Message "UNKNOWN impact squash must fail closed."
+
+$lowDefault = Resolve-DDDAMergeStrategy -Policy $policy -Impact "LOW" -Pr 998 -BaseSha $baseSha -PrBody $lowBody
+Assert-Equal $lowDefault.merge_method "merge" "LOW must default to merge commit."
+$lowSquash = Resolve-DDDAMergeStrategy -Policy $policy -Impact "LOW" -RequestedMethod "squash" -Pr 998 -BaseSha $baseSha -PrBody $lowBody
+Assert-True $lowSquash.human_squash_exception_required "LOW squash must require human exception."
+
+$transition = $policy.merge_strategy.bootstrap_transition
+$bootstrapBody = @'
+Implements #70
+<!-- ddda:change-classification:v1 -->
+```json
+{"schema_version":1,"impact":"HIGH"}
+```
+'@
+$bootstrapDefault = Resolve-DDDAMergeStrategy `
+    -Policy $policy `
+    -Impact "HIGH" `
+    -Pr 83 `
+    -BaseSha ([string]$transition.legacy_base_sha) `
+    -PrBody $bootstrapBody
+Assert-True $bootstrapDefault.bootstrap_transition "#70 exact-base candidate must be recognized even when implementation PR number differs."
+Assert-Equal $bootstrapDefault.merge_method "squash" "#70 bootstrap must default to the pre-existing legacy merge method."
+
+$bootstrapExplicit = Resolve-DDDAMergeStrategy `
+    -Policy $policy `
+    -Impact "HIGH" `
+    -RequestedMethod "squash" `
+    -Pr 83 `
+    -BaseSha ([string]$transition.legacy_base_sha) `
+    -PrBody $bootstrapBody
+Assert-True $bootstrapExplicit.bootstrap_transition "Explicit legacy method must retain bootstrap classification."
+Assert-Throws -Action {
+    Resolve-DDDAMergeStrategy -Policy $policy -Impact "HIGH" -RequestedMethod "merge" -Pr 83 -BaseSha ([string]$transition.legacy_base_sha) -PrBody $bootstrapBody | Out-Null
+} -Message "#70 bootstrap must reject the prospective new merge method before activation."
+
+$wrongBaseDefault = Resolve-DDDAMergeStrategy -Policy $policy -Impact "HIGH" -Pr 83 -BaseSha ("f" * 40) -PrBody $bootstrapBody
+Assert-True (-not $wrongBaseDefault.bootstrap_transition) "#70 bootstrap must not apply on another base SHA."
+Assert-Equal $wrongBaseDefault.merge_method "merge" "Outside exact bootstrap base HIGH follows prospective merge policy."
+Assert-Throws -Action {
+    Resolve-DDDAMergeStrategy -Policy $policy -Impact "HIGH" -RequestedMethod "squash" -Pr 83 -BaseSha ("f" * 40) -PrBody $bootstrapBody | Out-Null
+} -Message "Outside exact bootstrap base HIGH squash must fail."
+
+$wrongRelationBody = @'
+Implements #71
+<!-- ddda:change-classification:v1 -->
+```json
+{"schema_version":1,"impact":"HIGH"}
+```
+'@
+Assert-Throws -Action {
+    Resolve-DDDAMergeStrategy -Policy $policy -Impact "HIGH" -RequestedMethod "squash" -Pr 70 -BaseSha ([string]$transition.legacy_base_sha) -PrBody $wrongRelationBody | Out-Null
+} -Message "Matching PR number must not substitute for the authoritative Implements/Closes #70 relation."
+$duplicateRelationBody = @'
+Implements #70
+Closes #70
+<!-- ddda:change-classification:v1 -->
+```json
+{"schema_version":1,"impact":"HIGH"}
+```
+'@
+Assert-Throws -Action {
+    Resolve-DDDAMergeStrategy -Policy $policy -Impact "HIGH" -RequestedMethod "squash" -Pr 83 -BaseSha ([string]$transition.legacy_base_sha) -PrBody $duplicateRelationBody | Out-Null
+} -Message "Bootstrap requires exactly one authoritative #70 relation."
+
+$exceptionComment = [pscustomobject]@{
+    body = @'
+<!-- ddda:squash-exception:v1 -->
+```json
+{"schema_version":1,"kind":"squash_exception","repository":"romanhlavac/ddd-accelerator","pr":998,"validated_source_head_sha":"2222222222222222222222222222222222222222","candidate_package_sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","impact":"LOW","reason":"Explicit history-cleanliness exception for a low-risk change.","reviewer":"romanhlavac","approved_at":"2026-08-20T00:00:00Z"}
+```
+'@
+}
+$record = ConvertFrom-DDDASquashExceptionComment -Comment $exceptionComment
+Assert-DDDASquashExceptionRecord `
+    -Record $record `
+    -CommentAuthor "romanhlavac" `
+    -CommentAuthorType "User" `
+    -Repository "romanhlavac/ddd-accelerator" `
+    -Pr 998 `
+    -HeadSha "2222222222222222222222222222222222222222" `
+    -CandidatePackageSha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" `
+    -Impact "LOW"
+Assert-Throws -Action {
+    Assert-DDDASquashExceptionRecord -Record $record -CommentAuthor "automation[bot]" -CommentAuthorType "Bot" -Repository "romanhlavac/ddd-accelerator" -Pr 998 -HeadSha "2222222222222222222222222222222222222222" -CandidatePackageSha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" -Impact "LOW"
+} -Message "Bot must not authorize squash exception."
+
+Write-Host "DDDA merge strategy contract: PASS"

--- a/tests/powershell/Test-DDDAMiroEvidence.ps1
+++ b/tests/powershell/Test-DDDAMiroEvidence.ps1
@@ -50,6 +50,27 @@ foreach ($parameterName in @("KeepReviewBoard", "MiroTeamId", "EvidenceOutputPat
     Assert-True -Condition $wrapperCommand.Parameters.ContainsKey($parameterName) -Message "Miro evidence wrapper nemá parametr $parameterName."
 }
 
+$partialFailureOutput = @(
+    "DDDA Miro runtime provenance: PASS",
+    "DDDA_MIRO_BOARD_ID_HANDOFF:uXjV-PartialFailure=",
+    "DDDA Miro error: synthetic failure after board creation"
+)
+$partialHandoff = Get-DDDAMiroBoardIdentityHandoff -ChildOutput $partialFailureOutput
+Assert-Equal -Expected "uXjV-PartialFailure=" -Actual $partialHandoff.board_id -Message "Failure-path handoff nezachoval board ID."
+Assert-Equal -Expected "https://miro.com/app/board/uXjV-PartialFailure=/" -Actual $partialHandoff.board_url -Message "Failure-path handoff nevytvořil board URL."
+
+$conflictingHandoffRejected = $false
+try {
+    $null = Get-DDDAMiroBoardIdentityHandoff -ChildOutput @(
+        "DDDA_MIRO_BOARD_ID_HANDOFF:uXjV-One=",
+        "DDDA_MIRO_BOARD_ID_HANDOFF:uXjV-Two="
+    )
+}
+catch {
+    $conflictingHandoffRejected = $true
+}
+Assert-True -Condition $conflictingHandoffRejected -Message "Conflicting board identity handoff musí fail-closed."
+
 $tempRoot = Join-Path $env:TEMP ("ddda-miro-evidence-test-" + [Guid]::NewGuid().ToString("N"))
 try {
     New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null

--- a/tests/powershell/Test-DDDAPromotionGuards.ps1
+++ b/tests/powershell/Test-DDDAPromotionGuards.ps1
@@ -13,12 +13,7 @@ function Assert-True {
 
 $platformRoot = [System.IO.Path]::GetFullPath($PlatformPath).TrimEnd('\', '/')
 $entryPath = Join-Path $platformRoot "ddda.ps1"
-$governedMergePath = Join-Path $platformRoot "scripts/platform/Invoke-DDDAGovernedMergePr.ps1"
-$governedPromotionPath = Join-Path $platformRoot "scripts/platform/Invoke-DDDAGovernedPromotePr.ps1"
 $promotionPath = Join-Path $platformRoot "scripts/platform/Invoke-DDDAPromotePr.ps1"
-$releaseGovernanceSupportPath = Join-Path $platformRoot "scripts/platform/DDDAReleaseGovernanceSupport.ps1"
-$releaseScopeCollectorPath = Join-Path $platformRoot "scripts/platform/Test-DDDAReleaseScope.py"
-$hrdrSchemaPath = Join-Path $platformRoot "schemas/human-release-decision.schema.json"
 $githubSupportPath = Join-Path $platformRoot "scripts/platform/DDDAGitHubSupport.ps1"
 $platformSupportPath = Join-Path $platformRoot "scripts/platform/DDDAPlatformSupport.ps1"
 $changelogPath = Join-Path $platformRoot "CHANGELOG.md"
@@ -28,17 +23,12 @@ $gateCommandPath = Join-Path $platformRoot "scripts/Complete-DDDALifecycleStep.p
 $enginePath = Join-Path $platformRoot "runtime/steering/ddda_steering/engine.py"
 $gateSchemaPath = Join-Path $platformRoot "schemas/gate-status.schema.json"
 
-foreach ($path in @($entryPath, $governedMergePath, $governedPromotionPath, $promotionPath, $releaseGovernanceSupportPath, $releaseScopeCollectorPath, $hrdrSchemaPath, $githubSupportPath, $platformSupportPath, $changelogPath, $policyPath, $acceptancePath, $gateCommandPath, $enginePath, $gateSchemaPath)) {
-    Assert-True -Condition (Test-Path -LiteralPath $path -PathType Leaf) -Message "Chybí merge/promotion nebo gate kontrakt: $path"
+foreach ($path in @($entryPath, $promotionPath, $githubSupportPath, $platformSupportPath, $changelogPath, $policyPath, $acceptancePath, $gateCommandPath, $enginePath, $gateSchemaPath)) {
+    Assert-True -Condition (Test-Path -LiteralPath $path -PathType Leaf) -Message "Chybí promotion nebo gate kontrakt: $path"
 }
 
 $entry = Get-Content -LiteralPath $entryPath -Raw -Encoding UTF8
-$governedMerge = Get-Content -LiteralPath $governedMergePath -Raw -Encoding UTF8
-$governedPromotion = Get-Content -LiteralPath $governedPromotionPath -Raw -Encoding UTF8
 $promotion = Get-Content -LiteralPath $promotionPath -Raw -Encoding UTF8
-$releaseGovernanceSupport = Get-Content -LiteralPath $releaseGovernanceSupportPath -Raw -Encoding UTF8
-$releaseScopeCollector = Get-Content -LiteralPath $releaseScopeCollectorPath -Raw -Encoding UTF8
-$hrdrSchema = Get-Content -LiteralPath $hrdrSchemaPath -Raw -Encoding UTF8
 $githubSupport = Get-Content -LiteralPath $githubSupportPath -Raw -Encoding UTF8
 $platformSupport = Get-Content -LiteralPath $platformSupportPath -Raw -Encoding UTF8
 $changelog = Get-Content -LiteralPath $changelogPath -Raw -Encoding UTF8
@@ -51,84 +41,38 @@ $gateSchema = Get-Content -LiteralPath $gateSchemaPath -Raw -Encoding UTF8
 . $platformSupportPath
 . $githubSupportPath
 
-# Issue #9: root CLI must expose separate implementation merge and release promotion boundaries.
-Assert-True -Condition ($entry -match 'ValidateSet\("doctor",\s*"test",\s*"validate-pr",\s*"merge-pr",\s*"review-pr",\s*"promote-pr"\)') -Message "Root CLI nepublikuje oddělený merge-pr + review-pr + promote-pr contract."
-Assert-True -Condition ($entry -match 'Invoke-DDDAGovernedMergePr\.ps1') -Message "Root CLI neroutuje merge-pr přes governed implementation merge."
-Assert-True -Condition ($entry -match 'Invoke-DDDAGovernedPromotePr\.ps1') -Message "Root CLI obchází governed release promotion wrapper."
+Assert-True -Condition ($entry -match 'ValidateSet\("doctor",\s*"test",\s*"validate-pr"(?:,\s*"merge-pr")?(?:,\s*"review-pr")?,\s*"promote-pr"\)') -Message "Root CLI nepublikuje promote-pr."
 Assert-True -Condition ($entry -match '\[switch\]\$ConfirmMerge') -Message "Root CLI nemá explicitní ConfirmMerge."
-Assert-True -Condition ($entry -match '\[switch\]\$DryRun') -Message "Root CLI nemá DryRun."
+Assert-True -Condition ($entry -match '\[switch\]\$DryRun') -Message "Root CLI nemá promotion DryRun."
 Assert-True -Condition ([bool]$policy.require_explicit_confirmation) -Message "Development policy nevyžaduje explicitní confirmation."
 Assert-True -Condition ($policy.merge_method -in @("squash", "merge", "rebase")) -Message "Development policy má nepodporovaný merge method."
 Assert-True -Condition (@($policy.required_documents).Count -ge 3) -Message "Development policy nemá povinné governance dokumenty."
 
-# Governed implementation merge: exact evidence + human review + explicit confirmation; no release path.
-$mergeDryRunMatch = [regex]::Match($governedMerge, 'if\s*\(\$DryRun\)', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
-$mergeConfirmationMatch = [regex]::Match($governedMerge, 'require_explicit_confirmation[^\r\n]+\$ConfirmMerge', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
-$mergeApiMatch = [regex]::Match($governedMerge, 'Merge-DDDAGitHubPullRequest', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
-Assert-True -Condition ($mergeDryRunMatch.Success) -Message "merge-pr nemá fail-safe DryRun větev."
-Assert-True -Condition ($mergeConfirmationMatch.Success) -Message "merge-pr nemá explicitní confirmation guard."
-Assert-True -Condition ($mergeApiMatch.Success) -Message "merge-pr neobsahuje controlled GitHub API merge."
-Assert-True -Condition ($mergeDryRunMatch.Index -lt $mergeApiMatch.Index) -Message "merge-pr DryRun musí předcházet merge side effectu."
-Assert-True -Condition ($mergeConfirmationMatch.Index -lt $mergeApiMatch.Index) -Message "merge-pr confirmation musí předcházet merge side effectu."
-Assert-True -Condition ($governedMerge -match 'Get-DDDACandidateValidationEvidence') -Message "merge-pr není vázán na exact-SHA validate-pr evidence."
-Assert-True -Condition ($governedMerge -match 'PackageSha256') -Message "merge-pr neověřuje candidate package hash."
-Assert-True -Condition ($governedMerge -match 'Get-DDDAHumanPrReviewComments') -Message "merge-pr nenačítá authoritativní Human Review."
-Assert-True -Condition ($governedMerge -match 'candidate_package_sha256') -Message "merge-pr neváže Human Review na candidate package hash."
-Assert-True -Condition ($governedMerge -match 'reviewed_sha') -Message "merge-pr neváže Human Review na exact PR SHA."
-Assert-True -Condition ($governedMerge -match 'verdict[^\r\n]+pass') -Message "merge-pr nevyžaduje Human Review PASS."
-Assert-True -Condition ($governedMerge -match '-HeadSha\s+\$headSha') -Message "merge-pr nechrání GitHub merge exact head SHA."
-Assert-True -Condition ($governedMerge -match 'Release Scope Gate:\s+NOT APPLICABLE') -Message "merge-pr nedeklaruje Release Scope Gate jako N/A na implementation boundary."
-Assert-True -Condition ($governedMerge -notmatch 'Get-DDDAHrdrComments') -Message "merge-pr nesmí vyžadovat HRDR."
-Assert-True -Condition ($governedMerge -notmatch 'Test-DDDAReleaseScope') -Message "merge-pr nesmí vyhodnocovat Release Scope Gate collector."
-Assert-True -Condition ($governedMerge -notmatch 'Invoke-DDDAPromotePr\.ps1') -Message "merge-pr nesmí volat release promotion executor."
-Assert-True -Condition ($governedMerge -notmatch 'New-DDDAPlatformPackage') -Message "merge-pr nesmí vytvářet release package."
-Assert-True -Condition ($governedMerge -notmatch 'release-workspace') -Message "merge-pr nesmí vytvářet release validation workspace."
-Assert-True -Condition ($governedMerge -notmatch '@\("tag"') -Message "merge-pr nesmí vytvářet Git tag."
-Assert-True -Condition ($releaseGovernanceSupport -match 'ddda:human-pr-review:v1') -Message "Governance support nemá stabilní Human Review marker."
-Assert-True -Condition ($releaseGovernanceSupport -match 'Get-DDDAHumanPrReviewComments') -Message "Governance support neumí načíst Human Review evidence."
-Assert-True -Condition ($releaseGovernanceSupport -notmatch 'Set-DDDAHumanPrReview') -Message "Automation support nesmí publikovat Human Review PASS setter."
-
-# Public release promotion must stay strictly gated before the release executor is reachable.
-$scopeGateMatch = [regex]::Match($governedPromotion, 'release_scope_gate_status[^\r\n]+PASS', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
-$sideEffectsMatch = [regex]::Match($governedPromotion, 'side_effects_allowed', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
-$legacyExecutorMatch = [regex]::Match($governedPromotion, 'Invoke-DDDAPromotePr\.ps1', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
-Assert-True -Condition ($scopeGateMatch.Success) -Message "Governed promotion nevyžaduje Release Scope Gate PASS."
-Assert-True -Condition ($sideEffectsMatch.Success) -Message "Governed promotion neověřuje side_effects_allowed."
-Assert-True -Condition ($legacyExecutorMatch.Success) -Message "Governed promotion nevolá canonical release executor až po gate."
-Assert-True -Condition ($scopeGateMatch.Index -lt $legacyExecutorMatch.Index) -Message "Release Scope Gate musí předcházet release executor side effects."
-Assert-True -Condition ($governedPromotion -match 'Get-DDDAHrdrComments') -Message "Governed promotion nenačítá authoritativní HRDR."
-Assert-True -Condition ($governedPromotion -match 'commentAuthorType\s*-eq\s*"Bot"') -Message "Governed promotion neodmítá bot HRDR provenance."
-Assert-True -Condition ($governedPromotion -match 'DDDA_GITHUB_PROJECT_TOKEN') -Message "Release Scope Gate nevyžaduje Project V2 read-back token."
-Assert-True -Condition ($releaseGovernanceSupport -match 'ddda:human-release-decision:v1') -Message "HRDR support nemá stabilní authoritative marker."
-Assert-True -Condition ($releaseGovernanceSupport -match 'decision\s*=\s*"pending"' -or $hrdrSchema -match '"pending"') -Message "HRDR contract neobsahuje pending human state."
-Assert-True -Condition ($releaseScopeCollector -match 'dependencies/blocked_by') -Message "Release Scope collector nečte native blockers."
-Assert-True -Condition ($releaseScopeCollector -match 'Project V2') -Message "Release Scope collector neobsahuje Project V2 read-back."
-
 $dryRunMatch = [regex]::Match($promotion, 'if\s*\(\$DryRun\)', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 $confirmationMatch = [regex]::Match($promotion, 'if\s*\(\[bool\]\$policy\.require_explicit_confirmation\s*-and\s*-not\s*\$ConfirmMerge\)', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
-$promotionMergeMatch = [regex]::Match($promotion, 'Merge-DDDAGitHubPullRequest', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
+$mergeMatch = [regex]::Match($promotion, 'Merge-DDDAGitHubPullRequest', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 $releaseGateMatch = [regex]::Match($promotion, 'if\s*\(\s*-not\s+\$releasePassed(?:\s*-or\s*-not\s+\$releaseReportCreated)?\s*\)', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 $tagCreationMatch = [regex]::Match($promotion, 'Invoke-DDDAPlatformGit[^\r\n]+@\("tag"', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 $changelogGuardMatch = [regex]::Match($promotion, 'Assert-DDDAPlatformChangelogRelease', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 
 $dryRunIndex = if ($dryRunMatch.Success) { $dryRunMatch.Index } else { -1 }
 $confirmationIndex = if ($confirmationMatch.Success) { $confirmationMatch.Index } else { -1 }
-$promotionMergeIndex = if ($promotionMergeMatch.Success) { $promotionMergeMatch.Index } else { -1 }
+$mergeIndex = if ($mergeMatch.Success) { $mergeMatch.Index } else { -1 }
 $releaseGateIndex = if ($releaseGateMatch.Success) { $releaseGateMatch.Index } else { -1 }
 $tagCreationIndex = if ($tagCreationMatch.Success) { $tagCreationMatch.Index } else { -1 }
 $changelogGuardIndex = if ($changelogGuardMatch.Success) { $changelogGuardMatch.Index } else { -1 }
 
 Assert-True -Condition ($dryRunIndex -ge 0) -Message "Promotion nemá fail-safe DryRun větev."
 Assert-True -Condition ($confirmationIndex -ge 0) -Message "Promotion nemá explicitní confirmation guard."
-Assert-True -Condition ($promotionMergeIndex -ge 0) -Message "Promotion neobsahuje kontrolovaný release-candidate merge."
-Assert-True -Condition ($dryRunIndex -lt $promotionMergeIndex) -Message "Promotion DryRun guard musí předcházet merge operaci."
-Assert-True -Condition ($confirmationIndex -lt $promotionMergeIndex) -Message "Promotion confirmation guard musí předcházet merge operaci."
+Assert-True -Condition ($mergeIndex -ge 0) -Message "Promotion neobsahuje kontrolovaný GitHub API merge."
+Assert-True -Condition ($dryRunIndex -lt $mergeIndex) -Message "DryRun guard musí předcházet merge operaci."
+Assert-True -Condition ($confirmationIndex -lt $mergeIndex) -Message "Confirmation guard musí předcházet merge operaci."
 Assert-True -Condition ($promotion -match '-HeadSha\s+\$headSha') -Message "Promotion nechrání merge exact head SHA."
 Assert-True -Condition ($promotion -match 'validation-reports/pr-\$Pr-\$headSha') -Message "Promotion nehledá validation report podle PR a exact SHA."
 Assert-True -Condition ($promotion -match 'actualCandidateHash') -Message "Promotion neověřuje candidate package hash."
 Assert-True -Condition ($changelogGuardIndex -ge 0) -Message "Promotion neověřuje changelog release contract."
 Assert-True -Condition ($changelogGuardIndex -lt $dryRunIndex) -Message "Changelog release contract musí být ověřen před DryRun PASS."
-Assert-True -Condition ($changelogGuardIndex -lt $promotionMergeIndex) -Message "Changelog release contract musí být ověřen před release-candidate merge."
+Assert-True -Condition ($changelogGuardIndex -lt $mergeIndex) -Message "Changelog release contract musí být ověřen před merge."
 Assert-True -Condition ($platformSupport -match 'function\s+Assert-DDDAPlatformChangelogRelease') -Message "Platform support neobsahuje changelog release validator."
 Assert-True -Condition ($promotion -match '\$tag\s*=\s*\[string\]\$changelogRelease\.Tag') -Message "Release tag není odvozen ze stejného changelog/version kontraktu."
 Assert-True -Condition ($changelog -match '(?m)^## \[Unreleased\]\s*$') -Message "Changelog nemá kanonickou [Unreleased] sekci."
@@ -136,7 +80,8 @@ $versionHeadingPattern = '(?m)^## \[(?<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(
 $versionHeading = [regex]::Match($changelog, $versionHeadingPattern, [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 Assert-True -Condition $versionHeading.Success -Message "Changelog nemá platný versioned release cut."
 if ($versionHeading.Success) {
-    Assert-True -Condition ($versionHeading.Groups["version"].Value -match '^\d+\.\d+\.\d+$') -Message "Changelog release heading nemá SemVer."
+    $currentRelease = Assert-DDDAPlatformChangelogRelease -Path (Join-Path $platformRoot "CHANGELOG.md") -Version $versionHeading.Groups["version"].Value
+    Assert-True -Condition ([string]$currentRelease.Tag -eq ("v" + $versionHeading.Groups["version"].Value)) -Message "Changelog release validator neodvodil očekávaný tag."
 }
 Assert-True -Condition ($promotion -notmatch 'Get-Command\s+"gh"[^\r\n]+throw') -Message "Promotion nesmí tvrdě vyžadovat instalovaný GitHub CLI."
 Assert-True -Condition ($githubSupport -match 'git credential fill') -Message "GitHub support nepoužívá existující Git credential helper jako fallback."
@@ -154,7 +99,7 @@ Assert-True -Condition ($releaseGateIndex -ge 0) -Message "Promotion nemá relea
 Assert-True -Condition ($tagCreationIndex -ge 0) -Message "Promotion neobsahuje kontrolované vytvoření release tagu."
 Assert-True -Condition ($releaseGateIndex -lt $tagCreationIndex) -Message "Release validation gate musí předcházet vytvoření tagu."
 
-# Issue #13: automation must not manufacture human decisions.
+# Issue #13: promotion may trust acceptance PASS only if acceptance proves that automation did not create a human decision.
 Assert-True -Condition ($acceptance -notmatch '-Outcome\s+["'']?passed') -Message "Acceptance runner stále automaticky vytváří passed."
 Assert-True -Condition ($acceptance -match 'ready_for_review') -Message "Acceptance runner neověřuje ready_for_review."
 Assert-True -Condition ($acceptance -match 'human_decision_created\s*=\s*\$false') -Message "Acceptance report nedokládá, že nebylo vytvořeno lidské rozhodnutí."
@@ -197,24 +142,39 @@ Development notes only.
     Assert-True -Condition ($release.Tag -eq "v1.2.3") -Message "Changelog validator neodvodil tag."
 
     $mismatchRejected = $false
-    try { $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.4" } catch { $mismatchRejected = $true }
+    try {
+        $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.4"
+    }
+    catch {
+        $mismatchRejected = $true
+    }
     Assert-True -Condition $mismatchRejected -Message "Changelog validator neodmítl neshodu promotion verze."
 
     $unreleasedText = Get-Content -LiteralPath $tempChangelog -Raw -Encoding UTF8
     $unreleasedText = $unreleasedText.Replace("Development notes only.", "- unassigned release item.")
     Set-Content -LiteralPath $tempChangelog -Encoding UTF8 -Value $unreleasedText
     $unreleasedRejected = $false
-    try { $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.3" } catch { $unreleasedRejected = $true }
-    Assert-True -Condition $unreleasedRejected -Message "Promotion changelog guard neodmítl nepřiřazenou Unreleased položku."
+    try {
+        $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.3"
+    }
+    catch {
+        $unreleasedRejected = $true
+    }
+    Assert-True -Condition $unreleasedRejected -Message "Changelog validator neodmítl nepřiřazenou Unreleased položku."
 
     $invalidDateText = $unreleasedText.Replace("- unassigned release item.", "Development notes only.").Replace("2026-07-28", "2026-02-30")
     Set-Content -LiteralPath $tempChangelog -Encoding UTF8 -Value $invalidDateText
     $invalidDateRejected = $false
-    try { $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.3" } catch { $invalidDateRejected = $true }
+    try {
+        $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.3"
+    }
+    catch {
+        $invalidDateRejected = $true
+    }
     Assert-True -Condition $invalidDateRejected -Message "Changelog validator neodmítl neplatné ISO datum."
 }
 finally {
     Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
 
-Write-Host "DDDA merge/promotion guards: PASS"
+Write-Host "DDDA promotion guards: PASS"

--- a/tests/powershell/Test-DDDAPromotionGuards.ps1
+++ b/tests/powershell/Test-DDDAPromotionGuards.ps1
@@ -1,6 +1,7 @@
 ﻿[CmdletBinding()]
 param(
-    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
+    [switch]$PrePromotionCandidate
 )
 
 Set-StrictMode -Version Latest
@@ -79,7 +80,7 @@ Assert-True -Condition ($changelog -match '(?m)^## \[Unreleased\]\s*$') -Message
 $versionHeadingPattern = '(?m)^## \[(?<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))\] - (?<date>\d{4}-\d{2}-\d{2})\s*$'
 $versionHeading = [regex]::Match($changelog, $versionHeadingPattern, [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 Assert-True -Condition $versionHeading.Success -Message "Changelog nemá platný versioned release cut."
-if ($versionHeading.Success) {
+if ($versionHeading.Success -and -not $PrePromotionCandidate) {
     $currentRelease = Assert-DDDAPlatformChangelogRelease -Path (Join-Path $platformRoot "CHANGELOG.md") -Version $versionHeading.Groups["version"].Value
     Assert-True -Condition ([string]$currentRelease.Tag -eq ("v" + $versionHeading.Groups["version"].Value)) -Message "Changelog release validator neodvodil očekávaný tag."
 }

--- a/tests/powershell/Test-DDDAPromotionGuards.ps1
+++ b/tests/powershell/Test-DDDAPromotionGuards.ps1
@@ -13,7 +13,12 @@ function Assert-True {
 
 $platformRoot = [System.IO.Path]::GetFullPath($PlatformPath).TrimEnd('\', '/')
 $entryPath = Join-Path $platformRoot "ddda.ps1"
+$governedMergePath = Join-Path $platformRoot "scripts/platform/Invoke-DDDAGovernedMergePr.ps1"
+$governedPromotionPath = Join-Path $platformRoot "scripts/platform/Invoke-DDDAGovernedPromotePr.ps1"
 $promotionPath = Join-Path $platformRoot "scripts/platform/Invoke-DDDAPromotePr.ps1"
+$releaseGovernanceSupportPath = Join-Path $platformRoot "scripts/platform/DDDAReleaseGovernanceSupport.ps1"
+$releaseScopeCollectorPath = Join-Path $platformRoot "scripts/platform/Test-DDDAReleaseScope.py"
+$hrdrSchemaPath = Join-Path $platformRoot "schemas/human-release-decision.schema.json"
 $githubSupportPath = Join-Path $platformRoot "scripts/platform/DDDAGitHubSupport.ps1"
 $platformSupportPath = Join-Path $platformRoot "scripts/platform/DDDAPlatformSupport.ps1"
 $changelogPath = Join-Path $platformRoot "CHANGELOG.md"
@@ -23,12 +28,17 @@ $gateCommandPath = Join-Path $platformRoot "scripts/Complete-DDDALifecycleStep.p
 $enginePath = Join-Path $platformRoot "runtime/steering/ddda_steering/engine.py"
 $gateSchemaPath = Join-Path $platformRoot "schemas/gate-status.schema.json"
 
-foreach ($path in @($entryPath, $promotionPath, $githubSupportPath, $platformSupportPath, $changelogPath, $policyPath, $acceptancePath, $gateCommandPath, $enginePath, $gateSchemaPath)) {
-    Assert-True -Condition (Test-Path -LiteralPath $path -PathType Leaf) -Message "Chybí promotion nebo gate kontrakt: $path"
+foreach ($path in @($entryPath, $governedMergePath, $governedPromotionPath, $promotionPath, $releaseGovernanceSupportPath, $releaseScopeCollectorPath, $hrdrSchemaPath, $githubSupportPath, $platformSupportPath, $changelogPath, $policyPath, $acceptancePath, $gateCommandPath, $enginePath, $gateSchemaPath)) {
+    Assert-True -Condition (Test-Path -LiteralPath $path -PathType Leaf) -Message "Chybí merge/promotion nebo gate kontrakt: $path"
 }
 
 $entry = Get-Content -LiteralPath $entryPath -Raw -Encoding UTF8
+$governedMerge = Get-Content -LiteralPath $governedMergePath -Raw -Encoding UTF8
+$governedPromotion = Get-Content -LiteralPath $governedPromotionPath -Raw -Encoding UTF8
 $promotion = Get-Content -LiteralPath $promotionPath -Raw -Encoding UTF8
+$releaseGovernanceSupport = Get-Content -LiteralPath $releaseGovernanceSupportPath -Raw -Encoding UTF8
+$releaseScopeCollector = Get-Content -LiteralPath $releaseScopeCollectorPath -Raw -Encoding UTF8
+$hrdrSchema = Get-Content -LiteralPath $hrdrSchemaPath -Raw -Encoding UTF8
 $githubSupport = Get-Content -LiteralPath $githubSupportPath -Raw -Encoding UTF8
 $platformSupport = Get-Content -LiteralPath $platformSupportPath -Raw -Encoding UTF8
 $changelog = Get-Content -LiteralPath $changelogPath -Raw -Encoding UTF8
@@ -41,38 +51,84 @@ $gateSchema = Get-Content -LiteralPath $gateSchemaPath -Raw -Encoding UTF8
 . $platformSupportPath
 . $githubSupportPath
 
-Assert-True -Condition ($entry -match 'ValidateSet\("doctor",\s*"test",\s*"validate-pr",\s*"promote-pr"\)') -Message "Root CLI nepublikuje promote-pr."
+# Issue #9: root CLI must expose separate implementation merge and release promotion boundaries.
+Assert-True -Condition ($entry -match 'ValidateSet\("doctor",\s*"test",\s*"validate-pr",\s*"merge-pr",\s*"review-pr",\s*"promote-pr"\)') -Message "Root CLI nepublikuje oddělený merge-pr + review-pr + promote-pr contract."
+Assert-True -Condition ($entry -match 'Invoke-DDDAGovernedMergePr\.ps1') -Message "Root CLI neroutuje merge-pr přes governed implementation merge."
+Assert-True -Condition ($entry -match 'Invoke-DDDAGovernedPromotePr\.ps1') -Message "Root CLI obchází governed release promotion wrapper."
 Assert-True -Condition ($entry -match '\[switch\]\$ConfirmMerge') -Message "Root CLI nemá explicitní ConfirmMerge."
-Assert-True -Condition ($entry -match '\[switch\]\$DryRun') -Message "Root CLI nemá promotion DryRun."
+Assert-True -Condition ($entry -match '\[switch\]\$DryRun') -Message "Root CLI nemá DryRun."
 Assert-True -Condition ([bool]$policy.require_explicit_confirmation) -Message "Development policy nevyžaduje explicitní confirmation."
 Assert-True -Condition ($policy.merge_method -in @("squash", "merge", "rebase")) -Message "Development policy má nepodporovaný merge method."
 Assert-True -Condition (@($policy.required_documents).Count -ge 3) -Message "Development policy nemá povinné governance dokumenty."
 
+# Governed implementation merge: exact evidence + human review + explicit confirmation; no release path.
+$mergeDryRunMatch = [regex]::Match($governedMerge, 'if\s*\(\$DryRun\)', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
+$mergeConfirmationMatch = [regex]::Match($governedMerge, 'require_explicit_confirmation[^\r\n]+\$ConfirmMerge', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+$mergeApiMatch = [regex]::Match($governedMerge, 'Merge-DDDAGitHubPullRequest', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
+Assert-True -Condition ($mergeDryRunMatch.Success) -Message "merge-pr nemá fail-safe DryRun větev."
+Assert-True -Condition ($mergeConfirmationMatch.Success) -Message "merge-pr nemá explicitní confirmation guard."
+Assert-True -Condition ($mergeApiMatch.Success) -Message "merge-pr neobsahuje controlled GitHub API merge."
+Assert-True -Condition ($mergeDryRunMatch.Index -lt $mergeApiMatch.Index) -Message "merge-pr DryRun musí předcházet merge side effectu."
+Assert-True -Condition ($mergeConfirmationMatch.Index -lt $mergeApiMatch.Index) -Message "merge-pr confirmation musí předcházet merge side effectu."
+Assert-True -Condition ($governedMerge -match 'Get-DDDACandidateValidationEvidence') -Message "merge-pr není vázán na exact-SHA validate-pr evidence."
+Assert-True -Condition ($governedMerge -match 'PackageSha256') -Message "merge-pr neověřuje candidate package hash."
+Assert-True -Condition ($governedMerge -match 'Get-DDDAHumanPrReviewComments') -Message "merge-pr nenačítá authoritativní Human Review."
+Assert-True -Condition ($governedMerge -match 'candidate_package_sha256') -Message "merge-pr neváže Human Review na candidate package hash."
+Assert-True -Condition ($governedMerge -match 'reviewed_sha') -Message "merge-pr neváže Human Review na exact PR SHA."
+Assert-True -Condition ($governedMerge -match 'verdict[^\r\n]+pass') -Message "merge-pr nevyžaduje Human Review PASS."
+Assert-True -Condition ($governedMerge -match '-HeadSha\s+\$headSha') -Message "merge-pr nechrání GitHub merge exact head SHA."
+Assert-True -Condition ($governedMerge -match 'Release Scope Gate:\s+NOT APPLICABLE') -Message "merge-pr nedeklaruje Release Scope Gate jako N/A na implementation boundary."
+Assert-True -Condition ($governedMerge -notmatch 'Get-DDDAHrdrComments') -Message "merge-pr nesmí vyžadovat HRDR."
+Assert-True -Condition ($governedMerge -notmatch 'Test-DDDAReleaseScope') -Message "merge-pr nesmí vyhodnocovat Release Scope Gate collector."
+Assert-True -Condition ($governedMerge -notmatch 'Invoke-DDDAPromotePr\.ps1') -Message "merge-pr nesmí volat release promotion executor."
+Assert-True -Condition ($governedMerge -notmatch 'New-DDDAPlatformPackage') -Message "merge-pr nesmí vytvářet release package."
+Assert-True -Condition ($governedMerge -notmatch 'release-workspace') -Message "merge-pr nesmí vytvářet release validation workspace."
+Assert-True -Condition ($governedMerge -notmatch '@\("tag"') -Message "merge-pr nesmí vytvářet Git tag."
+Assert-True -Condition ($releaseGovernanceSupport -match 'ddda:human-pr-review:v1') -Message "Governance support nemá stabilní Human Review marker."
+Assert-True -Condition ($releaseGovernanceSupport -match 'Get-DDDAHumanPrReviewComments') -Message "Governance support neumí načíst Human Review evidence."
+Assert-True -Condition ($releaseGovernanceSupport -notmatch 'Set-DDDAHumanPrReview') -Message "Automation support nesmí publikovat Human Review PASS setter."
+
+# Public release promotion must stay strictly gated before the release executor is reachable.
+$scopeGateMatch = [regex]::Match($governedPromotion, 'release_scope_gate_status[^\r\n]+PASS', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+$sideEffectsMatch = [regex]::Match($governedPromotion, 'side_effects_allowed', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+$legacyExecutorMatch = [regex]::Match($governedPromotion, 'Invoke-DDDAPromotePr\.ps1', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
+Assert-True -Condition ($scopeGateMatch.Success) -Message "Governed promotion nevyžaduje Release Scope Gate PASS."
+Assert-True -Condition ($sideEffectsMatch.Success) -Message "Governed promotion neověřuje side_effects_allowed."
+Assert-True -Condition ($legacyExecutorMatch.Success) -Message "Governed promotion nevolá canonical release executor až po gate."
+Assert-True -Condition ($scopeGateMatch.Index -lt $legacyExecutorMatch.Index) -Message "Release Scope Gate musí předcházet release executor side effects."
+Assert-True -Condition ($governedPromotion -match 'Get-DDDAHrdrComments') -Message "Governed promotion nenačítá authoritativní HRDR."
+Assert-True -Condition ($governedPromotion -match 'commentAuthorType\s*-eq\s*"Bot"') -Message "Governed promotion neodmítá bot HRDR provenance."
+Assert-True -Condition ($governedPromotion -match 'DDDA_GITHUB_PROJECT_TOKEN') -Message "Release Scope Gate nevyžaduje Project V2 read-back token."
+Assert-True -Condition ($releaseGovernanceSupport -match 'ddda:human-release-decision:v1') -Message "HRDR support nemá stabilní authoritative marker."
+Assert-True -Condition ($releaseGovernanceSupport -match 'decision\s*=\s*"pending"' -or $hrdrSchema -match '"pending"') -Message "HRDR contract neobsahuje pending human state."
+Assert-True -Condition ($releaseScopeCollector -match 'dependencies/blocked_by') -Message "Release Scope collector nečte native blockers."
+Assert-True -Condition ($releaseScopeCollector -match 'Project V2') -Message "Release Scope collector neobsahuje Project V2 read-back."
+
 $dryRunMatch = [regex]::Match($promotion, 'if\s*\(\$DryRun\)', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 $confirmationMatch = [regex]::Match($promotion, 'if\s*\(\[bool\]\$policy\.require_explicit_confirmation\s*-and\s*-not\s*\$ConfirmMerge\)', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
-$mergeMatch = [regex]::Match($promotion, 'Merge-DDDAGitHubPullRequest', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
+$promotionMergeMatch = [regex]::Match($promotion, 'Merge-DDDAGitHubPullRequest', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 $releaseGateMatch = [regex]::Match($promotion, 'if\s*\(\s*-not\s+\$releasePassed(?:\s*-or\s*-not\s+\$releaseReportCreated)?\s*\)', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 $tagCreationMatch = [regex]::Match($promotion, 'Invoke-DDDAPlatformGit[^\r\n]+@\("tag"', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 $changelogGuardMatch = [regex]::Match($promotion, 'Assert-DDDAPlatformChangelogRelease', [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 
 $dryRunIndex = if ($dryRunMatch.Success) { $dryRunMatch.Index } else { -1 }
 $confirmationIndex = if ($confirmationMatch.Success) { $confirmationMatch.Index } else { -1 }
-$mergeIndex = if ($mergeMatch.Success) { $mergeMatch.Index } else { -1 }
+$promotionMergeIndex = if ($promotionMergeMatch.Success) { $promotionMergeMatch.Index } else { -1 }
 $releaseGateIndex = if ($releaseGateMatch.Success) { $releaseGateMatch.Index } else { -1 }
 $tagCreationIndex = if ($tagCreationMatch.Success) { $tagCreationMatch.Index } else { -1 }
 $changelogGuardIndex = if ($changelogGuardMatch.Success) { $changelogGuardMatch.Index } else { -1 }
 
 Assert-True -Condition ($dryRunIndex -ge 0) -Message "Promotion nemá fail-safe DryRun větev."
 Assert-True -Condition ($confirmationIndex -ge 0) -Message "Promotion nemá explicitní confirmation guard."
-Assert-True -Condition ($mergeIndex -ge 0) -Message "Promotion neobsahuje kontrolovaný GitHub API merge."
-Assert-True -Condition ($dryRunIndex -lt $mergeIndex) -Message "DryRun guard musí předcházet merge operaci."
-Assert-True -Condition ($confirmationIndex -lt $mergeIndex) -Message "Confirmation guard musí předcházet merge operaci."
+Assert-True -Condition ($promotionMergeIndex -ge 0) -Message "Promotion neobsahuje kontrolovaný release-candidate merge."
+Assert-True -Condition ($dryRunIndex -lt $promotionMergeIndex) -Message "Promotion DryRun guard musí předcházet merge operaci."
+Assert-True -Condition ($confirmationIndex -lt $promotionMergeIndex) -Message "Promotion confirmation guard musí předcházet merge operaci."
 Assert-True -Condition ($promotion -match '-HeadSha\s+\$headSha') -Message "Promotion nechrání merge exact head SHA."
 Assert-True -Condition ($promotion -match 'validation-reports/pr-\$Pr-\$headSha') -Message "Promotion nehledá validation report podle PR a exact SHA."
 Assert-True -Condition ($promotion -match 'actualCandidateHash') -Message "Promotion neověřuje candidate package hash."
 Assert-True -Condition ($changelogGuardIndex -ge 0) -Message "Promotion neověřuje changelog release contract."
 Assert-True -Condition ($changelogGuardIndex -lt $dryRunIndex) -Message "Changelog release contract musí být ověřen před DryRun PASS."
-Assert-True -Condition ($changelogGuardIndex -lt $mergeIndex) -Message "Changelog release contract musí být ověřen před merge."
+Assert-True -Condition ($changelogGuardIndex -lt $promotionMergeIndex) -Message "Changelog release contract musí být ověřen před release-candidate merge."
 Assert-True -Condition ($platformSupport -match 'function\s+Assert-DDDAPlatformChangelogRelease') -Message "Platform support neobsahuje changelog release validator."
 Assert-True -Condition ($promotion -match '\$tag\s*=\s*\[string\]\$changelogRelease\.Tag') -Message "Release tag není odvozen ze stejného changelog/version kontraktu."
 Assert-True -Condition ($changelog -match '(?m)^## \[Unreleased\]\s*$') -Message "Changelog nemá kanonickou [Unreleased] sekci."
@@ -80,8 +136,7 @@ $versionHeadingPattern = '(?m)^## \[(?<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(
 $versionHeading = [regex]::Match($changelog, $versionHeadingPattern, [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
 Assert-True -Condition $versionHeading.Success -Message "Changelog nemá platný versioned release cut."
 if ($versionHeading.Success) {
-    $currentRelease = Assert-DDDAPlatformChangelogRelease -Path (Join-Path $platformRoot "CHANGELOG.md") -Version $versionHeading.Groups["version"].Value
-    Assert-True -Condition ([string]$currentRelease.Tag -eq ("v" + $versionHeading.Groups["version"].Value)) -Message "Changelog release validator neodvodil očekávaný tag."
+    Assert-True -Condition ($versionHeading.Groups["version"].Value -match '^\d+\.\d+\.\d+$') -Message "Changelog release heading nemá SemVer."
 }
 Assert-True -Condition ($promotion -notmatch 'Get-Command\s+"gh"[^\r\n]+throw') -Message "Promotion nesmí tvrdě vyžadovat instalovaný GitHub CLI."
 Assert-True -Condition ($githubSupport -match 'git credential fill') -Message "GitHub support nepoužívá existující Git credential helper jako fallback."
@@ -99,7 +154,7 @@ Assert-True -Condition ($releaseGateIndex -ge 0) -Message "Promotion nemá relea
 Assert-True -Condition ($tagCreationIndex -ge 0) -Message "Promotion neobsahuje kontrolované vytvoření release tagu."
 Assert-True -Condition ($releaseGateIndex -lt $tagCreationIndex) -Message "Release validation gate musí předcházet vytvoření tagu."
 
-# Issue #13: promotion may trust acceptance PASS only if acceptance proves that automation did not create a human decision.
+# Issue #13: automation must not manufacture human decisions.
 Assert-True -Condition ($acceptance -notmatch '-Outcome\s+["'']?passed') -Message "Acceptance runner stále automaticky vytváří passed."
 Assert-True -Condition ($acceptance -match 'ready_for_review') -Message "Acceptance runner neověřuje ready_for_review."
 Assert-True -Condition ($acceptance -match 'human_decision_created\s*=\s*\$false') -Message "Acceptance report nedokládá, že nebylo vytvořeno lidské rozhodnutí."
@@ -142,39 +197,24 @@ Development notes only.
     Assert-True -Condition ($release.Tag -eq "v1.2.3") -Message "Changelog validator neodvodil tag."
 
     $mismatchRejected = $false
-    try {
-        $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.4"
-    }
-    catch {
-        $mismatchRejected = $true
-    }
+    try { $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.4" } catch { $mismatchRejected = $true }
     Assert-True -Condition $mismatchRejected -Message "Changelog validator neodmítl neshodu promotion verze."
 
     $unreleasedText = Get-Content -LiteralPath $tempChangelog -Raw -Encoding UTF8
     $unreleasedText = $unreleasedText.Replace("Development notes only.", "- unassigned release item.")
     Set-Content -LiteralPath $tempChangelog -Encoding UTF8 -Value $unreleasedText
     $unreleasedRejected = $false
-    try {
-        $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.3"
-    }
-    catch {
-        $unreleasedRejected = $true
-    }
-    Assert-True -Condition $unreleasedRejected -Message "Changelog validator neodmítl nepřiřazenou Unreleased položku."
+    try { $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.3" } catch { $unreleasedRejected = $true }
+    Assert-True -Condition $unreleasedRejected -Message "Promotion changelog guard neodmítl nepřiřazenou Unreleased položku."
 
     $invalidDateText = $unreleasedText.Replace("- unassigned release item.", "Development notes only.").Replace("2026-07-28", "2026-02-30")
     Set-Content -LiteralPath $tempChangelog -Encoding UTF8 -Value $invalidDateText
     $invalidDateRejected = $false
-    try {
-        $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.3"
-    }
-    catch {
-        $invalidDateRejected = $true
-    }
+    try { $null = Assert-DDDAPlatformChangelogRelease -Path $tempChangelog -Version "1.2.3" } catch { $invalidDateRejected = $true }
     Assert-True -Condition $invalidDateRejected -Message "Changelog validator neodmítl neplatné ISO datum."
 }
 finally {
     Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
 
-Write-Host "DDDA promotion guards: PASS"
+Write-Host "DDDA merge/promotion guards: PASS"

--- a/tests/powershell/Test-DDDAPromotionResultContract.ps1
+++ b/tests/powershell/Test-DDDAPromotionResultContract.ps1
@@ -1,0 +1,70 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PlatformPath "scripts/platform/DDDAPromotionResultSupport.ps1")
+
+function Assert-Equal {
+    param([AllowNull()]$Actual, [AllowNull()]$Expected, [Parameter(Mandatory = $true)][string]$Message)
+    if ([string]$Actual -ne [string]$Expected) {
+        throw "$Message Expected '$Expected', actual '$Actual'."
+    }
+}
+function Assert-Contains {
+    param([object[]]$Values, [Parameter(Mandatory = $true)][string]$Expected, [Parameter(Mandatory = $true)][string]$Message)
+    if ($Expected -notin @($Values | ForEach-Object { [string]$_ })) {
+        throw "$Message Missing '$Expected'."
+    }
+}
+
+Assert-Equal (Resolve-DDDAGitHubProbeStatus -Succeeded $true -HttpStatus 200) "PRESENT" "Successful probe classification failed."
+Assert-Equal (Resolve-DDDAGitHubProbeStatus -Succeeded $false -HttpStatus 404 -ExpectedAbsentStatus @(404)) "ABSENT" "Expected 404 must be successful absence."
+Assert-Equal (Resolve-DDDAGitHubProbeStatus -Succeeded $false -HttpStatus 401 -ExpectedAbsentStatus @(404)) "ERROR" "401 must remain an error."
+Assert-Equal (Resolve-DDDAGitHubProbeStatus -Succeeded $false -HttpStatus 403 -ExpectedAbsentStatus @(404)) "ERROR" "403 must remain an error."
+Assert-Equal (Resolve-DDDAGitHubProbeStatus -Succeeded $false -HttpStatus 500 -ExpectedAbsentStatus @(404)) "ERROR" "5xx must remain an error."
+Assert-Equal (Resolve-DDDAGitHubProbeStatus -Succeeded $false -HttpStatus $null -ExpectedAbsentStatus @(404)) "ERROR" "Network/unknown failure must remain an error."
+
+$expectedHead = "1111111111111111111111111111111111111111"
+$before = [pscustomobject]@{
+    pr_merged = $false
+    head_sha = $expectedHead
+    base_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    tag_status = "ABSENT"
+    github_release_status = "ABSENT"
+}
+$after = [pscustomobject]@{
+    pr_merged = $false
+    head_sha = $expectedHead
+    base_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    tag_status = "ABSENT"
+    github_release_status = "ABSENT"
+}
+$pass = Test-DDDAPromotionDryRunSideEffects -Before $before -After $after -ExpectedHeadSha $expectedHead
+Assert-Equal $pass.status "PASS" "Zero-side-effect scenario must PASS."
+Assert-Equal $pass.assertions.promotion_mutation_absent $true "Zero-side-effect scenario must expose promotion_mutation_absent=true."
+
+$mutations = @(
+    [pscustomobject]@{ Name = "pr_merged_by_dry_run"; Mutate = { param($x) $x.pr_merged = $true } },
+    [pscustomobject]@{ Name = "pr_head_changed_by_dry_run"; Mutate = { param($x) $x.head_sha = "2222222222222222222222222222222222222222" } },
+    [pscustomobject]@{ Name = "base_sha_changed_by_dry_run"; Mutate = { param($x) $x.base_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } },
+    [pscustomobject]@{ Name = "tag_created_by_dry_run"; Mutate = { param($x) $x.tag_status = "PRESENT" } },
+    [pscustomobject]@{ Name = "github_release_created_by_dry_run"; Mutate = { param($x) $x.github_release_status = "PRESENT" } }
+)
+foreach ($case in $mutations) {
+    $candidate = [pscustomobject]@{
+        pr_merged = $after.pr_merged
+        head_sha = $after.head_sha
+        base_sha = $after.base_sha
+        tag_status = $after.tag_status
+        github_release_status = $after.github_release_status
+    }
+    & $case.Mutate $candidate
+    $result = Test-DDDAPromotionDryRunSideEffects -Before $before -After $candidate -ExpectedHeadSha $expectedHead
+    Assert-Equal $result.status "FAIL" "Mutation '$($case.Name)' must FAIL."
+    Assert-Contains -Values $result.failures -Expected $case.Name -Message "Mutation '$($case.Name)' not identified."
+}
+
+Write-Host "DDDA promotion result contract: PASS"

--- a/tests/powershell/Test-DDDAReleasePublication.ps1
+++ b/tests/powershell/Test-DDDAReleasePublication.ps1
@@ -1,0 +1,50 @@
+﻿[CmdletBinding()]
+param([string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PlatformPath "scripts/platform/DDDAPlatformSupport.ps1")
+. (Join-Path $PlatformPath "scripts/platform/DDDAReleasePublicationSupport.ps1")
+
+function Assert-True {
+    param([Parameter(Mandatory = $true)][bool]$Condition, [Parameter(Mandatory = $true)][string]$Message)
+    if (-not $Condition) { throw $Message }
+}
+
+$root = Join-Path ([System.IO.Path]::GetTempPath()) ("ddda-release-publication-" + [Guid]::NewGuid().ToString("N"))
+try {
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+    $package = Join-Path $root "package.zip"
+    $reportJson = Join-Path $root "result.json"
+    $reportMarkdown = Join-Path $root "result.md"
+    [System.IO.File]::WriteAllText($package, "canonical package fixture")
+    [System.IO.File]::WriteAllText($reportJson, '{"status":"PASS"}')
+    [System.IO.File]::WriteAllText($reportMarkdown, "# PASS")
+
+    $descriptors = @(Get-DDDAReleasePublicationAssetDescriptors -Version "1.2.3" -PackagePath $package -ReportJsonPath $reportJson -ReportMarkdownPath $reportMarkdown)
+    Assert-True -Condition ($descriptors.Count -eq 3) -Message "Publication contract musí mít právě package + dva release report assets."
+    Assert-True -Condition ((@($descriptors.name) -join ',') -eq "ddda-1.2.3.zip,ddda-1.2.3-release-report.json,ddda-1.2.3-release-report.md") -Message "Asset names nejsou deterministické podle release verze."
+    Assert-True -Condition ($descriptors[0].sha256 -eq (Get-DDDAPlatformFileHash -Path $package)) -Message "Package asset SHA-256 není fyzický hash vstupního package."
+
+    $goodAsset = [pscustomobject]@{ digest = "sha256:$($descriptors[0].sha256)"; browser_download_url = "https://example.invalid/package" }
+    $badAsset = [pscustomobject]@{ digest = "sha256:$(('0' * 64))"; browser_download_url = "https://example.invalid/package" }
+    Assert-True -Condition (Test-DDDAGitHubReleaseAssetHash -Asset $goodAsset -ExpectedSha256 $descriptors[0].sha256 -Token "not-used-for-digest") -Message "GitHub digest matching nebyl akceptován."
+    Assert-True -Condition (-not (Test-DDDAGitHubReleaseAssetHash -Asset $badAsset -ExpectedSha256 $descriptors[0].sha256 -Token "not-used-for-digest")) -Message "Nesprávný GitHub digest nebyl odmítnut."
+
+    $missingRejected = $false
+    try { $null = Get-DDDAReleasePublicationAssetDescriptors -Version "1.2.3" -PackagePath $package -ReportJsonPath (Join-Path $root "missing.json") -ReportMarkdownPath $reportMarkdown } catch { $missingRejected = $true }
+    Assert-True -Condition $missingRejected -Message "Chybějící publication input musí failnout před side effectem."
+
+    $support = Get-Content -LiteralPath (Join-Path $PlatformPath "scripts/platform/DDDAReleasePublicationSupport.ps1") -Raw -Encoding UTF8
+    $promotion = Get-Content -LiteralPath (Join-Path $PlatformPath "scripts/platform/Invoke-DDDAPromotePr.ps1") -Raw -Encoding UTF8
+    $recovery = Get-Content -LiteralPath (Join-Path $PlatformPath "scripts/platform/Invoke-DDDARecoverGitHubRelease.ps1") -Raw -Encoding UTF8
+    Assert-True -Condition ($support -match 'Fresh GitHub read-back' -and $support -match 'assets\?name=' -and $support -match 'se nesmí přepsat') -Message "Publication support nemá fail-closed read-back/asset contract."
+    Assert-True -Condition ($promotion -match 'PortablePaths\s*=\s*\$true' -and $promotion -match 'Publish-DDDACanonicalGitHubRelease') -Message "Promotion nepublikuje portable validated evidence po tagu."
+    Assert-True -Condition ($recovery -match '\[switch\]\$ConfirmRecovery' -and $recovery -match 'if \(-not \$ConfirmRecovery\)') -Message "Recovery nemá explicitní authorization boundary."
+    Assert-True -Condition ($support -notmatch 'DELETE.+releases|Remove-DDDA.*Release|Delete-DDDA.*Asset') -Message "Publication contract nesmí obsahovat automatické přepsání Release/assets."
+}
+finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "DDDA release publication contract: PASS"


### PR DESCRIPTION
Implements #96

## Controlled release-source candidate — DDDA 0.1.1

This is the separately reconstructed source candidate authorized for the recovery decision recorded on CR #96.

- candidate head: `426ae4d6f9bd71f3056dc4705dbb568960035217`
- baseline: `v0.1.0` / `64e629dc6dc06c059b0e7569b8401fb726ea9161`
- inventory: ten recovered shipping commits (PRs #74, #77, #78, #79, #84, #97, #99, #101, #102, #111) plus exactly one metadata-only recovery-ledger commit.
- reconstruction: the non-standalone PR #100 replay and the three Project-contract paths from the PR #97 replay are intentionally excluded. The retained promotion guard is aligned to the independently governed merge/review/promotion command boundary; the candidate also carries #111's pre-promotion validation boundary, which does not relax final promotion. CR #98 remains represented by the standalone PR #99 recovery.

## Boundary

This Draft PR is an audit and validation surface for the controlled release source. It is **not** an implementation PR for `main` and must not be merged into `main`.

It does not change the declared release scope, Project, milestones, tags, releases or promotion state, and does not close CR #96. The candidate excludes the previously identified contaminating source changes; the ledger provides the versioned source-to-recovery mapping for read-back by the Physical Release Scope Gate.