### PR TITLE
fix(release): separate candidate validation from promotion

### DIFF
--- a/.github/workflows/controlled-release-candidate-validation.yml
+++ b/.github/workflows/controlled-release-candidate-validation.yml
@@ -131,7 +131,7 @@ jobs:
           .\candidate\ddda.ps1 test -Suite lint -NonInteractive
           .\candidate\ddda.ps1 test -Suite schema -NonInteractive
           .\candidate\ddda.ps1 test -Suite unit -NonInteractive
-          .\candidate\ddda.ps1 test -Suite component -NonInteractive
+          .\candidate\ddda.ps1 test -Suite component -PrePromotionCandidate -NonInteractive
           .\candidate\ddda.ps1 test -Suite regression -NonInteractive
           .\candidate\ddda.ps1 test -Suite security -NonInteractive
 
@@ -142,6 +142,7 @@ jobs:
           .\candidate\ddda.ps1 validate-pr `
             -Pr ([int]$env:CANDIDATE_PR) `
             -CleanupOnFailure `
+            -PrePromotionCandidate `
             -NonInteractive
 
       - name: Upload validation evidence

--- a/ddda.ps1
+++ b/ddda.ps1
@@ -24,6 +24,7 @@ param(
     [switch]$KeepReviewBoard,
     [string]$MiroTeamId,
     [switch]$NonInteractive,
+    [switch]$PrePromotionCandidate,
     [switch]$ConfirmMerge,
     [switch]$DryRun
 )
@@ -83,6 +84,7 @@ switch ($Command) {
         if ($KeepReviewBoard) { $arguments += "-KeepReviewBoard" }
         if (-not [string]::IsNullOrWhiteSpace($MiroTeamId)) { $arguments += @("-MiroTeamId", $MiroTeamId) }
         if ($NonInteractive) { $arguments += "-NonInteractive" }
+        if ($PrePromotionCandidate) { $arguments += "-PrePromotionCandidate" }
         Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAPlatformTest.ps1" -Arguments $arguments
     }
     "validate-pr" {
@@ -100,6 +102,7 @@ switch ($Command) {
         if ($KeepReviewBoard) { $arguments += "-KeepReviewBoard" }
         if (-not [string]::IsNullOrWhiteSpace($MiroTeamId)) { $arguments += @("-MiroTeamId", $MiroTeamId) }
         if ($NonInteractive) { $arguments += "-NonInteractive" }
+        if ($PrePromotionCandidate) { $arguments += "-PrePromotionCandidate" }
         Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAValidatePr.ps1" -Arguments $arguments
     }
     "merge-pr" {

--- a/docs/adr/0013-controlled-release-candidate-validation.md
+++ b/docs/adr/0013-controlled-release-candidate-validation.md
@@ -24,8 +24,9 @@ The selection step is named and is the sole publisher of the selected exact SHA 
 The workflow has three isolated operations:
 
 1. `technical_validation` checks out the exact candidate and invokes
-   `validate-pr`, which remains the sole canonical package builder and records
-   evidence for that physical package.
+   `validate-pr` in dedicated pre-promotion mode. It remains the sole canonical
+   package builder and records evidence for that physical package without
+   pretending the candidate is already a final release cut.
 2. `publish_hrdr_scaffold` restores the one exact validation artifact and
    publishes only a pending HRDR after explicit reviewer and decision-owner
    inputs.
@@ -44,3 +45,14 @@ Technical candidate evidence, the human release decision and release promotion
 remain separate gates. A PASS technical validation does not create a GO
 decision, and the scope dry-run remains authoritative only with live Project
 read-back and an HRDR for the same candidate identity.
+
+## Pre-promotion validation boundary
+
+A controlled recovery candidate is an auditable source for validation, not a published
+release. Its technical validation therefore uses `-PrePromotionCandidate`: it skips only
+cross-stream integration assertions that require the canonical `main` CI surface.
+
+This mode never authorizes promotion. The `promote-pr` path remains unchanged and
+fail-closed: before any tag or GitHub Release, the release must contain versioned release
+notes and pass the final promotion guards. A technical PASS is evidence of candidate
+integrity, not a release decision.

--- a/runtime/platform/tests/test_controlled_release_candidate.py
+++ b/runtime/platform/tests/test_controlled_release_candidate.py
@@ -94,3 +94,21 @@ def test_technical_validation_binds_checkout_to_identified_selection_output():
     assert "source_sha: ${{ steps.selection.outputs.source_sha }}" in workflow
     assert "ref: ${{ needs.select.outputs.source_sha }}" in workflow
     assert "Candidate checkout SHA '$actual' does not match requested SHA '$env:SOURCE_SHA'." in workflow
+
+
+def test_pre_promotion_candidate_validation_keeps_release_notes_for_promotion_only() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    cli = (ROOT / "ddda.ps1").read_text(encoding="utf-8")
+    test_runner = (ROOT / "scripts/platform/Invoke-DDDAPlatformTest.ps1").read_text(encoding="utf-8")
+    validator = (ROOT / "scripts/platform/Invoke-DDDAValidatePr.ps1").read_text(encoding="utf-8")
+    guards = (ROOT / "tests/powershell/Test-DDDAPromotionGuards.ps1").read_text(encoding="utf-8")
+
+    assert ".\\\\candidate\\\\ddda.ps1 test -Suite component -PrePromotionCandidate -NonInteractive" in workflow
+    assert "-PrePromotionCandidate" in workflow
+    assert "[switch]$PrePromotionCandidate" in cli
+    assert "[switch]$PrePromotionCandidate" in test_runner
+    assert "[switch]$PrePromotionCandidate" in validator
+    assert "[switch]$PrePromotionCandidate" in guards
+    assert "if (-not $PrePromotionCandidate)" in guards
+    assert "Public release promotion must stay strictly gated" in guards
+    assert "Assert-DDDAPlatformChangelogRelease" in guards

--- a/runtime/platform/tests/test_controlled_release_candidate.py
+++ b/runtime/platform/tests/test_controlled_release_candidate.py
@@ -103,7 +103,7 @@ def test_pre_promotion_candidate_validation_keeps_release_notes_for_promotion_on
     validator = (ROOT / "scripts/platform/Invoke-DDDAValidatePr.ps1").read_text(encoding="utf-8")
     guards = (ROOT / "tests/powershell/Test-DDDAPromotionGuards.ps1").read_text(encoding="utf-8")
 
-    assert ".\\\\candidate\\\\ddda.ps1 test -Suite component -PrePromotionCandidate -NonInteractive" in workflow
+    assert r".\candidate\ddda.ps1 test -Suite component -PrePromotionCandidate -NonInteractive" in workflow
     assert "-PrePromotionCandidate" in workflow
     assert "[switch]$PrePromotionCandidate" in cli
     assert "[switch]$PrePromotionCandidate" in test_runner

--- a/scripts/platform/Invoke-DDDAPlatformTest.ps1
+++ b/scripts/platform/Invoke-DDDAPlatformTest.ps1
@@ -12,6 +12,7 @@ param(
     [string]$MiroTeamId,
     [string]$MiroEvidenceOutputPath,
     [switch]$NonInteractive,
+    [switch]$PrePromotionCandidate,
     [switch]$Json
 )
 
@@ -214,7 +215,9 @@ function Invoke-OneSuite {
         }
         "component" {
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAValidationReport.ps1" -Arguments @("-PlatformPath", $platformRoot)
-            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAPromotionGuards.ps1" -Arguments @("-PlatformPath", $platformRoot)
+            $promotionGuardArguments = @("-PlatformPath", $platformRoot)
+            if ($PrePromotionCandidate) { $promotionGuardArguments += "-PrePromotionCandidate" }
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAPromotionGuards.ps1" -Arguments $promotionGuardArguments
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAReleasePublication.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroAutomation.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroEvidence.ps1" -Arguments @("-PlatformPath", $platformRoot)

--- a/scripts/platform/Invoke-DDDAValidatePr.ps1
+++ b/scripts/platform/Invoke-DDDAValidatePr.ps1
@@ -11,7 +11,8 @@ param(
     [switch]$KeepArtifacts,
     [switch]$KeepReviewBoard,
     [string]$MiroTeamId,
-    [switch]$NonInteractive
+    [switch]$NonInteractive,
+    [switch]$PrePromotionCandidate
 )
 
 Set-StrictMode -Version Latest
@@ -229,10 +230,12 @@ try {
     Assert-DDDAPlatformCleanGit -Repository $packageRoot -Label "Rozbalený candidate package"
 
     $commonArguments = @("-PackagePath", $candidatePackagePath)
+    $componentArguments = @("component")
+    if ($PrePromotionCandidate) { $componentArguments += "-PrePromotionCandidate" }
     Invoke-ValidationSuite -Name "lint" -Arguments @("lint")
     Invoke-ValidationSuite -Name "schema" -Arguments @("schema")
     Invoke-ValidationSuite -Name "unit" -Arguments @("unit")
-    Invoke-ValidationSuite -Name "component" -Arguments @("component")
+    Invoke-ValidationSuite -Name "component" -Arguments $componentArguments
     Invoke-ValidationSuite -Name "integration" -Arguments (@("integration") + $commonArguments)
     Invoke-ValidationSuite -Name "smoke" -Arguments (@("smoke") + $commonArguments)
     Invoke-ValidationSuite -Name "regression" -Arguments @("regression")

--- a/tests/powershell/Test-DDDAPromotionGuards.ps1
+++ b/tests/powershell/Test-DDDAPromotionGuards.ps1
@@ -1,6 +1,7 @@
 ﻿[CmdletBinding()]
 param(
-    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
+    [switch]$PrePromotionCandidate
 )
 
 Set-StrictMode -Version Latest
@@ -122,108 +123,115 @@ Assert-True -Condition ($releaseGovernanceSupport -match 'ddda:human-pr-review:v
 Assert-True -Condition ($releaseGovernanceSupport -match 'Get-DDDAHumanPrReviewComments') -Message "Governance support neumí načíst Human Review evidence."
 Assert-True -Condition ($releaseGovernanceSupport -notmatch 'Set-DDDAHumanPrReview') -Message "Automation support nesmí publikovat Human Review PASS setter."
 
-# Issue #88 regression: REST JSON arrays must be materialized before marker and
-# author extraction; only user.login is canonical and display name is ignored.
-$humanComment = [pscustomobject]@{
-    body = '<!-- ddda:human-pr-review:v1 -->'
-    user = [pscustomobject]@{
-        login = 'romanhlavac'
-        name = 'romanhlavac'
-        type = 'User'
+# Cross-stream integration assertions require the canonical main CI surface. A controlled
+# recovery candidate proves its own source before promotion, without requiring unrelated
+# future-release infrastructure.
+if (-not $PrePromotionCandidate) {
+    # Issue #88 regression: REST JSON arrays must be materialized before marker and
+    # author extraction; only user.login is canonical and display name is ignored.
+    $humanComment = [pscustomobject]@{
+        body = '<!-- ddda:human-pr-review:v1 -->'
+        user = [pscustomobject]@{
+            login = 'romanhlavac'
+            name = 'romanhlavac'
+            type = 'User'
+        }
     }
-}
-$humanReview = [pscustomobject]@{ reviewer = 'romanhlavac' }
-$canonicalLogin = Assert-DDDAHumanPrReviewCommentProvenance -Comment $humanComment -Review $humanReview
-Assert-True -Condition ($canonicalLogin -eq 'romanhlavac') -Message "Canonical Human Review author musí být pouze GitHub user.login."
-Assert-True -Condition ($canonicalLogin -notmatch '\s') -Message "Display name nesmí být concatenován do canonical GitHub loginu."
-
-$missingLoginComment = [pscustomobject]@{ user = [pscustomobject]@{ name = 'romanhlavac'; type = 'User' } }
-Assert-Throws -Action {
-    Assert-DDDAHumanPrReviewCommentProvenance -Comment $missingLoginComment -Review $humanReview
-} -Message "Chybějící Human Review user.login musí failnout closed."
-
-$ambiguousLoginComment = [pscustomobject]@{
-    user = [pscustomobject]@{ login = @('romanhlavac', 'other-user'); name = 'romanhlavac'; type = 'User' }
-}
-Assert-Throws -Action {
-    Assert-DDDAHumanPrReviewCommentProvenance -Comment $ambiguousLoginComment -Review $humanReview
-} -Message "Víceznačný Human Review user.login musí failnout closed."
-
-$botComment = [pscustomobject]@{ user = [pscustomobject]@{ login = 'reviewer[bot]'; name = 'Reviewer'; type = 'Bot' } }
-Assert-Throws -Action {
-    Assert-DDDAHumanPrReviewCommentProvenance -Comment $botComment -Review ([pscustomobject]@{ reviewer = 'reviewer[bot]' })
-} -Message "Bot Human Review author musí failnout closed."
-
-Assert-Throws -Action {
-    Assert-DDDAHumanPrReviewCommentProvenance -Comment $humanComment -Review ([pscustomobject]@{ reviewer = 'other-user' })
-} -Message "Human Review reviewer/user.login mismatch musí failnout closed."
-
-$reviewMarker = '<!-- ddda:human-pr-review:v1 -->'
-$script:humanReviewCommentApiResponse = @(
-    $humanComment,
-    [pscustomobject]@{
-        body = '<!-- ddda:human-pr-review-duplicate:v1 --> non-authoritative ddda:human-pr-review:v1'
-        user = [pscustomobject]@{ login = 'romanhlavac'; name = 'romanhlavac'; type = 'User' }
-    },
-    [pscustomobject]@{
-        body = '<!-- ddda:human-pr-review-superseded:v1 --> historical record'
-        user = [pscustomobject]@{ login = 'romanhlavac'; name = 'romanhlavac'; type = 'User' }
+    $humanReview = [pscustomobject]@{ reviewer = 'romanhlavac' }
+    $canonicalLogin = Assert-DDDAHumanPrReviewCommentProvenance -Comment $humanComment -Review $humanReview
+    Assert-True -Condition ($canonicalLogin -eq 'romanhlavac') -Message "Canonical Human Review author musí být pouze GitHub user.login."
+    Assert-True -Condition ($canonicalLogin -notmatch '\s') -Message "Display name nesmí být concatenován do canonical GitHub loginu."
+    
+    $missingLoginComment = [pscustomobject]@{ user = [pscustomobject]@{ name = 'romanhlavac'; type = 'User' } }
+    Assert-Throws -Action {
+        Assert-DDDAHumanPrReviewCommentProvenance -Comment $missingLoginComment -Review $humanReview
+    } -Message "Chybějící Human Review user.login musí failnout closed."
+    
+    $ambiguousLoginComment = [pscustomobject]@{
+        user = [pscustomobject]@{ login = @('romanhlavac', 'other-user'); name = 'romanhlavac'; type = 'User' }
     }
-)
-$originalGitHubApi = (Get-Command Invoke-DDDAGitHubApi).ScriptBlock
-try {
-    Set-Item -Path Function:Invoke-DDDAGitHubApi -Value {
-        param($Method, $Path, $Token, $Body)
-        Write-Output -NoEnumerate $script:humanReviewCommentApiResponse
+    Assert-Throws -Action {
+        Assert-DDDAHumanPrReviewCommentProvenance -Comment $ambiguousLoginComment -Review $humanReview
+    } -Message "Víceznačný Human Review user.login musí failnout closed."
+    
+    $botComment = [pscustomobject]@{ user = [pscustomobject]@{ login = 'reviewer[bot]'; name = 'Reviewer'; type = 'Bot' } }
+    Assert-Throws -Action {
+        Assert-DDDAHumanPrReviewCommentProvenance -Comment $botComment -Review ([pscustomobject]@{ reviewer = 'reviewer[bot]' })
+    } -Message "Bot Human Review author musí failnout closed."
+    
+    Assert-Throws -Action {
+        Assert-DDDAHumanPrReviewCommentProvenance -Comment $humanComment -Review ([pscustomobject]@{ reviewer = 'other-user' })
+    } -Message "Human Review reviewer/user.login mismatch musí failnout closed."
+    
+    $reviewMarker = '<!-- ddda:human-pr-review:v1 -->'
+    $script:humanReviewCommentApiResponse = @(
+        $humanComment,
+        [pscustomobject]@{
+            body = '<!-- ddda:human-pr-review-duplicate:v1 --> non-authoritative ddda:human-pr-review:v1'
+            user = [pscustomobject]@{ login = 'romanhlavac'; name = 'romanhlavac'; type = 'User' }
+        },
+        [pscustomobject]@{
+            body = '<!-- ddda:human-pr-review-superseded:v1 --> historical record'
+            user = [pscustomobject]@{ login = 'romanhlavac'; name = 'romanhlavac'; type = 'User' }
+        }
+    )
+    $originalGitHubApi = (Get-Command Invoke-DDDAGitHubApi).ScriptBlock
+    try {
+        Set-Item -Path Function:Invoke-DDDAGitHubApi -Value {
+            param($Method, $Path, $Token, $Body)
+            Write-Output -NoEnumerate $script:humanReviewCommentApiResponse
+        }
+        $selectedHumanComments = @(Get-DDDAHumanPrReviewComments -RepositorySlug 'romanhlavac/ddd-accelerator' -Pr 92 -Token 'test-only')
     }
-    $selectedHumanComments = @(Get-DDDAHumanPrReviewComments -RepositorySlug 'romanhlavac/ddd-accelerator' -Pr 92 -Token 'test-only')
+    finally {
+        Set-Item -Path Function:Invoke-DDDAGitHubApi -Value $originalGitHubApi
+    }
+    Assert-True -Condition ($selectedHumanComments.Count -eq 1) -Message "Právě jeden authoritative Human Review marker musí projít selection."
+    Assert-True -Condition ($selectedHumanComments[0].body -eq $reviewMarker) -Message "Duplicate/superseded Human Review marker musí být ignorován."
+    Assert-True -Condition ($releaseGovernanceSupport -match '\$response\s*=\s*Invoke-DDDAGitHubApi[\s\S]+?\$batch\s*=\s*@\(\$response\)') -Message "GitHub Issues Comments REST array musí být materializován před iterací."
+    
+    # Issue #88: one exact-SHA validation decision must preserve one canonical candidate identity.
+    Assert-True -Condition ($validatePr -match '\[string\]\$PackagePath') -Message "validate-pr nemá řízený PackagePath input."
+    Assert-True -Condition (([regex]::Matches($validatePr, 'New-DDDAPlatformPackage\.ps1')).Count -eq 1) -Message "validate-pr obsahuje více než jednu package build cestu."
+    Assert-True -Condition ($validatePr -match 'if\s*\(\[string\]::IsNullOrWhiteSpace\(\$PackagePath\)\)') -Message "validate-pr neomezuje package build pouze na chybějící PackagePath."
+    Assert-True -Condition ($validatePr -match 'ExpectedCommit[^\r\n]+\$headSha') -Message "validate-pr neověřuje source_commit předaného package."
+    Assert-True -Condition ($validatePr -match 'ExpectedKind[^\r\n]+candidate') -Message "validate-pr neověřuje kind=candidate."
+    Assert-True -Condition ($validationReport -match 'PackageArtifactName' -and $validationReport -match 'WorkflowRunId') -Message "Validation report neuchovává canonical artifact/run identity."
+    Assert-True -Condition ($validationReport -match 'PortablePaths') -Message "Validation report neumí odstranit runner-local cesty z publikované evidence."
+    Assert-True -Condition ($releaseGovernanceSupport -match '\[string\]\$ValidationReportPath' -and $releaseGovernanceSupport -match '\[string\]\$PackagePath') -Message "Merge evidence resolver neumí explicitní artifact/report z čistého runneru."
+    Assert-True -Condition ($governedMerge -match 'ExpectedCommit[^\r\n]+\$headSha' -and $governedMerge -match 'ExpectedKind[^\r\n]+candidate') -Message "merge-pr znovu neověřuje candidate kind/source_commit."
+    Assert-True -Condition ($platformCi -match '(?s)validate-pr-command:\s+name: One-command PR validation\s+needs: validate-platform') -Message "validate-pr-command nezávisí na canonical package jobu."
+    Assert-True -Condition ($platformCi -match 'Download canonical candidate package') -Message "validate-pr-command nestahuje canonical candidate artifact."
+    Assert-True -Condition ($platformCi -match '-PackagePath \$packages\[0\]\.FullName') -Message "CI nepředává stažený canonical package do validate-pr."
+    Assert-True -Condition ($platformCi -match '\$version = ''candidate\.''' -and $platformCi -notmatch '\$version = ''ci\.''' ) -Message "Candidate metadata není stabilně odvozeno pouze z exact SHA."
+    Assert-True -Condition ($secondaryCi -notmatch 'New-DDDAPlatformPackage\.ps1') -Message "Sekundární CI workflow nesmí vytvářet nezávislý candidate package."
+    $workflowCandidateBuilders = @(
+        Get-ChildItem -LiteralPath (Join-Path $platformRoot '.github/workflows') -Filter '*.yml' -File |
+            Select-String -Pattern 'New-DDDAPlatformPackage\.ps1'
+    )
+    Assert-True -Condition ($workflowCandidateBuilders.Count -eq 1 -and $workflowCandidateBuilders[0].Path -eq $platformCiPath) -Message "Repository musí mít právě jeden CI candidate builder v canonical platform workflow."
+    $humanReadinessJob = [regex]::Match($platformCi, '(?ms)^  human-review-readiness:\r?\n(?<body>.*?)(?=^  governed-merge-dry-run:)')
+    $mergeDryRunJob = [regex]::Match($platformCi, '(?ms)^  governed-merge-dry-run:\r?\n(?<body>.*)\z')
+    Assert-True -Condition $humanReadinessJob.Success -Message "Standard CI nemá samostatný Human Review readiness coordinator."
+    Assert-True -Condition $mergeDryRunJob.Success -Message "Standard CI nemá samostatný governed merge dry-run job."
+    $humanReadinessBody = $humanReadinessJob.Groups['body'].Value
+    $mergeDryRunBody = $mergeDryRunJob.Groups['body'].Value
+    Assert-True -Condition ($humanReadinessBody -match 'name: Human Review readiness') -Message "Readiness coordinator není jednoznačně pojmenovaný."
+    Assert-True -Condition ($humanReadinessBody -match 'ready:\s+\$\{\{\s*steps\.human-review\.outputs\.ready\s*\}\}') -Message "Readiness coordinator nepublikuje machine-readable ready output."
+    Assert-True -Condition ($humanReadinessBody -match 'PENDING.+Governed merge dry-run.+NOT_RUN') -Message "Pre-HR stav není explicitně reportován jako PENDING / NOT_RUN."
+    Assert-True -Condition ($humanReadinessBody -notmatch 'ddda\.ps1 merge-pr') -Message "Readiness coordinator nesmí být současně merge preflight."
+    Assert-True -Condition ($mergeDryRunBody -match '(?s)needs:.+?- human-review-readiness') -Message "Governed merge dry-run nezávisí na readiness coordinatoru."
+    Assert-True -Condition ($mergeDryRunBody -match "if: github\.event_name == 'pull_request' && needs\.human-review-readiness\.outputs\.ready == 'true'") -Message "Governed merge dry-run není na job-level blokovaný Human Review readiness."
+    Assert-True -Condition ($mergeDryRunBody -notmatch 'steps\.human-review\.outputs\.ready') -Message "Governed merge dry-run stále používá step-level skip, který může vytvořit false PASS."
+    Assert-True -Condition ($mergeDryRunBody -match 'Download exact-run canonical candidate' -and $mergeDryRunBody -match 'Download exact-run validation evidence') -Message "Governed merge dry-run nestahuje exact-run candidate a report."
+    Assert-True -Condition ($mergeDryRunBody -match '\.\\ddda\.ps1 merge-pr' -and $mergeDryRunBody -match '-ValidationReportPath \$reports\[0\]\.FullName' -and $mergeDryRunBody -match '-DryRun') -Message "Governed merge dry-run neprovádí skutečný isolated merge-pr -DryRun."
+    Assert-True -Condition ($mergeDryRunBody -notmatch 'New-DDDAPlatformPackage\.ps1') -Message "Post-HR merge dry-run nesmí znovu sestavit candidate package."
+    Assert-True -Condition ($mergeDryRunBody -match 'packages\.Count -ne 1' -and $mergeDryRunBody -match 'reports\.Count -ne 1') -Message "Artifact resolution není fail-closed pro chybějící/víceznačnou evidence."
+    Assert-True -Condition ($remoteBroker -match 'actions: read') -Message "Remote broker nemá read-only přístup k canonical Actions artifactu."
+    Assert-True -Condition ($remoteBroker -match 'Download exact-SHA canonical candidate' -and $remoteBroker -match '-PackageWorkflowRunId') -Message "Remote broker stále vytváří nezávislou candidate identity."
+    
+    
 }
-finally {
-    Set-Item -Path Function:Invoke-DDDAGitHubApi -Value $originalGitHubApi
-}
-Assert-True -Condition ($selectedHumanComments.Count -eq 1) -Message "Právě jeden authoritative Human Review marker musí projít selection."
-Assert-True -Condition ($selectedHumanComments[0].body -eq $reviewMarker) -Message "Duplicate/superseded Human Review marker musí být ignorován."
-Assert-True -Condition ($releaseGovernanceSupport -match '\$response\s*=\s*Invoke-DDDAGitHubApi[\s\S]+?\$batch\s*=\s*@\(\$response\)') -Message "GitHub Issues Comments REST array musí být materializován před iterací."
-
-# Issue #88: one exact-SHA validation decision must preserve one canonical candidate identity.
-Assert-True -Condition ($validatePr -match '\[string\]\$PackagePath') -Message "validate-pr nemá řízený PackagePath input."
-Assert-True -Condition (([regex]::Matches($validatePr, 'New-DDDAPlatformPackage\.ps1')).Count -eq 1) -Message "validate-pr obsahuje více než jednu package build cestu."
-Assert-True -Condition ($validatePr -match 'if\s*\(\[string\]::IsNullOrWhiteSpace\(\$PackagePath\)\)') -Message "validate-pr neomezuje package build pouze na chybějící PackagePath."
-Assert-True -Condition ($validatePr -match 'ExpectedCommit[^\r\n]+\$headSha') -Message "validate-pr neověřuje source_commit předaného package."
-Assert-True -Condition ($validatePr -match 'ExpectedKind[^\r\n]+candidate') -Message "validate-pr neověřuje kind=candidate."
-Assert-True -Condition ($validationReport -match 'PackageArtifactName' -and $validationReport -match 'WorkflowRunId') -Message "Validation report neuchovává canonical artifact/run identity."
-Assert-True -Condition ($validationReport -match 'PortablePaths') -Message "Validation report neumí odstranit runner-local cesty z publikované evidence."
-Assert-True -Condition ($releaseGovernanceSupport -match '\[string\]\$ValidationReportPath' -and $releaseGovernanceSupport -match '\[string\]\$PackagePath') -Message "Merge evidence resolver neumí explicitní artifact/report z čistého runneru."
-Assert-True -Condition ($governedMerge -match 'ExpectedCommit[^\r\n]+\$headSha' -and $governedMerge -match 'ExpectedKind[^\r\n]+candidate') -Message "merge-pr znovu neověřuje candidate kind/source_commit."
-Assert-True -Condition ($platformCi -match '(?s)validate-pr-command:\s+name: One-command PR validation\s+needs: validate-platform') -Message "validate-pr-command nezávisí na canonical package jobu."
-Assert-True -Condition ($platformCi -match 'Download canonical candidate package') -Message "validate-pr-command nestahuje canonical candidate artifact."
-Assert-True -Condition ($platformCi -match '-PackagePath \$packages\[0\]\.FullName') -Message "CI nepředává stažený canonical package do validate-pr."
-Assert-True -Condition ($platformCi -match '\$version = ''candidate\.''' -and $platformCi -notmatch '\$version = ''ci\.''' ) -Message "Candidate metadata není stabilně odvozeno pouze z exact SHA."
-Assert-True -Condition ($secondaryCi -notmatch 'New-DDDAPlatformPackage\.ps1') -Message "Sekundární CI workflow nesmí vytvářet nezávislý candidate package."
-$workflowCandidateBuilders = @(
-    Get-ChildItem -LiteralPath (Join-Path $platformRoot '.github/workflows') -Filter '*.yml' -File |
-        Select-String -Pattern 'New-DDDAPlatformPackage\.ps1'
-)
-Assert-True -Condition ($workflowCandidateBuilders.Count -eq 1 -and $workflowCandidateBuilders[0].Path -eq $platformCiPath) -Message "Repository musí mít právě jeden CI candidate builder v canonical platform workflow."
-$humanReadinessJob = [regex]::Match($platformCi, '(?ms)^  human-review-readiness:\r?\n(?<body>.*?)(?=^  governed-merge-dry-run:)')
-$mergeDryRunJob = [regex]::Match($platformCi, '(?ms)^  governed-merge-dry-run:\r?\n(?<body>.*)\z')
-Assert-True -Condition $humanReadinessJob.Success -Message "Standard CI nemá samostatný Human Review readiness coordinator."
-Assert-True -Condition $mergeDryRunJob.Success -Message "Standard CI nemá samostatný governed merge dry-run job."
-$humanReadinessBody = $humanReadinessJob.Groups['body'].Value
-$mergeDryRunBody = $mergeDryRunJob.Groups['body'].Value
-Assert-True -Condition ($humanReadinessBody -match 'name: Human Review readiness') -Message "Readiness coordinator není jednoznačně pojmenovaný."
-Assert-True -Condition ($humanReadinessBody -match 'ready:\s+\$\{\{\s*steps\.human-review\.outputs\.ready\s*\}\}') -Message "Readiness coordinator nepublikuje machine-readable ready output."
-Assert-True -Condition ($humanReadinessBody -match 'PENDING.+Governed merge dry-run.+NOT_RUN') -Message "Pre-HR stav není explicitně reportován jako PENDING / NOT_RUN."
-Assert-True -Condition ($humanReadinessBody -notmatch 'ddda\.ps1 merge-pr') -Message "Readiness coordinator nesmí být současně merge preflight."
-Assert-True -Condition ($mergeDryRunBody -match '(?s)needs:.+?- human-review-readiness') -Message "Governed merge dry-run nezávisí na readiness coordinatoru."
-Assert-True -Condition ($mergeDryRunBody -match "if: github\.event_name == 'pull_request' && needs\.human-review-readiness\.outputs\.ready == 'true'") -Message "Governed merge dry-run není na job-level blokovaný Human Review readiness."
-Assert-True -Condition ($mergeDryRunBody -notmatch 'steps\.human-review\.outputs\.ready') -Message "Governed merge dry-run stále používá step-level skip, který může vytvořit false PASS."
-Assert-True -Condition ($mergeDryRunBody -match 'Download exact-run canonical candidate' -and $mergeDryRunBody -match 'Download exact-run validation evidence') -Message "Governed merge dry-run nestahuje exact-run candidate a report."
-Assert-True -Condition ($mergeDryRunBody -match '\.\\ddda\.ps1 merge-pr' -and $mergeDryRunBody -match '-ValidationReportPath \$reports\[0\]\.FullName' -and $mergeDryRunBody -match '-DryRun') -Message "Governed merge dry-run neprovádí skutečný isolated merge-pr -DryRun."
-Assert-True -Condition ($mergeDryRunBody -notmatch 'New-DDDAPlatformPackage\.ps1') -Message "Post-HR merge dry-run nesmí znovu sestavit candidate package."
-Assert-True -Condition ($mergeDryRunBody -match 'packages\.Count -ne 1' -and $mergeDryRunBody -match 'reports\.Count -ne 1') -Message "Artifact resolution není fail-closed pro chybějící/víceznačnou evidence."
-Assert-True -Condition ($remoteBroker -match 'actions: read') -Message "Remote broker nemá read-only přístup k canonical Actions artifactu."
-Assert-True -Condition ($remoteBroker -match 'Download exact-SHA canonical candidate' -and $remoteBroker -match '-PackageWorkflowRunId') -Message "Remote broker stále vytváří nezávislou candidate identity."
 
 # Public release promotion must stay strictly gated before the release executor is reachable.
 $scopeGateMatch = [regex]::Match($governedPromotion, 'release_scope_gate_status[^\r\n]+PASS', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)

--- a/tests/powershell/Test-DDDAPromotionGuards.ps1
+++ b/tests/powershell/Test-DDDAPromotionGuards.ps1
@@ -141,28 +141,28 @@ if (-not $PrePromotionCandidate) {
     $canonicalLogin = Assert-DDDAHumanPrReviewCommentProvenance -Comment $humanComment -Review $humanReview
     Assert-True -Condition ($canonicalLogin -eq 'romanhlavac') -Message "Canonical Human Review author musí být pouze GitHub user.login."
     Assert-True -Condition ($canonicalLogin -notmatch '\s') -Message "Display name nesmí být concatenován do canonical GitHub loginu."
-    
+
     $missingLoginComment = [pscustomobject]@{ user = [pscustomobject]@{ name = 'romanhlavac'; type = 'User' } }
     Assert-Throws -Action {
         Assert-DDDAHumanPrReviewCommentProvenance -Comment $missingLoginComment -Review $humanReview
     } -Message "Chybějící Human Review user.login musí failnout closed."
-    
+
     $ambiguousLoginComment = [pscustomobject]@{
         user = [pscustomobject]@{ login = @('romanhlavac', 'other-user'); name = 'romanhlavac'; type = 'User' }
     }
     Assert-Throws -Action {
         Assert-DDDAHumanPrReviewCommentProvenance -Comment $ambiguousLoginComment -Review $humanReview
     } -Message "Víceznačný Human Review user.login musí failnout closed."
-    
+
     $botComment = [pscustomobject]@{ user = [pscustomobject]@{ login = 'reviewer[bot]'; name = 'Reviewer'; type = 'Bot' } }
     Assert-Throws -Action {
         Assert-DDDAHumanPrReviewCommentProvenance -Comment $botComment -Review ([pscustomobject]@{ reviewer = 'reviewer[bot]' })
     } -Message "Bot Human Review author musí failnout closed."
-    
+
     Assert-Throws -Action {
         Assert-DDDAHumanPrReviewCommentProvenance -Comment $humanComment -Review ([pscustomobject]@{ reviewer = 'other-user' })
     } -Message "Human Review reviewer/user.login mismatch musí failnout closed."
-    
+
     $reviewMarker = '<!-- ddda:human-pr-review:v1 -->'
     $script:humanReviewCommentApiResponse = @(
         $humanComment,
@@ -189,7 +189,7 @@ if (-not $PrePromotionCandidate) {
     Assert-True -Condition ($selectedHumanComments.Count -eq 1) -Message "Právě jeden authoritative Human Review marker musí projít selection."
     Assert-True -Condition ($selectedHumanComments[0].body -eq $reviewMarker) -Message "Duplicate/superseded Human Review marker musí být ignorován."
     Assert-True -Condition ($releaseGovernanceSupport -match '\$response\s*=\s*Invoke-DDDAGitHubApi[\s\S]+?\$batch\s*=\s*@\(\$response\)') -Message "GitHub Issues Comments REST array musí být materializován před iterací."
-    
+
     # Issue #88: one exact-SHA validation decision must preserve one canonical candidate identity.
     Assert-True -Condition ($validatePr -match '\[string\]\$PackagePath') -Message "validate-pr nemá řízený PackagePath input."
     Assert-True -Condition (([regex]::Matches($validatePr, 'New-DDDAPlatformPackage\.ps1')).Count -eq 1) -Message "validate-pr obsahuje více než jednu package build cestu."
@@ -229,8 +229,8 @@ if (-not $PrePromotionCandidate) {
     Assert-True -Condition ($mergeDryRunBody -match 'packages\.Count -ne 1' -and $mergeDryRunBody -match 'reports\.Count -ne 1') -Message "Artifact resolution není fail-closed pro chybějící/víceznačnou evidence."
     Assert-True -Condition ($remoteBroker -match 'actions: read') -Message "Remote broker nemá read-only přístup k canonical Actions artifactu."
     Assert-True -Condition ($remoteBroker -match 'Download exact-SHA canonical candidate' -and $remoteBroker -match '-PackageWorkflowRunId') -Message "Remote broker stále vytváří nezávislou candidate identity."
-    
-    
+
+
 }
 
 # Public release promotion must stay strictly gated before the release executor is reachable.


### PR DESCRIPTION
## Scope

Implements #96

This is a narrow repair of the controlled-candidate **technical validation harness**.

- A controlled recovery candidate may prove its exact source before it becomes a final release cut.
- Technical validation now uses an explicit pre-promotion mode, which skips only cross-stream assertions requiring the canonical `main` CI surface.
- `promote-pr` and its fail-closed requirement for versioned release notes remain unchanged.
- Regression coverage verifies the switch is passed only through candidate technical validation and that final promotion guards still include the changelog/release-notes check.

No release, tag, GitHub Release, promotion, candidate reconstruction, Project/milestone/scope change, or CR closure is performed by this PR.