### PR TITLE
fix(release): bind exact controlled candidate output

### DIFF
--- a/.github/workflows/controlled-release-candidate-validation.yml
+++ b/.github/workflows/controlled-release-candidate-validation.yml
@@ -67,6 +67,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Read live candidate identity
+        id: selection
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Formát vychází z principu Keep a Changelog. Verze používají Semantic Versi
 - governed implementation merge používá po aktivaci #70 merge commit jako canonical default; HIGH/BREAKING a neklasifikované PR nesmějí squash/rebase, LOW/MEDIUM squash vyžaduje explicitní human exception a canonical merge ověřuje validated PR HEAD server-side jako parent/ancestor výsledného main state.
 
 ### Fixed
+- Controlled release-candidate validation now binds the selected exact SHA through an identified cross-job output; it cannot silently validate `main` instead of the candidate.
 
 - delivery governance nyní odvozuje PR `Blocked` a `Status` z unresolved blocker state primárního Change Requestu; stale Project dvojice `Blocked = Yes` / `Status = Blocked` proto nemůže projít fresh fail-closed read-backem a druhý reconcile je idempotentní;
 - governed `merge-pr` nyní sestavuje GitHub Contents API URL bez PowerShell variable-name ambiguity mezi cestou dokumentu a `?ref` query, takže isolated post-Human-Review dry-run ověří povinné dokumenty na exact PR SHA;

--- a/docs/adr/0013-controlled-release-candidate-validation.md
+++ b/docs/adr/0013-controlled-release-candidate-validation.md
@@ -19,6 +19,8 @@ Before every operation it reads the live candidate PR and requires all of:
 - base `main`;
 - candidate body marker for the requested version.
 
+The selection step is named and is the sole publisher of the selected exact SHA across job boundaries. If that output is absent or does not match the requested identity, validation must fail rather than fall back to the default branch.
+
 The workflow has three isolated operations:
 
 1. `technical_validation` checks out the exact candidate and invokes

--- a/runtime/platform/tests/test_controlled_release_candidate.py
+++ b/runtime/platform/tests/test_controlled_release_candidate.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = ROOT / "scripts" / "platform" / "Test-DDDAControlledReleaseCandidate.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "controlled-release-candidate-validation.yml"
 SPEC = importlib.util.spec_from_file_location("controlled_candidate", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -83,3 +84,13 @@ def test_rejects_package_or_report_identity_drift(tmp_path):
     assert result["status"] == "FAIL"
     assert "CONTROLLED_CANDIDATE_VALIDATION_SHA_MISMATCH" in result["failures"]
     assert "CONTROLLED_CANDIDATE_PACKAGE_HASH_MISMATCH" in result["failures"]
+
+
+def test_technical_validation_binds_checkout_to_identified_selection_output():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert """      - name: Read live candidate identity
+        id: selection""" in workflow
+    assert "source_sha: ${{ steps.selection.outputs.source_sha }}" in workflow
+    assert "ref: ${{ needs.select.outputs.source_sha }}" in workflow
+    assert "Candidate checkout SHA '$actual' does not match requested SHA '$env:SOURCE_SHA'." in workflow


### PR DESCRIPTION
## Controlled candidate exact-SHA output binding

Implements #96

This repair ensures technical validation checks out the exact selected controlled candidate, not the workflow default branch.

- names the selection step that emits the cross-job exact SHA;
- retains the existing checkout identity mismatch guard as a fail-closed boundary;
- adds a regression test and ADR/changelog documentation.

## Boundary

No merge, promotion, tag, GitHub Release, Project, milestone, scope or CR-state change. Candidate PR #103 remains Draft and audit-only.