### PR TITLE
fix(governance): permit verified eligibility guard repair

### DIFF
--- a/docs/adr/0012-future-release-metadata-merge-eligibility.md
+++ b/docs/adr/0012-future-release-metadata-merge-eligibility.md
@@ -35,6 +35,23 @@ transition: base `b61392ace66a95c808f321f3bd4b046cc5f564e5`, primary CR #16,
 an exact JSON marker and an exact six-file path/status set. It expires automatically
 when `main` advances and is not a general governance exception.
 
+The first implementation of the integration-merge normalization exposed a
+second bootstrap condition: a correction to that guard is neither a future
+release plan nor active-release content. A second exact-base-bound transition
+may therefore introduce a **governance-repair-only** allowance. Its base is
+`fdcc2b323eff4bcc9cef71207e280f3ffa950dd8`, its primary CR is #16, and its
+PR must carry one exact transition record and change exactly the collector,
+its collector tests, the eligibility evaluator and this ADR. The transition
+expires when `main` advances.
+
+After that transition, a guard repair is allowed only if it changes exactly
+the collector, its collector tests and this ADR; all are modifications; its
+sole primary CR is #16; and the complete versioned governance bootstrap is
+identical between base and branch-only head. A conventional current-`main`
+integration merge may be normalized only under the existing two-parent proof.
+Thus neither the active 0.1.1 scope nor any release-plan metadata can enter
+through this allowance.
+
 ## Consequences
 
 - a runtime, release or active-scope change remains blocked outside the active

--- a/runtime/platform/release_governance.py
+++ b/runtime/platform/release_governance.py
@@ -267,6 +267,16 @@ def evaluate_merge_release_eligibility(snapshot: dict[str, Any]) -> list[str]:
     if isinstance(transition, dict) and transition.get("status") == "PASS":
         return []
 
+    # Guard-only repairs are bounded to three implementation-evidence paths
+    # and prove the complete versioned governance contract is unchanged.  The
+    # bootstrap that introduces this allowance is itself exact-base-bound.
+    governance_repair = snapshot.get("governance_repair")
+    if isinstance(governance_repair, dict) and governance_repair.get("status") == "PASS":
+        return []
+    governance_repair_transition = snapshot.get("governance_repair_transition")
+    if isinstance(governance_repair_transition, dict) and governance_repair_transition.get("status") == "PASS":
+        return []
+
     failures: list[str] = []
     if authority.get("milestone") != f"DDDA {version}":
         failures.append(f"MERGE_ELIGIBILITY_OUTSIDE_ACTIVE_RELEASE:#{cr}")

--- a/runtime/platform/tests/test_merge_release_eligibility_collector.py
+++ b/runtime/platform/tests/test_merge_release_eligibility_collector.py
@@ -187,6 +187,31 @@ def test_governance_repair_rejects_a_governance_change(monkeypatch):
     assert "MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_GOVERNANCE_CHANGED" in result["failures"]
 
 
+
+def test_integration_merge_files_uses_only_verified_branch_diff(monkeypatch):
+    base_sha = "a" * 40
+    branch_sha = "b" * 40
+    current_main = "c" * 40
+    first_parent = "d" * 40
+    rows = [{"filename": path, "status": "modified"} for path in COLLECTOR.GOVERNANCE_REPAIR_PATHS]
+    responses = {
+        f"repos/romanhlavac/ddd-accelerator/commits/{branch_sha}": {
+            "parents": [{"sha": first_parent}, {"sha": current_main}]
+        },
+        "repos/romanhlavac/ddd-accelerator/commits/main": {"sha": current_main},
+        f"repos/romanhlavac/ddd-accelerator/compare/{base_sha}...{first_parent}": {"files": rows},
+    }
+    monkeypatch.setattr(COLLECTOR, "request_json", lambda path, _token: responses[path])
+
+    result = COLLECTOR.integration_merge_files(
+        "romanhlavac/ddd-accelerator",
+        {"base": {"sha": base_sha}, "head": {"sha": branch_sha}},
+        "not-used",
+    )
+
+    assert result == (first_parent, rows)
+
+
 def test_governance_repair_transition_requires_exact_base_marker_and_paths(monkeypatch):
     body = """Implements #16
 

--- a/runtime/platform/tests/test_merge_release_eligibility_collector.py
+++ b/runtime/platform/tests/test_merge_release_eligibility_collector.py
@@ -134,3 +134,79 @@ def test_transition_rejects_wrong_status_for_an_exact_path(monkeypatch):
 
     assert result["status"] == "FAIL"
     assert "MERGE_ELIGIBILITY_TRANSITION_FILE_STATUS_INVALID" in result["failures"]
+
+
+def test_governance_repair_requires_unchanged_governance_and_exact_paths(monkeypatch):
+    base = bootstrap([9, 12])
+    pr = future_plan_pr()
+    monkeypatch.setattr(
+        COLLECTOR,
+        "pr_files",
+        lambda *_args: [{"filename": path, "status": "modified"} for path in COLLECTOR.GOVERNANCE_REPAIR_PATHS],
+    )
+    monkeypatch.setattr(COLLECTOR, "content_text", lambda *_args: json.dumps(base))
+
+    result = COLLECTOR.governance_repair_evidence(
+        repository="romanhlavac/ddd-accelerator",
+        pr=pr,
+        active={"version": "0.1.1"},
+        active_issue_numbers={9, 12},
+        primary=[16],
+        token="not-used",
+    )
+
+    assert result["status"] == "PASS"
+    assert result["active_scope_unchanged"] is True
+
+
+def test_governance_repair_rejects_a_governance_change(monkeypatch):
+    base = bootstrap([9, 12])
+    changed = bootstrap([9])
+    pr = future_plan_pr()
+    monkeypatch.setattr(
+        COLLECTOR,
+        "pr_files",
+        lambda *_args: [{"filename": path, "status": "modified"} for path in COLLECTOR.GOVERNANCE_REPAIR_PATHS],
+    )
+    monkeypatch.setattr(
+        COLLECTOR,
+        "content_text",
+        lambda _repo, _path, ref, _token: json.dumps(base if ref == "a" * 40 else changed),
+    )
+
+    result = COLLECTOR.governance_repair_evidence(
+        repository="romanhlavac/ddd-accelerator",
+        pr=pr,
+        active={"version": "0.1.1"},
+        active_issue_numbers={9, 12},
+        primary=[16],
+        token="not-used",
+    )
+
+    assert result["status"] == "FAIL"
+    assert "MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_GOVERNANCE_CHANGED" in result["failures"]
+
+
+def test_governance_repair_transition_requires_exact_base_marker_and_paths(monkeypatch):
+    body = """Implements #16
+
+<!-- ddda:merge-eligibility-governance-repair:v1 -->
+```json
+{"schema_version":1,"kind":"merge_eligibility_governance_repair_transition","base_sha":"fdcc2b323eff4bcc9cef71207e280f3ffa950dd8"}
+```
+"""
+    pr = {"number": 107, "body": body, "base": {"sha": COLLECTOR.GOVERNANCE_REPAIR_TRANSITION_BASE_SHA}}
+    monkeypatch.setattr(
+        COLLECTOR,
+        "pr_files",
+        lambda *_args: [
+            {"filename": path, "status": status}
+            for path, status in COLLECTOR.GOVERNANCE_REPAIR_TRANSITION_FILE_STATUSES.items()
+        ],
+    )
+
+    result = COLLECTOR.governance_repair_transition_evidence(
+        pr, "romanhlavac/ddd-accelerator", [16], "not-used"
+    )
+
+    assert result["status"] == "PASS"

--- a/scripts/platform/Test-DDDAMergeReleaseEligibility.py
+++ b/scripts/platform/Test-DDDAMergeReleaseEligibility.py
@@ -168,6 +168,35 @@ def pr_files(repository: str, pr_number: int, token: str) -> list[dict[str, Any]
     return rows
 
 
+
+def integration_merge_files(
+    repository: str, pr: dict[str, Any], token: str
+) -> tuple[str, list[dict[str, Any]]] | None:
+    """Return the branch-only diff for one freshly merged main update.
+
+    GitHub's PR-files endpoint reports both parents after merging main.
+    Accept this normalization only for a conventional two-parent merge whose
+    second parent is the current main head; all other ancestry fails closed.
+    """
+    head_sha = str(((pr.get("head") or {}).get("sha")) or "")
+    base_sha = str(((pr.get("base") or {}).get("sha")) or "")
+    commit = request_json(f"repos/{repository}/commits/{head_sha}", token)
+    main = request_json(f"repos/{repository}/commits/main", token)
+    parents = commit.get("parents") if isinstance(commit, dict) else None
+    main_sha = str(main.get("sha") or "") if isinstance(main, dict) else ""
+    if not isinstance(parents, list) or len(parents) != 2 or not base_sha:
+        return None
+    first_parent = str((parents[0] or {}).get("sha") or "")
+    second_parent = str((parents[1] or {}).get("sha") or "")
+    if not first_parent or second_parent != main_sha:
+        return None
+    comparison = request_json(f"repos/{repository}/compare/{base_sha}...{first_parent}", token)
+    rows = comparison.get("files") if isinstance(comparison, dict) else None
+    if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+        return None
+    return first_parent, rows
+
+
 def milestone_spec(config: dict[str, Any], version: str) -> dict[str, Any] | None:
     wanted = f"DDDA {version}"
     matches = [row for row in config.get("milestones", []) if isinstance(row, dict) and row.get("title") == wanted]

--- a/scripts/platform/Test-DDDAMergeReleaseEligibility.py
+++ b/scripts/platform/Test-DDDAMergeReleaseEligibility.py
@@ -36,6 +36,9 @@ TARGET_RE = re.compile(
 TRANSITION_RE = re.compile(
     r"(?is)<!--\s*ddda:merge-eligibility-transition:v1\s*-->\s*```json\s*(\{.*?\})\s*```"
 )
+GOVERNANCE_REPAIR_RE = re.compile(
+    r"(?is)<!--\s*ddda:merge-eligibility-governance-repair:v1\s*-->\s*```json\s*(\{.*?\})\s*```"
+)
 
 FUTURE_RELEASE_METADATA_PATHS = frozenset(
     {
@@ -68,6 +71,25 @@ TRANSITION_FILE_STATUSES = {
 # transition is therefore impossible once any other main change is integrated.
 TRANSITION_BASE_SHA = "b61392ace66a95c808f321f3bd4b046cc5f564e5"
 TRANSITION_PRIMARY_CR = 16
+
+# This is a second, one-time bootstrap transition.  It permits the narrowly
+# scoped repair that makes a previously integrated guard able to assess its
+# own follow-up repair.  It is intentionally exact-base-bound and expires as
+# soon as main advances.
+GOVERNANCE_REPAIR_TRANSITION_BASE_SHA = "fdcc2b323eff4bcc9cef71207e280f3ffa950dd8"
+GOVERNANCE_REPAIR_PATHS = frozenset(
+    {
+        "docs/adr/0012-future-release-metadata-merge-eligibility.md",
+        "runtime/platform/tests/test_merge_release_eligibility_collector.py",
+        "scripts/platform/Test-DDDAMergeReleaseEligibility.py",
+    }
+)
+GOVERNANCE_REPAIR_TRANSITION_PATHS = GOVERNANCE_REPAIR_PATHS | {
+    "runtime/platform/release_governance.py",
+}
+GOVERNANCE_REPAIR_TRANSITION_FILE_STATUSES = {
+    path: "modified" for path in GOVERNANCE_REPAIR_TRANSITION_PATHS
+}
 
 
 class GitHubReadError(RuntimeError):
@@ -227,6 +249,58 @@ def future_release_metadata_evidence(
     }
 
 
+def governance_repair_evidence(
+    *,
+    repository: str,
+    pr: dict[str, Any],
+    active: dict[str, str] | None,
+    active_issue_numbers: set[int],
+    primary: list[int],
+    token: str,
+) -> dict[str, Any] | None:
+    """Prove a guard-only repair cannot change the active release contract."""
+    if active is None:
+        return None
+    base_sha = str(((pr.get("base") or {}).get("sha")) or "")
+    head_sha = str(((pr.get("head") or {}).get("sha")) or "")
+    failures: list[str] = []
+    try:
+        rows = pr_files(repository, int(pr["number"]), token)
+        paths = {str(row.get("filename") or "") for row in rows}
+        integration_merge = False
+        if paths != GOVERNANCE_REPAIR_PATHS:
+            normalized = integration_merge_files(repository, pr, token)
+            if normalized is not None:
+                head_sha, rows = normalized
+                paths = {str(row.get("filename") or "") for row in rows}
+                integration_merge = True
+        if primary != [TRANSITION_PRIMARY_CR]:
+            failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_PRIMARY_CR_INVALID")
+        if paths != GOVERNANCE_REPAIR_PATHS:
+            failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_PATHS_INVALID")
+        if any(str(row.get("status") or "") != "modified" for row in rows):
+            failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_FILE_STATUS_INVALID")
+
+        base = json.loads(content_text(repository, "config/governance/github-bootstrap.json", base_sha, token))
+        head = json.loads(content_text(repository, "config/governance/github-bootstrap.json", head_sha, token))
+        if not isinstance(base, dict) or not isinstance(head, dict) or base != head:
+            failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_GOVERNANCE_CHANGED")
+        spec = milestone_spec(base, active["version"]) if isinstance(base, dict) else None
+        if spec is None or set(spec.get("issues") or []) != active_issue_numbers:
+            failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_ACTIVE_SCOPE_EVIDENCE_INVALID")
+    except (GitHubReadError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_EVIDENCE_INVALID")
+        paths = set()
+    return {
+        "status": "PASS" if not failures else "FAIL",
+        "exception": "MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_ONLY",
+        "changed_paths": sorted(paths),
+        "integration_merge_normalized": integration_merge if "integration_merge" in locals() else False,
+        "active_scope_unchanged": not failures,
+        "failures": sorted(set(failures)),
+    }
+
+
 def transition_evidence(pr: dict[str, Any], repository: str, primary: list[int], token: str) -> dict[str, Any] | None:
     """Validate the one-time exact-base transition for this guard remediation."""
     base_sha = str(((pr.get("base") or {}).get("sha")) or "")
@@ -257,6 +331,43 @@ def transition_evidence(pr: dict[str, Any], repository: str, primary: list[int],
     return {
         "status": "PASS" if not failures else "FAIL",
         "exception": "FUTURE_RELEASE_METADATA_GUARD_TRANSITION_V1",
+        "changed_paths": sorted(paths),
+        "failures": sorted(set(failures)),
+    }
+
+
+def governance_repair_transition_evidence(
+    pr: dict[str, Any], repository: str, primary: list[int], token: str
+) -> dict[str, Any] | None:
+    """Validate the exact-base bootstrap for the guard-repair allowance."""
+    base_sha = str(((pr.get("base") or {}).get("sha")) or "")
+    failures: list[str] = []
+    if base_sha != GOVERNANCE_REPAIR_TRANSITION_BASE_SHA:
+        failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_TRANSITION_BASE_MISMATCH")
+    if primary != [TRANSITION_PRIMARY_CR]:
+        failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_TRANSITION_PRIMARY_CR_MISMATCH")
+    try:
+        record_match = GOVERNANCE_REPAIR_RE.search(str(pr.get("body") or ""))
+        record = json.loads(record_match.group(1)) if record_match else None
+        if not isinstance(record, dict) or record != {
+            "schema_version": 1,
+            "kind": "merge_eligibility_governance_repair_transition",
+            "base_sha": GOVERNANCE_REPAIR_TRANSITION_BASE_SHA,
+        }:
+            failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_TRANSITION_RECORD_INVALID")
+        rows = pr_files(repository, int(pr["number"]), token)
+        paths = {str(row.get("filename") or "") for row in rows}
+        if paths != GOVERNANCE_REPAIR_TRANSITION_PATHS:
+            failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_TRANSITION_PATHS_INVALID")
+        statuses = {str(row.get("filename") or ""): str(row.get("status") or "") for row in rows}
+        if statuses != GOVERNANCE_REPAIR_TRANSITION_FILE_STATUSES:
+            failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_TRANSITION_FILE_STATUS_INVALID")
+    except (GitHubReadError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_TRANSITION_EVIDENCE_INVALID")
+        paths = set()
+    return {
+        "status": "PASS" if not failures else "FAIL",
+        "exception": "MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_TRANSITION_V1",
         "changed_paths": sorted(paths),
         "failures": sorted(set(failures)),
     }
@@ -301,7 +412,18 @@ def collect(repository: str, pr_number: int, expected_sha: str, token: str) -> d
         active_issue_numbers=active_issue_numbers,
         token=token,
     )
+    snapshot["governance_repair"] = governance_repair_evidence(
+        repository=repository,
+        pr=pr,
+        active=active,
+        active_issue_numbers=active_issue_numbers,
+        primary=primary,
+        token=token,
+    )
     snapshot["merge_eligibility_transition"] = transition_evidence(pr, repository, primary, token)
+    snapshot["governance_repair_transition"] = governance_repair_transition_evidence(
+        pr, repository, primary, token
+    )
     return snapshot
 
 


### PR DESCRIPTION
Implements #16

## Purpose
Provides the one exact-base bootstrap needed to integrate a verified repair of the merge-eligibility guard without widening the active DDDA 0.1.1 scope.

<!-- ddda:merge-eligibility-governance-repair:v1 -->
```json
{"schema_version":1,"kind":"merge_eligibility_governance_repair_transition","base_sha":"fdcc2b323eff4bcc9cef71207e280f3ffa950dd8"}
```

## Fail-closed boundary
- this PR is bound to exact base `fdcc2b323eff4bcc9cef71207e280f3ffa950dd8`;
- it changes only the eligibility collector, evaluator, regression tests and ADR;
- after the one-time transition, a guard repair must change only collector, collector tests and ADR;
- the complete versioned governance bootstrap must be unchanged;
- conventional integration merges require the existing two-parent/current-main proof.

No Project or milestone write; no release, promotion or tag.