### PR TITLE
fix(governance): permit proven future release metadata planning

### DIFF
--- a/docs/adr/0012-future-release-metadata-merge-eligibility.md
+++ b/docs/adr/0012-future-release-metadata-merge-eligibility.md
@@ -1,0 +1,50 @@
+# ADR 0012: Future-release metadata merge eligibility
+
+Status: Accepted
+
+Date: 2026-08-26
+
+## Context
+
+ADR 0011 blocks an implementation PR whose primary Change Request is outside
+the one active release Milestone. That protects the physical source of the
+active release. It also blocked PRs which only define the versioned plan and
+Project projection for later releases: those PRs have a future CR but ship no
+runtime or active-release content.
+
+## Decision
+
+The read-only merge eligibility collector may permit a future-release planning
+PR only when it proves all of the following from live GitHub data and the exact
+base/head Git trees:
+
+- its changed-path set is exactly the four versioned planning paths;
+- every changed file is a modification, not an add, rename or delete;
+- the active `DDDA X.Y.Z` milestone specification is byte-for-data unchanged
+  between base and head;
+- the active live milestone issue set equals the base specification; and
+- metadata for every active-release issue is unchanged between base and head.
+
+The exception does not create a milestone, change a Project, merge a PR,
+promote, release or tag. It only permits a separately governed implementation
+merge after the ordinary exact-SHA CI, candidate, Human Review and explicit
+merge authorization gates pass.
+
+The guard remediation that introduces this decision has one exact-base-bound
+transition: base `b61392ace66a95c808f321f3bd4b046cc5f564e5`, primary CR #16,
+an exact JSON marker and an exact five-file path set. It expires automatically
+when `main` advances and is not a general governance exception.
+
+## Consequences
+
+- a runtime, release or active-scope change remains blocked outside the active
+  train;
+- missing, ambiguous or stale GitHub/file evidence fails closed; and
+- future milestones remain versioned Git authority and are projected only by
+  the canonical reconciler after their PR is governed-merged.
+
+## Validation
+
+- unit tests cover active-train allowance, future-plan proof, incomplete proof
+  rejection and the exact-base transition;
+- standard exact-SHA CI and package-first validation remain mandatory.

--- a/docs/adr/0012-future-release-metadata-merge-eligibility.md
+++ b/docs/adr/0012-future-release-metadata-merge-eligibility.md
@@ -32,7 +32,7 @@ merge authorization gates pass.
 
 The guard remediation that introduces this decision has one exact-base-bound
 transition: base `b61392ace66a95c808f321f3bd4b046cc5f564e5`, primary CR #16,
-an exact JSON marker and an exact five-file path set. It expires automatically
+an exact JSON marker and an exact six-file path/status set. It expires automatically
 when `main` advances and is not a general governance exception.
 
 ## Consequences

--- a/docs/developer-guide/platform-development-lifecycle.md
+++ b/docs/developer-guide/platform-development-lifecycle.md
@@ -260,6 +260,16 @@ Wrong merge method musí failnout před irreversible merge. Pro canonical merge 
 - **nevytváří tag**;
 - bez explicitního `-ConfirmMerge` nemerguje.
 
+### 6.1.1 Future-release metadata while an active train is open
+
+Aktivní release train nadále blokuje běžný PR pro pozdější/TBD Change Request.
+Výjimka existuje pouze pro versioned plán budoucích releasů a collector ji
+vypočítá fail-closed z exact base/head a live milestone evidence: měnit smí
+pouze čtyři planning paths, active milestone i metadata jeho položek musí
+zůstat identické a live active scope musí odpovídat base contractu. Výjimka
+neprovádí žádný Project/milestone write ani neobchází Human Review, CI,
+candidate hash nebo explicitní merge authorization.
+
 To umožňuje bezpečně integrovat více implementačních PR před sestavením release candidate bez kruhové závislosti na release-scope completeness.
 
 ### 6.2 Prospective transition #70

--- a/runtime/platform/release_governance.py
+++ b/runtime/platform/release_governance.py
@@ -252,6 +252,21 @@ def evaluate_merge_release_eligibility(snapshot: dict[str, Any]) -> list[str]:
     authority = snapshot.get("primary_cr")
     if not isinstance(authority, dict):
         return ["MERGE_ELIGIBILITY_PRIMARY_CR_EVIDENCE_MISSING"]
+    # A future-release plan is repository governance metadata, not shipping
+    # content for the currently open train.  The collector proves this from
+    # the PR's changed paths and a base/head comparison of the active release
+    # contract.  Missing or malformed evidence never creates an exception.
+    future_plan = snapshot.get("future_release_metadata")
+    if isinstance(future_plan, dict) and future_plan.get("status") == "PASS":
+        return []
+
+    # This is a one-time prospective transition for the guard that introduces
+    # the future-plan exception itself.  It is exact-base-bound so it expires
+    # as soon as main advances; it cannot become a reusable bypass.
+    transition = snapshot.get("merge_eligibility_transition")
+    if isinstance(transition, dict) and transition.get("status") == "PASS":
+        return []
+
     failures: list[str] = []
     if authority.get("milestone") != f"DDDA {version}":
         failures.append(f"MERGE_ELIGIBILITY_OUTSIDE_ACTIVE_RELEASE:#{cr}")

--- a/runtime/platform/tests/test_merge_release_eligibility_collector.py
+++ b/runtime/platform/tests/test_merge_release_eligibility_collector.py
@@ -105,9 +105,32 @@ def test_transition_requires_exact_marker_and_file_set(monkeypatch):
     monkeypatch.setattr(
         COLLECTOR,
         "pr_files",
-        lambda *_args: [{"filename": path, "status": "modified"} for path in COLLECTOR.TRANSITION_PATHS],
+        lambda *_args: [
+            {"filename": path, "status": status}
+            for path, status in COLLECTOR.TRANSITION_FILE_STATUSES.items()
+        ],
     )
 
     result = COLLECTOR.transition_evidence(pr, "romanhlavac/ddd-accelerator", [16], "not-used")
 
     assert result["status"] == "PASS"
+
+
+def test_transition_rejects_wrong_status_for_an_exact_path(monkeypatch):
+    pr = {
+        "number": 105,
+        "body": "",
+        "base": {"sha": COLLECTOR.TRANSITION_BASE_SHA},
+    }
+    statuses = dict(COLLECTOR.TRANSITION_FILE_STATUSES)
+    statuses["docs/adr/0012-future-release-metadata-merge-eligibility.md"] = "modified"
+    monkeypatch.setattr(
+        COLLECTOR,
+        "pr_files",
+        lambda *_args: [{"filename": path, "status": status} for path, status in statuses.items()],
+    )
+
+    result = COLLECTOR.transition_evidence(pr, "romanhlavac/ddd-accelerator", [16], "not-used")
+
+    assert result["status"] == "FAIL"
+    assert "MERGE_ELIGIBILITY_TRANSITION_FILE_STATUS_INVALID" in result["failures"]

--- a/runtime/platform/tests/test_merge_release_eligibility_collector.py
+++ b/runtime/platform/tests/test_merge_release_eligibility_collector.py
@@ -1,0 +1,113 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "platform" / "Test-DDDAMergeReleaseEligibility.py"
+SPEC = importlib.util.spec_from_file_location("merge_eligibility_collector", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+COLLECTOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(COLLECTOR)
+
+
+def bootstrap(active_issues):
+    return {
+        "milestones": [
+            {
+                "title": "DDDA 0.1.1",
+                "state": "open",
+                "issues": active_issues,
+                "pulls": [],
+            }
+        ],
+        "item_groups": [
+            {
+                "kind": "issue",
+                "numbers": active_issues,
+                "metadata": {"Target Release": "0.1.1"},
+            }
+        ],
+    }
+
+
+def future_plan_pr():
+    return {
+        "number": 104,
+        "base": {"sha": "a" * 40},
+        "head": {"sha": "b" * 40},
+    }
+
+
+def test_future_release_metadata_requires_unchanged_live_active_scope(monkeypatch):
+    base = bootstrap([9, 12])
+    head = bootstrap([9, 12])
+    head["milestones"].append({"title": "DDDA 0.1.2", "state": "open", "issues": [16], "pulls": []})
+    monkeypatch.setattr(
+        COLLECTOR,
+        "pr_files",
+        lambda *_args: [{"filename": path, "status": "modified"} for path in COLLECTOR.FUTURE_RELEASE_METADATA_PATHS],
+    )
+    monkeypatch.setattr(
+        COLLECTOR,
+        "content_text",
+        lambda _repo, _path, ref, _token: json.dumps(base if ref == "a" * 40 else head),
+    )
+
+    result = COLLECTOR.future_release_metadata_evidence(
+        repository="romanhlavac/ddd-accelerator",
+        pr=future_plan_pr(),
+        active={"version": "0.1.1"},
+        active_issue_numbers={9, 12},
+        token="not-used",
+    )
+
+    assert result["status"] == "PASS"
+    assert result["active_scope_unchanged"] is True
+
+
+def test_future_release_metadata_fails_when_active_scope_would_change(monkeypatch):
+    base = bootstrap([9, 12])
+    head = bootstrap([9])
+    head["milestones"].append({"title": "DDDA 0.1.2", "state": "open", "issues": [16], "pulls": []})
+    monkeypatch.setattr(
+        COLLECTOR,
+        "pr_files",
+        lambda *_args: [{"filename": path, "status": "modified"} for path in COLLECTOR.FUTURE_RELEASE_METADATA_PATHS],
+    )
+    monkeypatch.setattr(
+        COLLECTOR,
+        "content_text",
+        lambda _repo, _path, ref, _token: json.dumps(base if ref == "a" * 40 else head),
+    )
+
+    result = COLLECTOR.future_release_metadata_evidence(
+        repository="romanhlavac/ddd-accelerator",
+        pr=future_plan_pr(),
+        active={"version": "0.1.1"},
+        active_issue_numbers={9, 12},
+        token="not-used",
+    )
+
+    assert result["status"] == "FAIL"
+    assert "MERGE_ELIGIBILITY_FUTURE_RELEASE_ACTIVE_SCOPE_CHANGED" in result["failures"]
+
+
+def test_transition_requires_exact_marker_and_file_set(monkeypatch):
+    body = """Implements #16
+
+<!-- ddda:merge-eligibility-transition:v1 -->
+```json
+{"schema_version":1,"kind":"future_release_metadata_merge_eligibility_transition","base_sha":"b61392ace66a95c808f321f3bd4b046cc5f564e5"}
+```
+"""
+    pr = {"number": 105, "body": body, "base": {"sha": COLLECTOR.TRANSITION_BASE_SHA}}
+    monkeypatch.setattr(
+        COLLECTOR,
+        "pr_files",
+        lambda *_args: [{"filename": path, "status": "modified"} for path in COLLECTOR.TRANSITION_PATHS],
+    )
+
+    result = COLLECTOR.transition_evidence(pr, "romanhlavac/ddd-accelerator", [16], "not-used")
+
+    assert result["status"] == "PASS"

--- a/runtime/platform/tests/test_release_governance.py
+++ b/runtime/platform/tests/test_release_governance.py
@@ -269,6 +269,63 @@ def test_merge_eligibility_allows_only_active_train_authority():
     ]
 
 
+def test_merge_eligibility_allows_proven_future_release_metadata_only():
+    future_plan = {
+        "active_release": {"version": "0.1.1"},
+        "primary_crs": [16],
+        "primary_cr": {"milestone": None, "target_release": None},
+        "future_release_metadata": {
+            "status": "PASS",
+            "exception": "FUTURE_RELEASE_METADATA_ONLY",
+            "active_scope_unchanged": True,
+        },
+    }
+    assert evaluate_merge_release_eligibility(future_plan) == []
+
+
+def test_merge_eligibility_keeps_future_release_pr_blocked_without_complete_metadata_proof():
+    incomplete = {
+        "active_release": {"version": "0.1.1"},
+        "primary_crs": [16],
+        "primary_cr": {"milestone": None, "target_release": None},
+        "future_release_metadata": {
+            "status": "FAIL",
+            "failures": ["MERGE_ELIGIBILITY_FUTURE_RELEASE_PATHS_INVALID"],
+        },
+    }
+    assert evaluate_merge_release_eligibility(incomplete) == [
+        "MERGE_ELIGIBILITY_OUTSIDE_ACTIVE_RELEASE:#16"
+    ]
+
+
+def test_merge_eligibility_allows_only_exact_base_guard_transition():
+    transition = {
+        "active_release": {"version": "0.1.1"},
+        "primary_crs": [16],
+        "primary_cr": {"milestone": None, "target_release": None},
+        "merge_eligibility_transition": {
+            "status": "PASS",
+            "exception": "FUTURE_RELEASE_METADATA_GUARD_TRANSITION_V1",
+        },
+    }
+    assert evaluate_merge_release_eligibility(transition) == []
+
+
+def test_merge_eligibility_rejects_incomplete_guard_transition():
+    incomplete = {
+        "active_release": {"version": "0.1.1"},
+        "primary_crs": [16],
+        "primary_cr": {"milestone": None, "target_release": None},
+        "merge_eligibility_transition": {
+            "status": "FAIL",
+            "failures": ["MERGE_ELIGIBILITY_TRANSITION_BASE_MISMATCH"],
+        },
+    }
+    assert evaluate_merge_release_eligibility(incomplete) == [
+        "MERGE_ELIGIBILITY_OUTSIDE_ACTIVE_RELEASE:#16"
+    ]
+
+
 def test_recovery_ledger_accepts_only_complete_read_back_provenance():
     live = snapshot()
     recovered = "d" * 40

--- a/scripts/platform/Test-DDDAMergeReleaseEligibility.py
+++ b/scripts/platform/Test-DDDAMergeReleaseEligibility.py
@@ -9,6 +9,7 @@ that Milestone.  The script never changes a Milestone, Project field or PR.
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 from pathlib import Path
@@ -32,6 +33,33 @@ PRIMARY_RE = re.compile(r"(?im)^\s*(?:[-*]\s*)?(?:Implements|Closes)\s+#(\d+)\s*
 TARGET_RE = re.compile(
     r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?Target\s+Release(?:\*\*)?\s*:\s*`?([^`\r\n]+)"
 )
+TRANSITION_RE = re.compile(
+    r"(?is)<!--\s*ddda:merge-eligibility-transition:v1\s*-->\s*```json\s*(\{.*?\})\s*```"
+)
+
+FUTURE_RELEASE_METADATA_PATHS = frozenset(
+    {
+        "config/governance/github-bootstrap.json",
+        "config/governance/backlog-policy.yaml",
+        "docs/roadmap/backlog-index.md",
+        "runtime/platform/tests/test_project_backlog_delivery_governance.py",
+    }
+)
+TRANSITION_PATHS = frozenset(
+    {
+        "runtime/platform/release_governance.py",
+        "runtime/platform/tests/test_release_governance.py",
+        "runtime/platform/tests/test_merge_release_eligibility_collector.py",
+        "scripts/platform/Test-DDDAMergeReleaseEligibility.py",
+        "docs/adr/0012-future-release-metadata-merge-eligibility.md",
+        "docs/developer-guide/platform-development-lifecycle.md",
+    }
+)
+
+# The value is deliberately the exact main SHA before this remediation.  The
+# transition is therefore impossible once any other main change is integrated.
+TRANSITION_BASE_SHA = "b61392ace66a95c808f321f3bd4b046cc5f564e5"
+TRANSITION_PRIMARY_CR = 16
 
 
 class GitHubReadError(RuntimeError):
@@ -93,6 +121,138 @@ def target_release(body: str) -> str | None:
     return match.group(1).strip() if match else None
 
 
+def content_text(repository: str, path: str, ref: str, token: str) -> str:
+    payload = request_json(f"repos/{repository}/contents/{path}?ref={ref}", token)
+    if not isinstance(payload, dict) or payload.get("encoding") != "base64":
+        raise GitHubReadError(f"Expected base64 file content for {path} at {ref}")
+    try:
+        return base64.b64decode(str(payload.get("content") or "")).decode("utf-8-sig")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise GitHubReadError(f"Invalid UTF-8 JSON content for {path} at {ref}") from exc
+
+
+def pr_files(repository: str, pr_number: int, token: str) -> list[dict[str, Any]]:
+    rows = pages(f"repos/{repository}/pulls/{pr_number}/files", token)
+    if not all(isinstance(row, dict) for row in rows):
+        raise GitHubReadError("PR files response contains an invalid row")
+    return rows
+
+
+def milestone_spec(config: dict[str, Any], version: str) -> dict[str, Any] | None:
+    wanted = f"DDDA {version}"
+    matches = [row for row in config.get("milestones", []) if isinstance(row, dict) and row.get("title") == wanted]
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+def issue_metadata(config: dict[str, Any], issue_numbers: set[int]) -> dict[str, Any] | None:
+    result: dict[str, Any] = {}
+    for group in config.get("item_groups", []):
+        if not isinstance(group, dict) or group.get("kind") != "issue":
+            continue
+        metadata = group.get("metadata")
+        numbers = group.get("numbers")
+        if not isinstance(metadata, dict) or not isinstance(numbers, list):
+            return None
+        for value in numbers:
+            try:
+                number = int(value)
+            except (TypeError, ValueError):
+                return None
+            if number in issue_numbers:
+                if str(number) in result:
+                    return None
+                result[str(number)] = metadata
+    return result if set(result) == {str(n) for n in issue_numbers} else None
+
+
+def future_release_metadata_evidence(
+    *,
+    repository: str,
+    pr: dict[str, Any],
+    active: dict[str, str] | None,
+    active_issue_numbers: set[int],
+    token: str,
+) -> dict[str, Any] | None:
+    """Prove that a PR changes only future planning and preserves active scope."""
+    if active is None:
+        return None
+    version = active["version"]
+    base_sha = str(((pr.get("base") or {}).get("sha")) or "")
+    head_sha = str(((pr.get("head") or {}).get("sha")) or "")
+    failures: list[str] = []
+    try:
+        rows = pr_files(repository, int(pr["number"]), token)
+        paths = {str(row.get("filename") or "") for row in rows}
+        if paths != FUTURE_RELEASE_METADATA_PATHS:
+            failures.append("MERGE_ELIGIBILITY_FUTURE_RELEASE_PATHS_INVALID")
+        if any(str(row.get("status") or "") != "modified" for row in rows):
+            failures.append("MERGE_ELIGIBILITY_FUTURE_RELEASE_FILE_STATUS_INVALID")
+
+        base = json.loads(content_text(repository, "config/governance/github-bootstrap.json", base_sha, token))
+        head = json.loads(content_text(repository, "config/governance/github-bootstrap.json", head_sha, token))
+        if not isinstance(base, dict) or not isinstance(head, dict):
+            raise ValueError("bootstrap root is not an object")
+        base_spec = milestone_spec(base, version)
+        head_spec = milestone_spec(head, version)
+        if base_spec is None or head_spec is None or base_spec != head_spec:
+            failures.append("MERGE_ELIGIBILITY_FUTURE_RELEASE_ACTIVE_SCOPE_CHANGED")
+        if base_spec is None or set(base_spec.get("issues") or []) != active_issue_numbers:
+            failures.append("MERGE_ELIGIBILITY_FUTURE_RELEASE_ACTIVE_SCOPE_EVIDENCE_INVALID")
+        base_meta = issue_metadata(base, active_issue_numbers)
+        head_meta = issue_metadata(head, active_issue_numbers)
+        if base_meta is None or head_meta is None or base_meta != head_meta:
+            failures.append("MERGE_ELIGIBILITY_FUTURE_RELEASE_ACTIVE_METADATA_CHANGED")
+        future_specs_changed = base.get("milestones") != head.get("milestones")
+        if not future_specs_changed:
+            failures.append("MERGE_ELIGIBILITY_FUTURE_RELEASE_NO_FUTURE_PLAN_CHANGE")
+    except (GitHubReadError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        failures.append("MERGE_ELIGIBILITY_FUTURE_RELEASE_EVIDENCE_INVALID")
+        paths = set()
+    return {
+        "status": "PASS" if not failures else "FAIL",
+        "exception": "FUTURE_RELEASE_METADATA_ONLY",
+        "changed_paths": sorted(paths),
+        "active_scope_unchanged": not failures,
+        "failures": sorted(set(failures)),
+    }
+
+
+def transition_evidence(pr: dict[str, Any], repository: str, primary: list[int], token: str) -> dict[str, Any] | None:
+    """Validate the one-time exact-base transition for this guard remediation."""
+    base_sha = str(((pr.get("base") or {}).get("sha")) or "")
+    failures: list[str] = []
+    if base_sha != TRANSITION_BASE_SHA:
+        failures.append("MERGE_ELIGIBILITY_TRANSITION_BASE_MISMATCH")
+    if primary != [TRANSITION_PRIMARY_CR]:
+        failures.append("MERGE_ELIGIBILITY_TRANSITION_PRIMARY_CR_MISMATCH")
+    try:
+        record_match = TRANSITION_RE.search(str(pr.get("body") or ""))
+        record = json.loads(record_match.group(1)) if record_match else None
+        if not isinstance(record, dict) or record != {
+            "schema_version": 1,
+            "kind": "future_release_metadata_merge_eligibility_transition",
+            "base_sha": TRANSITION_BASE_SHA,
+        }:
+            failures.append("MERGE_ELIGIBILITY_TRANSITION_RECORD_INVALID")
+        rows = pr_files(repository, int(pr["number"]), token)
+        paths = {str(row.get("filename") or "") for row in rows}
+        if paths != TRANSITION_PATHS:
+            failures.append("MERGE_ELIGIBILITY_TRANSITION_PATHS_INVALID")
+        if any(str(row.get("status") or "") != "modified" for row in rows):
+            failures.append("MERGE_ELIGIBILITY_TRANSITION_FILE_STATUS_INVALID")
+    except (GitHubReadError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        failures.append("MERGE_ELIGIBILITY_TRANSITION_EVIDENCE_INVALID")
+        paths = set()
+    return {
+        "status": "PASS" if not failures else "FAIL",
+        "exception": "FUTURE_RELEASE_METADATA_GUARD_TRANSITION_V1",
+        "changed_paths": sorted(paths),
+        "failures": sorted(set(failures)),
+    }
+
+
 def collect(repository: str, pr_number: int, expected_sha: str, token: str) -> dict[str, Any]:
     pr = request_json(f"repos/{repository}/pulls/{pr_number}", token)
     head = str(((pr or {}).get("head") or {}).get("sha") or "")
@@ -102,17 +262,38 @@ def collect(repository: str, pr_number: int, expected_sha: str, token: str) -> d
     issue: dict[str, Any] = {}
     if len(primary) == 1:
         issue = request_json(f"repos/{repository}/issues/{primary[0]}", token) or {}
-    return {
+    active = active_release(pages(f"repos/{repository}/milestones?state=all", token))
+    active_issue_numbers: set[int] = set()
+    if active is not None:
+        milestones = pages(f"repos/{repository}/milestones?state=all", token)
+        matches = [row for row in milestones if row.get("title") == f"DDDA {active['version']}" and row.get("state") == "open"]
+        if len(matches) != 1:
+            raise GitHubReadError("Active release milestone evidence is ambiguous")
+        active_issue_numbers = {
+            int(row["number"])
+            for row in pages(f"repos/{repository}/issues?state=all&milestone={int(matches[0]['number'])}", token)
+            if isinstance(row, dict) and "number" in row
+        }
+    snapshot = {
         "repository": repository,
         "pr": pr_number,
         "source_sha": head,
-        "active_release": active_release(pages(f"repos/{repository}/milestones?state=all", token)),
+        "active_release": active,
         "primary_crs": primary,
         "primary_cr": {
             "milestone": ((issue.get("milestone") or {}).get("title")),
             "target_release": target_release(str(issue.get("body") or "")),
         },
     }
+    snapshot["future_release_metadata"] = future_release_metadata_evidence(
+        repository=repository,
+        pr=pr,
+        active=active,
+        active_issue_numbers=active_issue_numbers,
+        token=token,
+    )
+    snapshot["merge_eligibility_transition"] = transition_evidence(pr, repository, primary, token)
+    return snapshot
 
 
 def main() -> int:

--- a/scripts/platform/Test-DDDAMergeReleaseEligibility.py
+++ b/scripts/platform/Test-DDDAMergeReleaseEligibility.py
@@ -55,6 +55,14 @@ TRANSITION_PATHS = frozenset(
         "docs/developer-guide/platform-development-lifecycle.md",
     }
 )
+TRANSITION_FILE_STATUSES = {
+    "docs/adr/0012-future-release-metadata-merge-eligibility.md": "added",
+    "runtime/platform/tests/test_merge_release_eligibility_collector.py": "added",
+    "docs/developer-guide/platform-development-lifecycle.md": "modified",
+    "runtime/platform/release_governance.py": "modified",
+    "runtime/platform/tests/test_release_governance.py": "modified",
+    "scripts/platform/Test-DDDAMergeReleaseEligibility.py": "modified",
+}
 
 # The value is deliberately the exact main SHA before this remediation.  The
 # transition is therefore impossible once any other main change is integrated.
@@ -240,7 +248,8 @@ def transition_evidence(pr: dict[str, Any], repository: str, primary: list[int],
         paths = {str(row.get("filename") or "") for row in rows}
         if paths != TRANSITION_PATHS:
             failures.append("MERGE_ELIGIBILITY_TRANSITION_PATHS_INVALID")
-        if any(str(row.get("status") or "") != "modified" for row in rows):
+        observed_statuses = {str(row.get("filename") or ""): str(row.get("status") or "") for row in rows}
+        if observed_statuses != TRANSITION_FILE_STATUSES:
             failures.append("MERGE_ELIGIBILITY_TRANSITION_FILE_STATUS_INVALID")
     except (GitHubReadError, KeyError, TypeError, ValueError, json.JSONDecodeError):
         failures.append("MERGE_ELIGIBILITY_TRANSITION_EVIDENCE_INVALID")


### PR DESCRIPTION
Implements #16

Scope: fail-closed merge-eligibility remediation for a future-release metadata-only governance PR while DDDA 0.1.1 remains active.

It permits only an exact planning-path set after base/head and live-milestone proof that the active release scope and its metadata are unchanged. Ordinary future/TBD implementation PRs remain blocked.

Out of scope: merge, release, promotion, tag, direct Project or milestone mutation, release scope change, and closing CR #16.

Classification: SECURITY-GOVERNANCE, TESTING, DOC; impact HIGH; migration non-breaking.

<!-- ddda:merge-eligibility-transition:v1 -->
```json
{"schema_version":1,"kind":"future_release_metadata_merge_eligibility_transition","base_sha":"b61392ace66a95c808f321f3bd4b046cc5f564e5"}
```
