### PR TITLE
fix(release): validate exact controlled candidates

### DIFF
--- a/.github/workflows/controlled-release-candidate-validation.yml
+++ b/.github/workflows/controlled-release-candidate-validation.yml
@@ -133,35 +133,14 @@ jobs:
           .\ddda.ps1 test -Suite regression -NonInteractive
           .\ddda.ps1 test -Suite security -NonInteractive
 
-      - name: Build one canonical candidate package
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $output = Join-Path $env:RUNNER_TEMP ('ddda-candidate-' + $env:SOURCE_SHA.Substring(0, 12) + '.zip')
-          $json = .\scripts\platform\New-DDDAPlatformPackage.ps1 -PlatformPath $PWD.Path -Kind candidate -Version ('candidate.' + $env:SOURCE_SHA) -SourceRef $env:SOURCE_SHA -OutputPath $output -Json | Out-String
-          $package = $json.Trim() | ConvertFrom-Json
-          if ($package.source_commit -ne $env:SOURCE_SHA) { throw 'Package source SHA mismatch.' }
-          "CANONICAL_PACKAGE_PATH=$([string]$package.path)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "CANONICAL_PACKAGE_SHA256=$([string]$package.sha256)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Run exact validate-pr against canonical package
+      - name: Run exact validate-pr through the canonical package path
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           .\ddda.ps1 validate-pr `
             -Pr ([int]$env:CANDIDATE_PR) `
-            -PackagePath $env:CANONICAL_PACKAGE_PATH `
-            -PackageArtifactName ('controlled-candidate-' + $env:SOURCE_SHA) `
             -CleanupOnFailure `
             -NonInteractive
-
-      - name: Upload canonical candidate
-        uses: actions/upload-artifact@v4
-        with:
-          name: controlled-candidate-${{ env.SOURCE_SHA }}
-          path: ${{ env.CANONICAL_PACKAGE_PATH }}
-          if-no-files-found: error
-          retention-days: 14
 
       - name: Upload validation evidence
         if: always()

--- a/.github/workflows/controlled-release-candidate-validation.yml
+++ b/.github/workflows/controlled-release-candidate-validation.yml
@@ -1,0 +1,236 @@
+name: Controlled release-candidate validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Exact candidate operation; never publishes a release.
+        required: true
+        default: technical_validation
+        type: choice
+        options:
+          - technical_validation
+          - publish_hrdr_scaffold
+          - release_scope_dry_run
+      candidate_pr:
+        description: Open Draft controlled release-candidate PR number.
+        required: true
+        default: "103"
+        type: string
+      source_sha:
+        description: Exact 40-character controlled candidate SHA.
+        required: true
+        type: string
+      version:
+        description: Release version without v prefix.
+        required: true
+        default: "0.1.1"
+        type: string
+      reviewer:
+        description: GitHub login, required only to publish a pending HRDR scaffold.
+        required: false
+        type: string
+      decision_owner:
+        description: GitHub login, required only to publish a pending HRDR scaffold.
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: controlled-release-candidate-${{ inputs.candidate_pr }}-${{ inputs.source_sha }}-${{ inputs.operation }}
+  cancel-in-progress: false
+
+env:
+  REPOSITORY: ${{ github.repository }}
+  CANDIDATE_PR: ${{ inputs.candidate_pr }}
+  SOURCE_SHA: ${{ inputs.source_sha }}
+  VERSION: ${{ inputs.version }}
+  OPERATION: ${{ inputs.operation }}
+
+jobs:
+  select:
+    name: Select exact controlled candidate
+    runs-on: windows-latest
+    outputs:
+      source_sha: ${{ steps.selection.outputs.source_sha }}
+    steps:
+      - name: Checkout trusted control plane
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Read live candidate identity
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          gh api "repos/$env:REPOSITORY/pulls/$env:CANDIDATE_PR" > candidate-pr.json
+          python .\scripts\platform\Test-DDDAControlledReleaseCandidate.py `
+            --repository $env:REPOSITORY `
+            --pr ([int]$env:CANDIDATE_PR) `
+            --source-sha $env:SOURCE_SHA `
+            --version $env:VERSION `
+            --operation $env:OPERATION `
+            --pr-json candidate-pr.json `
+            --output selection.json
+          "source_sha=$env:SOURCE_SHA" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Upload selection evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: controlled-candidate-selection-${{ env.CANDIDATE_PR }}-${{ env.SOURCE_SHA }}
+          path: |
+            candidate-pr.json
+            selection.json
+          if-no-files-found: error
+          retention-days: 14
+
+  technical-validation:
+    name: Exact controlled candidate validation
+    needs: select
+    if: inputs.operation == 'technical_validation'
+    runs-on: windows-latest
+    timeout-minutes: 120
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout exact controlled candidate
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.select.outputs.source_sha }}
+
+      - name: Verify exact candidate checkout
+        shell: pwsh
+        run: |
+          $actual = (git rev-parse HEAD).Trim()
+          if ($actual -ne $env:SOURCE_SHA) {
+            throw "Candidate checkout SHA '$actual' does not match requested SHA '$env:SOURCE_SHA'."
+          }
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run source-level validation
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          .\ddda.ps1 doctor
+          .\ddda.ps1 test -Suite lint -NonInteractive
+          .\ddda.ps1 test -Suite schema -NonInteractive
+          .\ddda.ps1 test -Suite unit -NonInteractive
+          .\ddda.ps1 test -Suite component -NonInteractive
+          .\ddda.ps1 test -Suite regression -NonInteractive
+          .\ddda.ps1 test -Suite security -NonInteractive
+
+      - name: Build one canonical candidate package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $output = Join-Path $env:RUNNER_TEMP ('ddda-candidate-' + $env:SOURCE_SHA.Substring(0, 12) + '.zip')
+          $json = .\scripts\platform\New-DDDAPlatformPackage.ps1 -PlatformPath $PWD.Path -Kind candidate -Version ('candidate.' + $env:SOURCE_SHA) -SourceRef $env:SOURCE_SHA -OutputPath $output -Json | Out-String
+          $package = $json.Trim() | ConvertFrom-Json
+          if ($package.source_commit -ne $env:SOURCE_SHA) { throw 'Package source SHA mismatch.' }
+          "CANONICAL_PACKAGE_PATH=$([string]$package.path)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CANONICAL_PACKAGE_SHA256=$([string]$package.sha256)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Run exact validate-pr against canonical package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          .\ddda.ps1 validate-pr `
+            -Pr ([int]$env:CANDIDATE_PR) `
+            -PackagePath $env:CANONICAL_PACKAGE_PATH `
+            -PackageArtifactName ('controlled-candidate-' + $env:SOURCE_SHA) `
+            -CleanupOnFailure `
+            -NonInteractive
+
+      - name: Upload canonical candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: controlled-candidate-${{ env.SOURCE_SHA }}
+          path: ${{ env.CANONICAL_PACKAGE_PATH }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload validation evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: controlled-candidate-validation-${{ env.CANDIDATE_PR }}-${{ env.SOURCE_SHA }}
+          path: ${{ env.LOCALAPPDATA }}/DDDA/validation-reports/pr-${{ env.CANDIDATE_PR }}-${{ env.SOURCE_SHA }}/**
+          if-no-files-found: warn
+          retention-days: 14
+
+  publish-hrdr-scaffold:
+    name: Publish pending HRDR scaffold
+    needs: select
+    if: inputs.operation == 'publish_hrdr_scaffold'
+    runs-on: windows-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REVIEWER: ${{ inputs.reviewer }}
+      DECISION_OWNER: ${{ inputs.decision_owner }}
+    steps:
+      - name: Require explicit owner inputs
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:REVIEWER) -or [string]::IsNullOrWhiteSpace($env:DECISION_OWNER)) {
+            throw 'reviewer and decision_owner are required for a pending HRDR scaffold.'
+          }
+
+      - name: Checkout exact controlled candidate
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.select.outputs.source_sha }}
+
+      - name: Publish pending scaffold only
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          .\ddda.ps1 review-pr `
+            -Pr ([int]$env:CANDIDATE_PR) `
+            -Version $env:VERSION `
+            -Reviewer $env:REVIEWER `
+            -DecisionOwner $env:DECISION_OWNER `
+            -PublishScaffold
+
+  release-scope-dry-run:
+    name: Physical Release Scope Gate dry-run
+    needs: select
+    if: inputs.operation == 'release_scope_dry_run'
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      GH_TOKEN: ${{ github.token }}
+      DDDA_GITHUB_PROJECT_TOKEN: ${{ secrets.DDDA_GITHUB_PROJECT_TOKEN }}
+    steps:
+      - name: Require Project read credential
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:DDDA_GITHUB_PROJECT_TOKEN)) {
+            throw 'DDDA_GITHUB_PROJECT_TOKEN is required for the authoritative read-only Release Scope Gate.'
+          }
+
+      - name: Checkout exact controlled candidate
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.select.outputs.source_sha }}
+
+      - name: Run promotion preflight only
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          .\ddda.ps1 promote-pr -Pr ([int]$env:CANDIDATE_PR) -Version $env:VERSION -DryRun

--- a/docs/adr/0013-controlled-release-candidate-validation.md
+++ b/docs/adr/0013-controlled-release-candidate-validation.md
@@ -1,0 +1,39 @@
+# ADR-0013: Exact validation lane for controlled release candidates
+
+## Context
+
+A controlled recovery candidate is intentionally an open Draft audit surface and
+must not be merged into `main`. Standard PR CI creates `validate-pr`
+evidence only for ordinary `pull_request` events, so it cannot establish the
+technical identity required by the release lifecycle for such a candidate.
+
+## Decision
+
+Add a manual GitHub Actions workflow hosted on trusted `main`.
+
+Before every operation it reads the live candidate PR and requires all of:
+
+- open Draft PR owned by this repository;
+- exact requested head SHA;
+- branch exactly `release/<version>-controlled-recovery-source`;
+- base `main`;
+- candidate body marker for the requested version.
+
+The workflow has three isolated operations:
+
+1. `technical_validation` checks out the exact candidate, builds one
+   canonical package, and runs `validate-pr` against that physical package.
+2. `publish_hrdr_scaffold` publishes only a pending HRDR after explicit
+   reviewer and decision-owner inputs.
+3. `release_scope_dry_run` invokes `promote-pr -DryRun`; it cannot merge,
+   tag, publish or promote.
+
+Each operation fails closed on identity drift. The workflow never changes a
+milestone, Project field, scope, release, tag or promotion state.
+
+## Consequences
+
+Technical candidate evidence, the human release decision and release promotion
+remain separate gates. A PASS technical validation does not create a GO
+decision, and the scope dry-run remains authoritative only with live Project
+read-back and an HRDR for the same candidate identity.

--- a/docs/adr/0013-controlled-release-candidate-validation.md
+++ b/docs/adr/0013-controlled-release-candidate-validation.md
@@ -21,8 +21,9 @@ Before every operation it reads the live candidate PR and requires all of:
 
 The workflow has three isolated operations:
 
-1. `technical_validation` checks out the exact candidate, builds one
-   canonical package, and runs `validate-pr` against that physical package.
+1. `technical_validation` checks out the exact candidate and invokes
+   `validate-pr`, which remains the sole canonical package builder and records
+   evidence for that physical package.
 2. `publish_hrdr_scaffold` publishes only a pending HRDR after explicit
    reviewer and decision-owner inputs.
 3. `release_scope_dry_run` invokes `promote-pr -DryRun`; it cannot merge,

--- a/runtime/platform/tests/test_controlled_release_candidate.py
+++ b/runtime/platform/tests/test_controlled_release_candidate.py
@@ -1,0 +1,50 @@
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "platform" / "Test-DDDAControlledReleaseCandidate.py"
+SPEC = importlib.util.spec_from_file_location("controlled_candidate", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def candidate(*, sha="a" * 40, draft=True, ref="release/0.1.1-controlled-recovery-source"):
+    return {
+        "number": 103,
+        "state": "open",
+        "draft": draft,
+        "head": {"sha": sha, "ref": ref, "repo": {"full_name": "romanhlavac/ddd-accelerator"}},
+        "base": {"ref": "main"},
+        "body": "## Controlled release-source candidate — DDDA 0.1.1",
+    }
+
+
+def validate(pr, **overrides):
+    arguments = {
+        "repository": "romanhlavac/ddd-accelerator",
+        "pr_number": 103,
+        "source_sha": "a" * 40,
+        "version": "0.1.1",
+        "operation": "technical_validation",
+    }
+    arguments.update(overrides)
+    return MODULE.validate_request(pr, **arguments)
+
+
+def test_accepts_only_exact_controlled_candidate_identity():
+    assert validate(candidate())["status"] == "PASS"
+
+
+def test_rejects_non_draft_or_wrong_branch_even_with_matching_sha():
+    result = validate(candidate(draft=False, ref="feature/release-validation"))
+    assert result["status"] == "FAIL"
+    assert "CONTROLLED_CANDIDATE_MUST_REMAIN_OPEN_DRAFT" in result["failures"]
+    assert "CONTROLLED_CANDIDATE_BRANCH_INVALID" in result["failures"]
+
+
+def test_rejects_sha_drift_and_unknown_operation():
+    result = validate(candidate(), source_sha="b" * 40, operation="publish_release")
+    assert result["status"] == "FAIL"
+    assert "CONTROLLED_CANDIDATE_HEAD_SHA_MISMATCH" in result["failures"]
+    assert "CONTROLLED_CANDIDATE_OPERATION_INVALID" in result["failures"]

--- a/scripts/platform/Test-DDDAControlledReleaseCandidate.py
+++ b/scripts/platform/Test-DDDAControlledReleaseCandidate.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Fail-closed selection contract for controlled release-candidate operations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+VERSION_RE = re.compile(r"^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$")
+OPERATIONS = frozenset({"technical_validation", "publish_hrdr_scaffold", "release_scope_dry_run"})
+
+
+def validate_request(
+    pr: dict[str, Any], *, repository: str, pr_number: int, source_sha: str, version: str, operation: str
+) -> dict[str, Any]:
+    failures: list[str] = []
+    if operation not in OPERATIONS:
+        failures.append("CONTROLLED_CANDIDATE_OPERATION_INVALID")
+    if not VERSION_RE.fullmatch(version):
+        failures.append("CONTROLLED_CANDIDATE_VERSION_INVALID")
+    if not SHA_RE.fullmatch(source_sha):
+        failures.append("CONTROLLED_CANDIDATE_SOURCE_SHA_INVALID")
+    head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
+    base = pr.get("base") if isinstance(pr.get("base"), dict) else {}
+    head_repo = head.get("repo") if isinstance(head.get("repo"), dict) else {}
+    expected_ref = f"release/{version}-controlled-recovery-source"
+    if int(pr.get("number") or -1) != pr_number:
+        failures.append("CONTROLLED_CANDIDATE_PR_IDENTITY_INVALID")
+    if pr.get("state") != "open" or pr.get("draft") is not True:
+        failures.append("CONTROLLED_CANDIDATE_MUST_REMAIN_OPEN_DRAFT")
+    if str(head.get("sha") or "") != source_sha:
+        failures.append("CONTROLLED_CANDIDATE_HEAD_SHA_MISMATCH")
+    if str(head.get("ref") or "") != expected_ref:
+        failures.append("CONTROLLED_CANDIDATE_BRANCH_INVALID")
+    if str(head_repo.get("full_name") or "") != repository:
+        failures.append("CONTROLLED_CANDIDATE_HEAD_REPOSITORY_INVALID")
+    if str(base.get("ref") or "") != "main":
+        failures.append("CONTROLLED_CANDIDATE_BASE_INVALID")
+    body = str(pr.get("body") or "")
+    if f"Controlled release-source candidate — DDDA {version}" not in body:
+        failures.append("CONTROLLED_CANDIDATE_MARKER_INVALID")
+    return {
+        "status": "PASS" if not failures else "FAIL",
+        "operation": operation,
+        "repository": repository,
+        "pr": pr_number,
+        "source_sha": source_sha,
+        "version": version,
+        "expected_branch": expected_ref,
+        "failures": sorted(set(failures)),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--pr", required=True, type=int)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--operation", required=True)
+    parser.add_argument("--pr-json", required=True, type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    pr = json.loads(args.pr_json.read_text(encoding="utf-8"))
+    result = validate_request(
+        pr,
+        repository=args.repository,
+        pr_number=args.pr,
+        source_sha=args.source_sha,
+        version=args.version,
+        operation=args.operation,
+    )
+    text = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 0 if result["status"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/platform/Test-DDDAControlledReleaseCandidate.py
+++ b/scripts/platform/Test-DDDAControlledReleaseCandidate.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-VERSION_RE = re.compile(r"^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$")
+VERSION_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 OPERATIONS = frozenset({"technical_validation", "publish_hrdr_scaffold", "release_scope_dry_run"})
 
 


### PR DESCRIPTION
Implements #96

## Purpose
Adds a fail-closed, manual validation lane for controlled release candidates without changing their source, active release scope, Project or milestones.

## Boundary
- accepts only an open Draft `release/<version>-controlled-recovery-source` PR at the requested exact SHA;
- technical validation builds one canonical package and records `validate-pr` evidence;
- HRDR scaffold requires explicit owner inputs and is pending only;
- Physical Release Scope Gate runs only through `promote-pr -DryRun`;
- no operation can merge, promote, tag or publish a release.

No release, promotion, tag, Project or milestone mutation.