### PR TITLE
fix(release): stage exact candidate validation evidence

### DIFF
--- a/.github/workflows/controlled-release-candidate-validation.yml
+++ b/.github/workflows/controlled-release-candidate-validation.yml
@@ -145,14 +145,35 @@ jobs:
             -PrePromotionCandidate `
             -NonInteractive
 
+      - name: Stage exact validation evidence
+        if: success()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $sourceRoot = Join-Path $env:LOCALAPPDATA 'DDDA'
+          $stageRoot = Join-Path $env:RUNNER_TEMP 'controlled-candidate-evidence'
+          $reportRoot = Join-Path $sourceRoot "validation-reports/pr-$env:CANDIDATE_PR-$env:SOURCE_SHA"
+          $packageRoot = Join-Path $sourceRoot 'packages'
+          $packages = @(Get-ChildItem -LiteralPath $packageRoot -Filter "ddda-candidate-pr-$env:CANDIDATE_PR-$env:SOURCE_SHA-*.zip" -File -ErrorAction SilentlyContinue)
+
+          if (-not (Test-Path -LiteralPath $reportRoot -PathType Container)) {
+            throw "Exact validation report root was not produced: $reportRoot"
+          }
+          if ($packages.Count -ne 1) {
+            throw "Expected exactly one exact candidate package for PR $env:CANDIDATE_PR / $env:SOURCE_SHA, found $($packages.Count)."
+          }
+
+          Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $stageRoot -Force | Out-Null
+          Copy-Item -LiteralPath $reportRoot -Destination (Join-Path $stageRoot 'validation-reports') -Recurse -Force
+          Copy-Item -LiteralPath $packages[0].FullName -Destination (Join-Path $stageRoot $packages[0].Name) -Force
+
       - name: Upload validation evidence
         if: success()
         uses: actions/upload-artifact@v4
         with:
           name: controlled-candidate-validation-${{ env.CANDIDATE_PR }}-${{ env.SOURCE_SHA }}
-          path: |
-            ${{ env.LOCALAPPDATA }}/DDDA/validation-reports/pr-${{ env.CANDIDATE_PR }}-${{ env.SOURCE_SHA }}/**
-            ${{ env.LOCALAPPDATA }}/DDDA/packages/ddda-candidate-pr-${{ env.CANDIDATE_PR }}-${{ env.SOURCE_SHA }}-*.zip
+          path: ${{ runner.temp }}/controlled-candidate-evidence/**
           if-no-files-found: error
           retention-days: 14
 

--- a/docs/adr/0013-controlled-release-candidate-validation.md
+++ b/docs/adr/0013-controlled-release-candidate-validation.md
@@ -56,3 +56,15 @@ This mode never authorizes promotion. The `promote-pr` path remains unchanged an
 fail-closed: before any tag or GitHub Release, the release must contain versioned release
 notes and pass the final promotion guards. A technical PASS is evidence of candidate
 integrity, not a release decision.
+
+
+## Evidence staging boundary
+
+Runner-local environment variables are not evaluated in an action input expression.
+After successful technical validation, the workflow therefore stages the exact report
+directory and the single exact candidate package from `$env:LOCALAPPDATA` into
+`$env:RUNNER_TEMP`. The upload action consumes only that staged directory.
+
+Staging fails closed if the report directory is missing or the exact package count is
+not one. This keeps artifact upload bound to the selected PR and SHA while avoiding a
+silent empty upload.

--- a/runtime/platform/tests/test_controlled_release_candidate.py
+++ b/runtime/platform/tests/test_controlled_release_candidate.py
@@ -112,3 +112,15 @@ def test_pre_promotion_candidate_validation_keeps_release_notes_for_promotion_on
     assert "if (-not $PrePromotionCandidate)" in guards
     assert "Public release promotion must stay strictly gated" in guards
     assert "Assert-DDDAPlatformChangelogRelease" in guards
+
+
+def test_technical_validation_stages_runner_local_evidence_before_upload() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Stage exact validation evidence" in workflow
+    assert "$env:LOCALAPPDATA" in workflow
+    assert "$env:RUNNER_TEMP" in workflow
+    assert "Expected exactly one exact candidate package" in workflow
+    assert "${{ runner.temp }}/controlled-candidate-evidence/**" in workflow
+    assert "${{ env.LOCALAPPDATA }}" not in workflow
+    assert "if-no-files-found: error" in workflow


### PR DESCRIPTION
## Purpose

Repairs the controlled-candidate technical validation artifact upload after run #33260207920.

The exact candidate source and canonical `validate-pr` both passed. The workflow then failed only because `actions/upload-artifact` tried to resolve `LOCALAPPDATA` as a GitHub expression, producing an empty path.

Implements #96

## Change

- stage the exact report directory and exactly one exact candidate package from runner-local `LOCALAPPDATA` into `RUNNER_TEMP`;
- upload only that staged directory;
- fail closed on a missing report root or an ambiguous/missing exact package;
- add a regression assertion and document the runner-expression boundary.

## Boundary

No candidate reconstruction, release, tag, GitHub Release, promotion, Project, milestone, declared scope or CR-state change. PR #103 stays Draft and audit-only.