### PR TITLE
fix(release): forward HRDR candidate evidence

### DIFF
--- a/ddda.ps1
+++ b/ddda.ps1
@@ -10,6 +10,7 @@ param(
     [int]$Pr,
     [string]$Version,
     [string]$PackagePath,
+    [string]$CandidatePackagePath,
     [string]$PackageArtifactName,
     [string]$PackageWorkflowRunId,
     [string]$ValidationReportPath,
@@ -127,6 +128,8 @@ switch ($Command) {
         $arguments = @("-PlatformPath", $platformRoot, "-Pr", [string]$Pr, "-Version", $Version)
         if (-not [string]::IsNullOrWhiteSpace($Reviewer)) { $arguments += @("-Reviewer", $Reviewer) }
         if (-not [string]::IsNullOrWhiteSpace($DecisionOwner)) { $arguments += @("-DecisionOwner", $DecisionOwner) }
+        if (-not [string]::IsNullOrWhiteSpace($ValidationReportPath)) { $arguments += @("-ValidationReportPath", $ValidationReportPath) }
+        if (-not [string]::IsNullOrWhiteSpace($CandidatePackagePath)) { $arguments += @("-CandidatePackagePath", $CandidatePackagePath) }
         if ($PublishScaffold) { $arguments += "-PublishScaffold" }
         Invoke-DDDACommandScript -RelativePath "scripts/platform/Invoke-DDDAReviewPr.ps1" -Arguments $arguments
     }

--- a/docs/adr/0013-controlled-release-candidate-validation.md
+++ b/docs/adr/0013-controlled-release-candidate-validation.md
@@ -90,3 +90,16 @@ flattens only their artifacts arrays and then requires exactly one unexpired
 artifact with the exact candidate identity. A pagination, response-shape or
 identity ambiguity remains fail-closed; it cannot select an arbitrary first
 artifact or silently narrow the evidence set.
+
+## HRDR canonical evidence handoff
+
+The controlled-candidate workflow restores both the canonical validation report and
+the one report-bound candidate package before it creates a pending HRDR. Its
+public `ddda.ps1 review-pr` entrypoint explicitly accepts and forwards
+`CandidatePackagePath` together with `ValidationReportPath` to the review
+command. The review command then rechecks the report/package identity and hash.
+
+This keeps the HRDR bound to the already validated physical package. It neither
+rebuilds a candidate nor permits a filename-only or ambient-artifact fallback;
+an unsupported or missing evidence handoff fails before any pending HRDR comment
+is written.

--- a/runtime/platform/tests/test_controlled_release_candidate.py
+++ b/runtime/platform/tests/test_controlled_release_candidate.py
@@ -139,3 +139,14 @@ def test_restored_candidate_evidence_aggregates_paginated_artifact_pages_fail_cl
     assert workflow.count('$artifacts = @($pages | ForEach-Object { @($_.artifacts) })') == 2
     assert '$all.artifacts' not in workflow
     assert workflow.count("Expected exactly one unexpired exact validation artifact") == 2
+
+def test_hrdr_scaffold_forwards_report_bound_package_through_public_review_entrypoint() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    cli = (ROOT / "ddda.ps1").read_text(encoding="utf-8")
+    review_command = (ROOT / "scripts/platform/Invoke-DDDAReviewPr.ps1").read_text(encoding="utf-8")
+
+    assert "-CandidatePackagePath $env:candidate_package" in workflow
+    assert "[string]$CandidatePackagePath" in cli
+    assert 'if (-not [string]::IsNullOrWhiteSpace($CandidatePackagePath)) { $arguments += @("-CandidatePackagePath", $CandidatePackagePath) }' in cli
+    assert "[string]$CandidatePackagePath" in review_command
+    assert "-PackagePath $CandidatePackagePath" in review_command


### PR DESCRIPTION
Implements #96

## Purpose

Repairs the public `review-pr` entrypoint used by the controlled-candidate HRDR scaffold so the report-bound candidate package reaches the evidence verifier.

## Change

- accept and forward `CandidatePackagePath` with the canonical validation report;
- regression-test the complete workflow → public entrypoint → review-command handoff;
- document the no-rebuild, fail-closed evidence boundary.

## Boundary

No candidate reconstruction, merge, release, promotion, tag, GitHub Release, Project, milestone, declared-scope or CR-state change. PR #103 remains Draft and audit-only.

## Governance classification

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"impact":"HIGH"}
```