### PR TITLE
fix(release): gate Draft controlled candidates

### DIFF
--- a/.github/workflows/controlled-release-candidate-validation.yml
+++ b/.github/workflows/controlled-release-candidate-validation.yml
@@ -102,16 +102,17 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Checkout exact controlled candidate
+      - name: Checkout trusted control plane
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ needs.select.outputs.source_sha }}
+          path: candidate
 
       - name: Verify exact candidate checkout
         shell: pwsh
         run: |
-          $actual = (git rev-parse HEAD).Trim()
+          $actual = (git -C candidate rev-parse HEAD).Trim()
           if ($actual -ne $env:SOURCE_SHA) {
             throw "Candidate checkout SHA '$actual' does not match requested SHA '$env:SOURCE_SHA'."
           }
@@ -125,30 +126,32 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          .\ddda.ps1 doctor
-          .\ddda.ps1 test -Suite lint -NonInteractive
-          .\ddda.ps1 test -Suite schema -NonInteractive
-          .\ddda.ps1 test -Suite unit -NonInteractive
-          .\ddda.ps1 test -Suite component -NonInteractive
-          .\ddda.ps1 test -Suite regression -NonInteractive
-          .\ddda.ps1 test -Suite security -NonInteractive
+          .\candidate\ddda.ps1 doctor
+          .\candidate\ddda.ps1 test -Suite lint -NonInteractive
+          .\candidate\ddda.ps1 test -Suite schema -NonInteractive
+          .\candidate\ddda.ps1 test -Suite unit -NonInteractive
+          .\candidate\ddda.ps1 test -Suite component -NonInteractive
+          .\candidate\ddda.ps1 test -Suite regression -NonInteractive
+          .\candidate\ddda.ps1 test -Suite security -NonInteractive
 
       - name: Run exact validate-pr through the canonical package path
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          .\ddda.ps1 validate-pr `
+          .\candidate\ddda.ps1 validate-pr `
             -Pr ([int]$env:CANDIDATE_PR) `
             -CleanupOnFailure `
             -NonInteractive
 
       - name: Upload validation evidence
-        if: always()
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: controlled-candidate-validation-${{ env.CANDIDATE_PR }}-${{ env.SOURCE_SHA }}
-          path: ${{ env.LOCALAPPDATA }}/DDDA/validation-reports/pr-${{ env.CANDIDATE_PR }}-${{ env.SOURCE_SHA }}/**
-          if-no-files-found: warn
+          path: |
+            ${{ env.LOCALAPPDATA }}/DDDA/validation-reports/pr-${{ env.CANDIDATE_PR }}-${{ env.SOURCE_SHA }}/**
+            ${{ env.LOCALAPPDATA }}/DDDA/packages/ddda-candidate-pr-${{ env.CANDIDATE_PR }}-${{ env.SOURCE_SHA }}-*.zip
+          if-no-files-found: error
           retention-days: 14
 
   publish-hrdr-scaffold:
@@ -172,17 +175,62 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.sha }}
+          path: control-plane
+
+      - name: Checkout exact controlled candidate
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
           ref: ${{ needs.select.outputs.source_sha }}
+          path: candidate
+
+      - name: Read live candidate identity
+        shell: pwsh
+        run: |
+          gh api "repos/$env:REPOSITORY/pulls/$env:CANDIDATE_PR" > candidate-pr.json
+
+      - name: Restore exact technical evidence
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $artifactName = "controlled-candidate-validation-$env:CANDIDATE_PR-$env:SOURCE_SHA"
+          $all = gh api --paginate "repos/$env:REPOSITORY/actions/artifacts?per_page=100" | ConvertFrom-Json
+          $matches = @($all.artifacts | Where-Object { $_.name -eq $artifactName -and -not $_.expired })
+          if ($matches.Count -ne 1) { throw "Expected exactly one unexpired exact validation artifact '$artifactName', found $($matches.Count)." }
+          gh api -H "Accept: application/vnd.github+json" "repos/$env:REPOSITORY/actions/artifacts/$($matches[0].id)/zip" > validation-evidence.zip
+          Expand-Archive -LiteralPath validation-evidence.zip -DestinationPath validation-evidence -Force
+          $reports = @(Get-ChildItem validation-evidence -Filter result.json -File -Recurse)
+          $packages = @(Get-ChildItem validation-evidence -Filter "ddda-candidate-pr-$env:CANDIDATE_PR-$env:SOURCE_SHA-*.zip" -File -Recurse)
+          if ($reports.Count -ne 1 -or $packages.Count -ne 1) { throw "Exact validation artifact must contain exactly one report and one canonical candidate package." }
+          "validation_report=$($reports[0].FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "candidate_package=$($packages[0].FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Verify restored exact evidence
+        shell: pwsh
+        run: |
+          python .\control-plane\scripts\platform\Test-DDDAControlledReleaseCandidate.py `
+            --repository $env:REPOSITORY `
+            --pr ([int]$env:CANDIDATE_PR) `
+            --source-sha $env:SOURCE_SHA `
+            --version $env:VERSION `
+            --operation $env:OPERATION `
+            --pr-json candidate-pr.json `
+            --validation-report $env:validation_report `
+            --candidate-package $env:candidate_package `
+            --output restored-evidence.json
 
       - name: Publish pending scaffold only
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          .\ddda.ps1 review-pr `
+          .\control-plane\ddda.ps1 review-pr `
             -Pr ([int]$env:CANDIDATE_PR) `
             -Version $env:VERSION `
             -Reviewer $env:REVIEWER `
             -DecisionOwner $env:DECISION_OWNER `
+            -ValidationReportPath $env:validation_report `
+            -CandidatePackagePath $env:candidate_package `
             -PublishScaffold
 
   release-scope-dry-run:
@@ -206,10 +254,77 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.select.outputs.source_sha }}
+          ref: ${{ github.sha }}
+          path: control-plane
 
-      - name: Run promotion preflight only
+      - name: Checkout exact controlled candidate
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.select.outputs.source_sha }}
+          path: candidate
+
+      - name: Read live candidate identity
+        shell: pwsh
+        run: |
+          gh api "repos/$env:REPOSITORY/pulls/$env:CANDIDATE_PR" > candidate-pr.json
+
+      - name: Restore exact technical evidence
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          .\ddda.ps1 promote-pr -Pr ([int]$env:CANDIDATE_PR) -Version $env:VERSION -DryRun
+          $artifactName = "controlled-candidate-validation-$env:CANDIDATE_PR-$env:SOURCE_SHA"
+          $all = gh api --paginate "repos/$env:REPOSITORY/actions/artifacts?per_page=100" | ConvertFrom-Json
+          $matches = @($all.artifacts | Where-Object { $_.name -eq $artifactName -and -not $_.expired })
+          if ($matches.Count -ne 1) { throw "Expected exactly one unexpired exact validation artifact '$artifactName', found $($matches.Count)." }
+          gh api -H "Accept: application/vnd.github+json" "repos/$env:REPOSITORY/actions/artifacts/$($matches[0].id)/zip" > validation-evidence.zip
+          Expand-Archive -LiteralPath validation-evidence.zip -DestinationPath validation-evidence -Force
+          $reports = @(Get-ChildItem validation-evidence -Filter result.json -File -Recurse)
+          $packages = @(Get-ChildItem validation-evidence -Filter "ddda-candidate-pr-$env:CANDIDATE_PR-$env:SOURCE_SHA-*.zip" -File -Recurse)
+          if ($reports.Count -ne 1 -or $packages.Count -ne 1) { throw "Exact validation artifact must contain exactly one report and one canonical candidate package." }
+          "validation_report=$($reports[0].FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "candidate_package=$($packages[0].FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Read exact Human Release Decision Record
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          gh api --paginate "repos/$env:REPOSITORY/issues/$env:CANDIDATE_PR/comments?per_page=100" > hrdr-comments.json
+          python .\control-plane\scripts\platform\Read-DDDAHrdr.py --comments-json hrdr-comments.json --output hrdr.json
+
+      - name: Run Physical Release Scope Gate only
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          python .\control-plane\scripts\platform\Test-DDDAControlledReleaseCandidate.py `
+            --repository $env:REPOSITORY `
+            --pr ([int]$env:CANDIDATE_PR) `
+            --source-sha $env:SOURCE_SHA `
+            --version $env:VERSION `
+            --operation $env:OPERATION `
+            --pr-json candidate-pr.json `
+            --validation-report $env:validation_report `
+            --candidate-package $env:candidate_package `
+            --output restored-evidence.json
+          $evidence = Get-Content restored-evidence.json -Raw -Encoding utf8 | ConvertFrom-Json
+          if ($evidence.status -ne 'PASS') { throw 'Restored exact candidate evidence did not pass.' }
+          python .\control-plane\scripts\platform\Test-DDDAReleaseScope.py `
+            --repository $env:REPOSITORY `
+            --pr ([int]$env:CANDIDATE_PR) `
+            --source-sha $env:SOURCE_SHA `
+            --candidate-sha256 $evidence.validation_evidence.candidate_package_sha256 `
+            --version $env:VERSION `
+            --hrdr hrdr.json `
+            --output physical-release-scope.json
+
+      - name: Upload scope-gate evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: controlled-candidate-scope-gate-${{ env.CANDIDATE_PR }}-${{ env.SOURCE_SHA }}
+          path: |
+            restored-evidence.json
+            hrdr.json
+            physical-release-scope.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/adr/0013-controlled-release-candidate-validation.md
+++ b/docs/adr/0013-controlled-release-candidate-validation.md
@@ -24,12 +24,16 @@ The workflow has three isolated operations:
 1. `technical_validation` checks out the exact candidate and invokes
    `validate-pr`, which remains the sole canonical package builder and records
    evidence for that physical package.
-2. `publish_hrdr_scaffold` publishes only a pending HRDR after explicit
-   reviewer and decision-owner inputs.
-3. `release_scope_dry_run` invokes `promote-pr -DryRun`; it cannot merge,
-   tag, publish or promote.
+2. `publish_hrdr_scaffold` restores the one exact validation artifact and
+   publishes only a pending HRDR after explicit reviewer and decision-owner
+   inputs.
+3. `release_scope_dry_run` restores that same physical package and report,
+   reads exactly one authoritative HRDR, and invokes the read-only Physical
+   Release Scope Gate directly. It does not call `promote-pr`, because that
+   command deliberately rejects Draft implementation/release PRs.
 
-Each operation fails closed on identity drift. The workflow never changes a
+Each operation fails closed on identity drift, missing/ambiguous validation
+artifacts, package-hash mismatch or HRDR ambiguity. The workflow never changes a
 milestone, Project field, scope, release, tag or promotion state.
 
 ## Consequences

--- a/docs/user-guide/validate-and-promote-pr.md
+++ b/docs/user-guide/validate-and-promote-pr.md
@@ -223,3 +223,11 @@ release-reports/
 - LOW/MEDIUM squash exception musí mít lidskou provenance a exact candidate binding;
 - `merge-pr` nesmí být release bypass;
 - `promote-pr` nesmí být použit jako obecný mechanismus merge implementačních PR.
+## GitHub Release notes
+
+Every published DDDA release contains a user-facing **Co je nové** section.
+It is generated only from the matching versioned section in `CHANGELOG.md`;
+therefore the release notes list the functionality and relevant fixes delivered
+by that release. Publication fails closed when that versioned section is missing
+or has no concrete list items. Existing GitHub Release notes must match the same
+versioned section on fresh server read-back and are never replaced heuristically.

--- a/runtime/platform/tests/test_controlled_release_candidate.py
+++ b/runtime/platform/tests/test_controlled_release_candidate.py
@@ -48,3 +48,38 @@ def test_rejects_sha_drift_and_unknown_operation():
     assert result["status"] == "FAIL"
     assert "CONTROLLED_CANDIDATE_HEAD_SHA_MISMATCH" in result["failures"]
     assert "CONTROLLED_CANDIDATE_OPERATION_INVALID" in result["failures"]
+
+
+def test_binds_reusable_package_to_exact_validation_report(tmp_path):
+    package = tmp_path / "candidate.zip"
+    package.write_bytes(b"exact physical package")
+    import hashlib
+
+    report = {
+        "status": "PASS",
+        "source": {"repository": "romanhlavac/ddd-accelerator", "pr": 103, "commit": "a" * 40},
+        "package": {"sha256": hashlib.sha256(package.read_bytes()).hexdigest()},
+    }
+    assert MODULE.validate_validation_evidence(
+        report,
+        repository="romanhlavac/ddd-accelerator",
+        pr_number=103,
+        source_sha="a" * 40,
+        package_path=package,
+    )["status"] == "PASS"
+
+
+def test_rejects_package_or_report_identity_drift(tmp_path):
+    package = tmp_path / "candidate.zip"
+    package.write_bytes(b"changed package")
+    report = {"status": "PASS", "source": {"repository": "wrong", "pr": 99, "commit": "b" * 40}, "package": {"sha256": "0" * 64}}
+    result = MODULE.validate_validation_evidence(
+        report,
+        repository="romanhlavac/ddd-accelerator",
+        pr_number=103,
+        source_sha="a" * 40,
+        package_path=package,
+    )
+    assert result["status"] == "FAIL"
+    assert "CONTROLLED_CANDIDATE_VALIDATION_SHA_MISMATCH" in result["failures"]
+    assert "CONTROLLED_CANDIDATE_PACKAGE_HASH_MISMATCH" in result["failures"]

--- a/runtime/platform/tests/test_hrdr_comment.py
+++ b/runtime/platform/tests/test_hrdr_comment.py
@@ -1,0 +1,31 @@
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "platform" / "Read-DDDAHrdr.py"
+SPEC = importlib.util.spec_from_file_location("read_hrdr", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def comment(*, decision="pending", reviewer="romanhlavac", author="github-actions[bot]"):
+    return {
+        "user": {"login": author},
+        "body": "<!-- ddda:human-release-decision:v1 -->\n```json\n"
+        + '{"schema_version":1,"decision":"' + decision + '","reviewer":"' + reviewer + '"}\n```',
+    }
+
+
+def test_accepts_one_pending_scaffold_and_human_decision():
+    assert MODULE.extract_hrdr([comment()])["decision"] == "pending"
+    assert MODULE.extract_hrdr([comment(decision="go", author="romanhlavac")])["decision"] == "go"
+
+
+def test_rejects_ambiguous_or_spoofed_decision():
+    import pytest
+
+    with pytest.raises(ValueError):
+        MODULE.extract_hrdr([comment(), comment()])
+    with pytest.raises(ValueError):
+        MODULE.extract_hrdr([comment(decision="go", author="github-actions[bot]")])

--- a/scripts/platform/DDDAReleasePublicationSupport.ps1
+++ b/scripts/platform/DDDAReleasePublicationSupport.ps1
@@ -27,6 +27,29 @@ function Get-DDDAReleasePublicationAssetDescriptors {
     }
 }
 
+function Get-DDDAReleaseNotes {
+    param(
+        [Parameter(Mandatory = $true)][string]$ChangelogPath,
+        [Parameter(Mandatory = $true)][string]$Version
+    )
+
+    if (-not (Test-Path -LiteralPath $ChangelogPath -PathType Leaf)) {
+        throw "Release notes source CHANGELOG neexistuje: $ChangelogPath"
+    }
+    $changelog = Get-Content -LiteralPath $ChangelogPath -Raw -Encoding UTF8
+    $heading = [regex]::Match($changelog, "(?m)^## \[" + [regex]::Escape($Version) + "\] - \d{4}-\d{2}-\d{2}\s*$")
+    if (-not $heading.Success) {
+        throw "CHANGELOG neobsahuje versioned release section pro $Version."
+    }
+    $tail = $changelog.Substring($heading.Index + $heading.Length)
+    $next = [regex]::Match($tail, "(?m)^## \[")
+    $section = if ($next.Success) { $tail.Substring(0, $next.Index).Trim() } else { $tail.Trim() }
+    if ([string]::IsNullOrWhiteSpace($section) -or $section -notmatch '(?m)^\s*-\s+\S') {
+        throw "CHANGELOG release section pro $Version musí obsahovat konkrétní seznam funkcionalit nebo změn."
+    }
+    return "## Co je nové v DDDA $Version`n`n$section`n`n---`nCanonical DDDA product package and verified release evidence for ``v$Version``. GitHub automatic source archives are convenience source archives, not the canonical DDDA product package."
+}
+
 function Get-DDDAGitHubReleaseByTag {
     param(
         [Parameter(Mandatory = $true)][string]$RepositorySlug,
@@ -66,12 +89,14 @@ function Assert-DDDAGitHubReleaseIdentity {
     param(
         [Parameter(Mandatory = $true)]$Release,
         [Parameter(Mandatory = $true)][string]$Tag,
-        [Parameter(Mandatory = $true)][string]$Title
+        [Parameter(Mandatory = $true)][string]$Title,
+        [Parameter(Mandatory = $true)][string]$ReleaseNotes
     )
 
     if ([string]$Release.tag_name -ne $Tag) { throw "GitHub Release tag neodpovídá $Tag." }
     if ([string]$Release.name -ne $Title) { throw "GitHub Release title neodpovídá '$Title'." }
     if ([bool]$Release.draft -or [bool]$Release.prerelease) { throw "GitHub Release musí být publikovaný finální release." }
+    if ([string]$Release.body -ne $ReleaseNotes) { throw "GitHub Release notes neodpovídají versioned CHANGELOG release section." }
 }
 
 function Test-DDDAGitHubReleaseAssetHash {
@@ -120,12 +145,14 @@ function Publish-DDDACanonicalGitHubRelease {
         [Parameter(Mandatory = $true)][string]$PackagePath,
         [Parameter(Mandatory = $true)][string]$ReportJsonPath,
         [Parameter(Mandatory = $true)][string]$ReportMarkdownPath,
+        [Parameter(Mandatory = $true)][string]$ChangelogPath,
         [Parameter(Mandatory = $true)][string]$Token,
         [Parameter(Mandatory = $true)][string]$PublicationEvidencePath
     )
 
     if ($ReleaseSourceSha -notmatch '^[0-9a-f]{40}$') { throw "Release source SHA není platný." }
     $title = "DDDA $Version"
+    $releaseNotes = Get-DDDAReleaseNotes -ChangelogPath $ChangelogPath -Version $Version
     $tagCommit = Assert-DDDACanonicalReleaseTagReadBack -OriginUrl $OriginUrl -Tag $Tag -ExpectedCommit $ReleaseSourceSha
     $assets = @(Get-DDDAReleasePublicationAssetDescriptors -Version $Version -PackagePath $PackagePath -ReportJsonPath $ReportJsonPath -ReportMarkdownPath $ReportMarkdownPath)
     $report = Get-Content -LiteralPath $ReportJsonPath -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -141,13 +168,13 @@ function Publish-DDDACanonicalGitHubRelease {
             tag_name = $Tag
             target_commitish = $ReleaseSourceSha
             name = $title
-            body = "Canonical DDDA product package and release evidence for `$Tag. GitHub automatic source archives are convenience source archives, not the canonical DDDA product package."
+            body = $releaseNotes
             draft = $false
             prerelease = $false
             generate_release_notes = $false
         }
     }
-    Assert-DDDAGitHubReleaseIdentity -Release $release -Tag $Tag -Title $title
+    Assert-DDDAGitHubReleaseIdentity -Release $release -Tag $Tag -Title $title -ReleaseNotes $releaseNotes
 
     foreach ($descriptor in $assets) {
         $existing = @($release.assets | Where-Object { [string]$_.name -eq [string]$descriptor.name })
@@ -163,7 +190,7 @@ function Publish-DDDACanonicalGitHubRelease {
 
     $readBack = Get-DDDAGitHubReleaseByTag -RepositorySlug $RepositorySlug -Tag $Tag -Token $Token
     if ($null -eq $readBack) { throw "Fresh GitHub read-back nenašel Release pro $Tag." }
-    Assert-DDDAGitHubReleaseIdentity -Release $readBack -Tag $Tag -Title $title
+    Assert-DDDAGitHubReleaseIdentity -Release $readBack -Tag $Tag -Title $title -ReleaseNotes $releaseNotes
     $evidenceAssets = [ordered]@{}
     foreach ($descriptor in $assets) {
         $asset = @($readBack.assets | Where-Object { [string]$_.name -eq [string]$descriptor.name })

--- a/scripts/platform/Invoke-DDDAPromotePr.ps1
+++ b/scripts/platform/Invoke-DDDAPromotePr.ps1
@@ -433,6 +433,7 @@ $publication = Publish-DDDACanonicalGitHubRelease `
     -PackagePath $releasePackagePath `
     -ReportJsonPath $releaseReportJson `
     -ReportMarkdownPath $releaseReportMarkdown `
+    -ChangelogPath (Join-Path $releasePackageRoot "CHANGELOG.md") `
     -Token $githubAuth.Token `
     -PublicationEvidencePath $publicationEvidencePath
 

--- a/scripts/platform/Invoke-DDDARecoverGitHubRelease.ps1
+++ b/scripts/platform/Invoke-DDDARecoverGitHubRelease.ps1
@@ -6,6 +6,7 @@ param(
     [Parameter(Mandatory = $true)][string]$ReleasePackagePath,
     [Parameter(Mandatory = $true)][string]$ReleaseReportJsonPath,
     [Parameter(Mandatory = $true)][string]$ReleaseReportMarkdownPath,
+    [Parameter(Mandatory = $true)][string]$ChangelogPath,
     [switch]$ConfirmRecovery
 )
 
@@ -38,6 +39,7 @@ $publication = Publish-DDDACanonicalGitHubRelease `
     -PackagePath $ReleasePackagePath `
     -ReportJsonPath $ReleaseReportJsonPath `
     -ReportMarkdownPath $ReleaseReportMarkdownPath `
+    -ChangelogPath $ChangelogPath `
     -Token $githubAuth.Token `
     -PublicationEvidencePath (Join-Path $evidenceRoot "publication.json")
 

--- a/scripts/platform/Invoke-DDDAReviewPr.ps1
+++ b/scripts/platform/Invoke-DDDAReviewPr.ps1
@@ -5,6 +5,8 @@ param(
     [Parameter(Mandatory = $true)][string]$Version,
     [string]$Reviewer,
     [string]$DecisionOwner,
+    [string]$ValidationReportPath,
+    [string]$CandidatePackagePath,
     [switch]$PublishScaffold,
     [switch]$Json
 )
@@ -31,7 +33,11 @@ if ($headSha -notmatch '^[0-9a-f]{40}$') {
     throw "GitHub nevrátil platný PR head SHA."
 }
 
-$validation = Get-DDDACandidateValidationEvidence -Pr $Pr -HeadSha $headSha
+$validation = Get-DDDACandidateValidationEvidence `
+    -Pr $Pr `
+    -HeadSha $headSha `
+    -ValidationReportPath $ValidationReportPath `
+    -PackagePath $CandidatePackagePath
 $scope = Get-DDDAReleaseMilestoneScope -RepositorySlug $repositorySlug -Version $Version -Token $githubAuth.Token
 
 $record = [ordered]@{

--- a/scripts/platform/Read-DDDAHrdr.py
+++ b/scripts/platform/Read-DDDAHrdr.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Extract one authoritative Human Release Decision Record from issue comments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+MARKER = "<!-- ddda:human-release-decision:v1 -->"
+JSON_RE = re.compile(r"(?s)```json\s*(?P<json>\{.*?\})\s*```")
+
+
+def extract_hrdr(comments: list[dict[str, Any]]) -> dict[str, Any]:
+    matches = [row for row in comments if MARKER in str(row.get("body") or "")]
+    if len(matches) != 1:
+        raise ValueError("Expected exactly one authoritative HRDR comment")
+    comment = matches[0]
+    match = JSON_RE.search(str(comment.get("body") or ""))
+    if not match:
+        raise ValueError("Authoritative HRDR comment has no fenced JSON record")
+    record = json.loads(match.group("json"))
+    if not isinstance(record, dict) or record.get("schema_version") != 1:
+        raise ValueError("Authoritative HRDR record has an unsupported schema")
+    author = str(((comment.get("user") or {}).get("login")) or "")
+    if not author:
+        raise ValueError("Authoritative HRDR comment has no GitHub author")
+    if record.get("decision") != "pending" and author != str(record.get("reviewer") or ""):
+        raise ValueError("Positive/negative HRDR must have human reviewer provenance")
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--comments-json", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    payload = json.loads(args.comments_json.read_text(encoding="utf-8"))
+    comments = payload if isinstance(payload, list) else []
+    record = extract_hrdr(comments)
+    args.output.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/platform/Test-DDDAControlledReleaseCandidate.py
+++ b/scripts/platform/Test-DDDAControlledReleaseCandidate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 from pathlib import Path
@@ -55,6 +56,40 @@ def validate_request(
     }
 
 
+def validate_validation_evidence(
+    report: dict[str, Any], *, repository: str, pr_number: int, source_sha: str, package_path: Path
+) -> dict[str, Any]:
+    """Bind a reusable candidate package to one exact controlled candidate."""
+    failures: list[str] = []
+    source = report.get("source") if isinstance(report.get("source"), dict) else {}
+    package = report.get("package") if isinstance(report.get("package"), dict) else {}
+    expected_hash = str(package.get("sha256") or "").lower()
+    if report.get("status") != "PASS":
+        failures.append("CONTROLLED_CANDIDATE_VALIDATION_NOT_PASS")
+    if str(source.get("repository") or "") != repository:
+        failures.append("CONTROLLED_CANDIDATE_VALIDATION_REPOSITORY_MISMATCH")
+    if int(source.get("pr") or -1) != pr_number:
+        failures.append("CONTROLLED_CANDIDATE_VALIDATION_PR_MISMATCH")
+    if str(source.get("commit") or "") != source_sha:
+        failures.append("CONTROLLED_CANDIDATE_VALIDATION_SHA_MISMATCH")
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_hash):
+        failures.append("CONTROLLED_CANDIDATE_VALIDATION_PACKAGE_HASH_INVALID")
+    if not package_path.is_file():
+        failures.append("CONTROLLED_CANDIDATE_PACKAGE_MISSING")
+    elif expected_hash:
+        actual_hash = hashlib.sha256(package_path.read_bytes()).hexdigest()
+        if actual_hash != expected_hash:
+            failures.append("CONTROLLED_CANDIDATE_PACKAGE_HASH_MISMATCH")
+    return {
+        "status": "PASS" if not failures else "FAIL",
+        "repository": repository,
+        "pr": pr_number,
+        "source_sha": source_sha,
+        "candidate_package_sha256": expected_hash,
+        "failures": sorted(set(failures)),
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repository", required=True)
@@ -63,6 +98,8 @@ def main() -> int:
     parser.add_argument("--version", required=True)
     parser.add_argument("--operation", required=True)
     parser.add_argument("--pr-json", required=True, type=Path)
+    parser.add_argument("--validation-report", type=Path)
+    parser.add_argument("--candidate-package", type=Path)
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
     pr = json.loads(args.pr_json.read_text(encoding="utf-8"))
@@ -74,6 +111,20 @@ def main() -> int:
         version=args.version,
         operation=args.operation,
     )
+    if (args.validation_report is None) != (args.candidate_package is None):
+        parser.error("--validation-report and --candidate-package must be supplied together")
+    if args.validation_report and args.candidate_package:
+        evidence = validate_validation_evidence(
+            json.loads(args.validation_report.read_text(encoding="utf-8-sig")),
+            repository=args.repository,
+            pr_number=args.pr,
+            source_sha=args.source_sha,
+            package_path=args.candidate_package,
+        )
+        result["validation_evidence"] = evidence
+        if evidence["status"] != "PASS":
+            result["status"] = "FAIL"
+            result["failures"] = sorted(set(result["failures"] + evidence["failures"]))
     text = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
     if args.output:
         args.output.write_text(text, encoding="utf-8")

--- a/tests/powershell/Test-DDDAReleasePublication.ps1
+++ b/tests/powershell/Test-DDDAReleasePublication.ps1
@@ -17,14 +17,22 @@ try {
     $package = Join-Path $root "package.zip"
     $reportJson = Join-Path $root "result.json"
     $reportMarkdown = Join-Path $root "result.md"
+    $changelog = Join-Path $root "CHANGELOG.md"
     [System.IO.File]::WriteAllText($package, "canonical package fixture")
     [System.IO.File]::WriteAllText($reportJson, '{"status":"PASS"}')
     [System.IO.File]::WriteAllText($reportMarkdown, "# PASS")
+    [System.IO.File]::WriteAllText($changelog, "# Changelog`n`n## [Unreleased]`n`n## [1.2.3] - 2026-08-28`n`n### Added`n`n- A new governed capability.`n`n### Fixed`n`n- A release defect.")
 
     $descriptors = @(Get-DDDAReleasePublicationAssetDescriptors -Version "1.2.3" -PackagePath $package -ReportJsonPath $reportJson -ReportMarkdownPath $reportMarkdown)
     Assert-True -Condition ($descriptors.Count -eq 3) -Message "Publication contract musí mít právě package + dva release report assets."
     Assert-True -Condition ((@($descriptors.name) -join ',') -eq "ddda-1.2.3.zip,ddda-1.2.3-release-report.json,ddda-1.2.3-release-report.md") -Message "Asset names nejsou deterministické podle release verze."
     Assert-True -Condition ($descriptors[0].sha256 -eq (Get-DDDAPlatformFileHash -Path $package)) -Message "Package asset SHA-256 není fyzický hash vstupního package."
+    $notes = Get-DDDAReleaseNotes -ChangelogPath $changelog -Version "1.2.3"
+    Assert-True -Condition ($notes -match "Co je nové v DDDA 1.2.3" -and $notes -match "A new governed capability" -and $notes -match "A release defect") -Message "GitHub Release notes neobsahují versioned seznam funkcionalit a změn."
+    $missingNotesRejected = $false
+    [System.IO.File]::WriteAllText($changelog, "# Changelog`n`n## [Unreleased]`n`n## [1.2.3] - 2026-08-28")
+    try { $null = Get-DDDAReleaseNotes -ChangelogPath $changelog -Version "1.2.3" } catch { $missingNotesRejected = $true }
+    Assert-True -Condition $missingNotesRejected -Message "Prázdné release notes musí failnout před publikací."
 
     $goodAsset = [pscustomobject]@{ digest = "sha256:$($descriptors[0].sha256)"; browser_download_url = "https://example.invalid/package" }
     $badAsset = [pscustomobject]@{ digest = "sha256:$(('0' * 64))"; browser_download_url = "https://example.invalid/package" }
@@ -39,8 +47,8 @@ try {
     $promotion = Get-Content -LiteralPath (Join-Path $PlatformPath "scripts/platform/Invoke-DDDAPromotePr.ps1") -Raw -Encoding UTF8
     $recovery = Get-Content -LiteralPath (Join-Path $PlatformPath "scripts/platform/Invoke-DDDARecoverGitHubRelease.ps1") -Raw -Encoding UTF8
     Assert-True -Condition ($support -match 'Fresh GitHub read-back' -and $support -match 'assets\?name=' -and $support -match 'se nesmí přepsat') -Message "Publication support nemá fail-closed read-back/asset contract."
-    Assert-True -Condition ($promotion -match 'PortablePaths\s*=\s*\$true' -and $promotion -match 'Publish-DDDACanonicalGitHubRelease') -Message "Promotion nepublikuje portable validated evidence po tagu."
-    Assert-True -Condition ($recovery -match '\[switch\]\$ConfirmRecovery' -and $recovery -match 'if \(-not \$ConfirmRecovery\)') -Message "Recovery nemá explicitní authorization boundary."
+    Assert-True -Condition ($promotion -match 'PortablePaths\s*=\s*\$true' -and $promotion -match 'Publish-DDDACanonicalGitHubRelease' -and $promotion -match 'ChangelogPath') -Message "Promotion nepublikuje portable validated evidence a versioned release notes po tagu."
+    Assert-True -Condition ($recovery -match '\[switch\]\$ConfirmRecovery' -and $recovery -match 'if \(-not \$ConfirmRecovery\)' -and $recovery -match 'ChangelogPath') -Message "Recovery nemá explicitní authorization boundary a versioned release notes contract."
     Assert-True -Condition ($support -notmatch 'DELETE.+releases|Remove-DDDA.*Release|Delete-DDDA.*Asset') -Message "Publication contract nesmí obsahovat automatické přepsání Release/assets."
 }
 finally {


### PR DESCRIPTION
## Controlled candidate scope-gate remediation

Implements #96

This PR repairs the controlled-candidate validation lane without changing the candidate, release scope or any release state.

- keeps controlled recovery PRs Draft and evaluates their physical scope through the dedicated read-only gate, not `promote-pr`;
- restores exactly one physical validation package/report artifact and rejects identity or hash drift;
- reads exactly one authoritative HRDR and rejects ambiguous or spoofed decision provenance;
- makes published GitHub Release notes derive from the versioned CHANGELOG section, so every release lists delivered functionality and fixes.

## Boundary

No merge, promotion, tag, GitHub Release, Project, milestone, scope or CR-state change is included. PR #103 remains an audit-only Draft candidate and must not be merged into `main`.