### PR TITLE
fix(governance): normalize verified main integration merges

### DIFF
--- a/docs/adr/0012-future-release-metadata-merge-eligibility.md
+++ b/docs/adr/0012-future-release-metadata-merge-eligibility.md
@@ -25,6 +25,12 @@ base/head Git trees:
 - the active live milestone issue set equals the base specification; and
 - metadata for every active-release issue is unchanged between base and head.
 
+If a metadata PR is technically updated by a conventional `merge main` commit,
+the collector may normalize its file evidence to the first-parent branch diff.
+It does so only when the head has exactly two parents and its second parent is
+the current `main` SHA. A stale, reordered, squashed or otherwise ambiguous
+merge remains a failure; this mechanism never permits an active-release change.
+
 The exception does not create a milestone, change a Project, merge a PR,
 promote, release or tag. It only permits a separately governed implementation
 merge after the ordinary exact-SHA CI, candidate, Human Review and explicit

--- a/runtime/platform/tests/test_merge_release_eligibility_collector.py
+++ b/runtime/platform/tests/test_merge_release_eligibility_collector.py
@@ -93,6 +93,69 @@ def test_future_release_metadata_fails_when_active_scope_would_change(monkeypatc
     assert "MERGE_ELIGIBILITY_FUTURE_RELEASE_ACTIVE_SCOPE_CHANGED" in result["failures"]
 
 
+def test_future_release_metadata_normalizes_only_a_current_main_merge(monkeypatch):
+    base = bootstrap([9, 12])
+    head = bootstrap([9, 12])
+    head["milestones"].append({"title": "DDDA 0.1.2", "state": "open", "issues": [16], "pulls": []})
+    pr = future_plan_pr()
+    pr["head"]["sha"] = "m" * 40
+    monkeypatch.setattr(
+        COLLECTOR,
+        "pr_files",
+        lambda *_args: [{"filename": "runtime/platform/release_governance.py", "status": "modified"}],
+    )
+    monkeypatch.setattr(
+        COLLECTOR,
+        "content_text",
+        lambda _repo, _path, ref, _token: json.dumps(base if ref == "a" * 40 else head),
+    )
+    first_parent = "b" * 40
+    monkeypatch.setattr(
+        COLLECTOR,
+        "request_json",
+        lambda path, _token: (
+            {"parents": [{"sha": first_parent}, {"sha": "c" * 40}]}
+            if path.endswith("/commits/" + "m" * 40)
+            else {"sha": "c" * 40}
+            if path.endswith("/commits/main")
+            else {"files": [{"filename": item, "status": "modified"} for item in COLLECTOR.FUTURE_RELEASE_METADATA_PATHS]}
+        ),
+    )
+
+    result = COLLECTOR.future_release_metadata_evidence(
+        repository="romanhlavac/ddd-accelerator", pr=pr, active={"version": "0.1.1"}, active_issue_numbers={9, 12}, token="not-used"
+    )
+
+    assert result["status"] == "PASS"
+    assert result["integration_merge_normalized"] is True
+
+
+def test_future_release_metadata_rejects_merge_with_stale_main_parent(monkeypatch):
+    pr = future_plan_pr()
+    pr["head"]["sha"] = "m" * 40
+    monkeypatch.setattr(
+        COLLECTOR,
+        "pr_files",
+        lambda *_args: [{"filename": "runtime/platform/release_governance.py", "status": "modified"}],
+    )
+    monkeypatch.setattr(
+        COLLECTOR,
+        "request_json",
+        lambda path, _token: (
+            {"parents": [{"sha": "b" * 40}, {"sha": "d" * 40}]}
+            if path.endswith("/commits/" + "m" * 40)
+            else {"sha": "c" * 40}
+        ),
+    )
+
+    result = COLLECTOR.future_release_metadata_evidence(
+        repository="romanhlavac/ddd-accelerator", pr=pr, active={"version": "0.1.1"}, active_issue_numbers={9, 12}, token="not-used"
+    )
+
+    assert result["status"] == "FAIL"
+    assert "MERGE_ELIGIBILITY_FUTURE_RELEASE_PATHS_INVALID" in result["failures"]
+
+
 def test_transition_requires_exact_marker_and_file_set(monkeypatch):
     body = """Implements #16
 

--- a/scripts/platform/Test-DDDAMergeReleaseEligibility.py
+++ b/scripts/platform/Test-DDDAMergeReleaseEligibility.py
@@ -146,6 +146,37 @@ def pr_files(repository: str, pr_number: int, token: str) -> list[dict[str, Any]
     return rows
 
 
+def integration_merge_files(
+    repository: str, pr: dict[str, Any], token: str
+) -> tuple[str, list[dict[str, Any]]] | None:
+    """Return the branch-only diff for one freshly merged main update.
+
+    GitHub's PR-files endpoint reports both parents after ``git merge main``.
+    That is correct for a complete PR diff, but would make a metadata-only PR
+    appear to own files newly introduced by main.  Accept this narrow
+    normalization only when the head is the conventional two-parent merge and
+    its second parent is *the current* main head.  Any stale or malformed
+    ancestry remains ordinary fail-closed evidence.
+    """
+    head_sha = str(((pr.get("head") or {}).get("sha")) or "")
+    base_sha = str(((pr.get("base") or {}).get("sha")) or "")
+    commit = request_json(f"repos/{repository}/commits/{head_sha}", token)
+    main = request_json(f"repos/{repository}/commits/main", token)
+    parents = commit.get("parents") if isinstance(commit, dict) else None
+    main_sha = str(main.get("sha") or "") if isinstance(main, dict) else ""
+    if not isinstance(parents, list) or len(parents) != 2 or not base_sha:
+        return None
+    first_parent = str((parents[0] or {}).get("sha") or "")
+    second_parent = str((parents[1] or {}).get("sha") or "")
+    if not first_parent or second_parent != main_sha:
+        return None
+    comparison = request_json(f"repos/{repository}/compare/{base_sha}...{first_parent}", token)
+    rows = comparison.get("files") if isinstance(comparison, dict) else None
+    if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+        return None
+    return first_parent, rows
+
+
 def milestone_spec(config: dict[str, Any], version: str) -> dict[str, Any] | None:
     wanted = f"DDDA {version}"
     matches = [row for row in config.get("milestones", []) if isinstance(row, dict) and row.get("title") == wanted]
@@ -193,6 +224,13 @@ def future_release_metadata_evidence(
     try:
         rows = pr_files(repository, int(pr["number"]), token)
         paths = {str(row.get("filename") or "") for row in rows}
+        integration_merge = False
+        if paths != FUTURE_RELEASE_METADATA_PATHS:
+            normalized = integration_merge_files(repository, pr, token)
+            if normalized is not None:
+                head_sha, rows = normalized
+                paths = {str(row.get("filename") or "") for row in rows}
+                integration_merge = True
         if paths != FUTURE_RELEASE_METADATA_PATHS:
             failures.append("MERGE_ELIGIBILITY_FUTURE_RELEASE_PATHS_INVALID")
         if any(str(row.get("status") or "") != "modified" for row in rows):
@@ -222,6 +260,7 @@ def future_release_metadata_evidence(
         "status": "PASS" if not failures else "FAIL",
         "exception": "FUTURE_RELEASE_METADATA_ONLY",
         "changed_paths": sorted(paths),
+        "integration_merge_normalized": integration_merge if "integration_merge" in locals() else False,
         "active_scope_unchanged": not failures,
         "failures": sorted(set(failures)),
     }


### PR DESCRIPTION
Implements #16

## Purpose
Fixes the merge-eligibility collector for a proven, conventional `merge main` update of a future-release metadata PR.

## Fail-closed evidence
- exactly two head parents;
- second parent equals the current `main` SHA;
- only the first-parent branch diff is evaluated;
- stale, reordered or ambiguous ancestry remains blocked;
- active DDDA 0.1.1 scope and metadata checks remain unchanged.

## Scope
Only collector logic, regression tests and ADR 0012. No Project or milestone write; no release, promotion or tag.