### PR TITLE
fix(release): page controlled candidate evidence

### DIFF
--- a/.github/workflows/controlled-release-candidate-validation.yml
+++ b/.github/workflows/controlled-release-candidate-validation.yml
@@ -232,8 +232,9 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $artifactName = "controlled-candidate-validation-$env:CANDIDATE_PR-$env:SOURCE_SHA"
-          $all = gh api --paginate "repos/$env:REPOSITORY/actions/artifacts?per_page=100" | ConvertFrom-Json
-          $matches = @($all.artifacts | Where-Object { $_.name -eq $artifactName -and -not $_.expired })
+          $pages = @(gh api --paginate --slurp "repos/$env:REPOSITORY/actions/artifacts?per_page=100" | ConvertFrom-Json)
+          $artifacts = @($pages | ForEach-Object { @($_.artifacts) })
+          $matches = @($artifacts | Where-Object { $_.name -eq $artifactName -and -not $_.expired })
           if ($matches.Count -ne 1) { throw "Expected exactly one unexpired exact validation artifact '$artifactName', found $($matches.Count)." }
           gh api -H "Accept: application/vnd.github+json" "repos/$env:REPOSITORY/actions/artifacts/$($matches[0].id)/zip" > validation-evidence.zip
           Expand-Archive -LiteralPath validation-evidence.zip -DestinationPath validation-evidence -Force
@@ -321,8 +322,9 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $artifactName = "controlled-candidate-validation-$env:CANDIDATE_PR-$env:SOURCE_SHA"
-          $all = gh api --paginate "repos/$env:REPOSITORY/actions/artifacts?per_page=100" | ConvertFrom-Json
-          $matches = @($all.artifacts | Where-Object { $_.name -eq $artifactName -and -not $_.expired })
+          $pages = @(gh api --paginate --slurp "repos/$env:REPOSITORY/actions/artifacts?per_page=100" | ConvertFrom-Json)
+          $artifacts = @($pages | ForEach-Object { @($_.artifacts) })
+          $matches = @($artifacts | Where-Object { $_.name -eq $artifactName -and -not $_.expired })
           if ($matches.Count -ne 1) { throw "Expected exactly one unexpired exact validation artifact '$artifactName', found $($matches.Count)." }
           gh api -H "Accept: application/vnd.github+json" "repos/$env:REPOSITORY/actions/artifacts/$($matches[0].id)/zip" > validation-evidence.zip
           Expand-Archive -LiteralPath validation-evidence.zip -DestinationPath validation-evidence -Force

--- a/docs/adr/0013-controlled-release-candidate-validation.md
+++ b/docs/adr/0013-controlled-release-candidate-validation.md
@@ -80,3 +80,13 @@ upload.
 
 A missing report, invalid identity, unsafe package record, absent package or hash
 mismatch fails closed. The filename alone is never treated as exact candidate evidence.
+
+
+## Artifact pagination boundary
+
+Artifact discovery is repository-wide and may exceed one API page. The workflow
+therefore collects GitHub Actions artifact pages with a JSON-safe paged response,
+flattens only their artifacts arrays and then requires exactly one unexpired
+artifact with the exact candidate identity. A pagination, response-shape or
+identity ambiguity remains fail-closed; it cannot select an arbitrary first
+artifact or silently narrow the evidence set.

--- a/runtime/platform/tests/test_controlled_release_candidate.py
+++ b/runtime/platform/tests/test_controlled_release_candidate.py
@@ -130,3 +130,12 @@ def test_technical_validation_stages_report_bound_exact_evidence_before_upload()
     assert "${{ runner.temp }}/controlled-candidate-evidence/**" in workflow
     assert "${{ env.LOCALAPPDATA }}" not in workflow
     assert "if-no-files-found: error" in workflow
+
+def test_restored_candidate_evidence_aggregates_paginated_artifact_pages_fail_closed() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert workflow.count('gh api --paginate --slurp "repos/$env:REPOSITORY/actions/artifacts?per_page=100"') == 2
+    assert workflow.count('$pages = @(gh api --paginate --slurp') == 2
+    assert workflow.count('$artifacts = @($pages | ForEach-Object { @($_.artifacts) })') == 2
+    assert '$all.artifacts' not in workflow
+    assert workflow.count("Expected exactly one unexpired exact validation artifact") == 2


### PR DESCRIPTION
Implements #96

## Purpose

Fixes fail-closed artifact discovery for the controlled release-candidate workflow when GitHub Actions returns more than one artifact page.

## Change

- collect paginated artifact responses as JSON-safe pages;
- flatten only their artifact arrays;
- still require exactly one unexpired artifact for the exact candidate identity;
- add a regression contract and document the pagination boundary.

## Boundary

No candidate reconstruction, merge, release, promotion, tag, GitHub Release, Project, milestone, declared-scope or CR-state change. PR #103 remains Draft and audit-only.

## Governance classification

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"impact":"HIGH"}
```