### PR TITLE
fix(governance): distinguish active release train

### DIFF
--- a/docs/adr/0012-future-release-metadata-merge-eligibility.md
+++ b/docs/adr/0012-future-release-metadata-merge-eligibility.md
@@ -12,11 +12,22 @@ active release. It also blocked PRs which only define the versioned plan and
 Project projection for later releases: those PRs have a future CR but ship no
 runtime or active-release content.
 
+Open GitHub Milestones alone cannot identify the active train: planned future
+versions may legitimately be open for roadmap visibility. The collector must
+therefore distinguish the sole versioned active train from those future plans
+without rewriting their live milestone state.
+
 ## Decision
 
-The read-only merge eligibility collector may permit a future-release planning
-PR only when it proves all of the following from live GitHub data and the exact
-base/head Git trees:
+The read-only merge eligibility collector derives the active train from the
+exact PR-base `backlog-policy.yaml`: exactly one `DDDA X.Y.Z` entry must be
+declared `open`, and exactly one live open Milestone with that same title must
+exist. Any other open DDDA Milestone remains a planned future train; it cannot
+change merge eligibility merely through its live state. Missing, duplicate or
+non-live active evidence fails closed.
+
+The collector may permit a future-release planning PR only when it proves all
+of the following from live GitHub data and the exact base/head Git trees:
 
 - its changed-path set is exactly the four versioned planning paths;
 - every changed file is a modification, not an add, rename or delete;
@@ -56,6 +67,7 @@ through this allowance.
 
 - a runtime, release or active-scope change remains blocked outside the active
   train;
+- an open future Milestone cannot silently become the active train;
 - missing, ambiguous or stale GitHub/file evidence fails closed; and
 - future milestones remain versioned Git authority and are projected only by
   the canonical reconciler after their PR is governed-merged.

--- a/runtime/platform/tests/test_merge_release_eligibility_collector.py
+++ b/runtime/platform/tests/test_merge_release_eligibility_collector.py
@@ -235,3 +235,35 @@ def test_governance_repair_transition_requires_exact_base_marker_and_paths(monke
     )
 
     assert result["status"] == "PASS"
+
+
+def test_active_release_uses_versioned_policy_for_one_open_active_train() -> None:
+    backlog_policy = """
+milestones:
+  initial:
+    - name: DDDA 0.1.1
+      state: open
+      issues: [9, 12]
+"""
+    milestones = [
+        {"title": "DDDA 0.1.1", "state": "open"},
+        {"title": "DDDA 0.1.2", "state": "open"},
+        {"title": "DDDA 0.2.0", "state": "open"},
+    ]
+
+    assert COLLECTOR.active_release(milestones, backlog_policy) == {"version": "0.1.1"}
+
+
+def test_active_release_fails_closed_when_versioned_active_train_is_not_live() -> None:
+    backlog_policy = """
+milestones:
+  initial:
+    - name: DDDA 0.1.1
+      state: open
+"""
+    try:
+        COLLECTOR.active_release([{"title": "DDDA 0.1.2", "state": "open"}], backlog_policy)
+    except COLLECTOR.GitHubReadError as exc:
+        assert "exactly one live active" in str(exc)
+    else:
+        raise AssertionError("expected missing live active train to fail closed")

--- a/scripts/platform/Test-DDDAMergeReleaseEligibility.py
+++ b/scripts/platform/Test-DDDAMergeReleaseEligibility.py
@@ -149,8 +149,21 @@ def configured_active_release(backlog_policy: str) -> str | None:
 
 
 def active_release(
-    milestones: list[dict[str, Any]], backlog_policy: str
+    milestones: list[dict[str, Any]], backlog_policy: str | None = None
 ) -> dict[str, str] | None:
+    if backlog_policy is None:
+        matches = [
+            match.group("version")
+            for milestone in milestones
+            if milestone.get("state") == "open"
+            if (match := MILESTONE_RE.fullmatch(str(milestone.get("title") or "")))
+        ]
+        if not matches:
+            return None
+        if len(matches) != 1:
+            raise GitHubReadError(f"Expected at most one active DDDA release train, found {sorted(matches)}")
+        return {"version": matches[0]}
+
     configured = configured_active_release(backlog_policy)
     if configured is None:
         return None

--- a/scripts/platform/Test-DDDAMergeReleaseEligibility.py
+++ b/scripts/platform/Test-DDDAMergeReleaseEligibility.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """Read-only releasable-main guard for governed implementation merges.
 
-The active train is the single open ``DDDA X.Y.Z`` Milestone.  While it
-exists, a PR may merge to main only when its one primary Change Request is in
-that Milestone.  The script never changes a Milestone, Project field or PR.
+The active train is the one release version declared open in versioned
+backlog policy and evidenced by its live ``DDDA X.Y.Z`` Milestone. Other
+open DDDA Milestones may be planned future trains and cannot become active
+merely by being open. While the active train exists, a PR may merge to main
+only when its one primary Change Request is in that Milestone. The script
+never changes a Milestone, Project field or PR.
 """
 
 from __future__ import annotations
@@ -29,6 +32,11 @@ from release_governance import evaluate_merge_release_eligibility  # noqa: E402
 
 API_ROOT = "https://api.github.com"
 MILESTONE_RE = re.compile(r"^DDDA (?P<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$")
+POLICY_ACTIVE_MILESTONE_RE = re.compile(
+    r"(?m)^[ \t]*-[ \t]+name:[ \t]*DDDA[ \t]+"
+    r"(?P<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))[ \t]*\r?$"
+    r"\n^[ \t]+state:[ \t]*open[ \t]*\r?$"
+)
 PRIMARY_RE = re.compile(r"(?im)^\s*(?:[-*]\s*)?(?:Implements|Closes)\s+#(\d+)\s*$")
 TARGET_RE = re.compile(
     r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?Target\s+Release(?:\*\*)?\s*:\s*`?([^`\r\n]+)"
@@ -129,18 +137,35 @@ def pages(path: str, token: str) -> list[Any]:
     raise GitHubReadError(f"Pagination limit exceeded for {path}")
 
 
-def active_release(milestones: list[dict[str, Any]]) -> dict[str, str] | None:
-    matches = []
-    for milestone in milestones:
-        match = MILESTONE_RE.fullmatch(str(milestone.get("title") or ""))
-        if match and milestone.get("state") == "open":
-            matches.append(match.group("version"))
+def configured_active_release(backlog_policy: str) -> str | None:
+    matches = POLICY_ACTIVE_MILESTONE_RE.findall(backlog_policy or "")
     if not matches:
         return None
     if len(matches) != 1:
-        raise GitHubReadError(f"Expected at most one active DDDA release train, found {sorted(matches)}")
-    return {"version": matches[0]}
+        raise GitHubReadError(
+            f"Expected exactly one versioned active DDDA release train, found {sorted(matches)}"
+        )
+    return matches[0]
 
+
+def active_release(
+    milestones: list[dict[str, Any]], backlog_policy: str
+) -> dict[str, str] | None:
+    configured = configured_active_release(backlog_policy)
+    if configured is None:
+        return None
+    matches = [
+        milestone
+        for milestone in milestones
+        if MILESTONE_RE.fullmatch(str(milestone.get("title") or ""))
+        and str(milestone.get("title") or "") == f"DDDA {configured}"
+        and milestone.get("state") == "open"
+    ]
+    if len(matches) != 1:
+        raise GitHubReadError(
+            f"Expected exactly one live active DDDA release train for {configured}, found {len(matches)}"
+        )
+    return {"version": configured}
 
 def primary_changes(body: str) -> list[int]:
     return sorted({int(x) for x in PRIMARY_RE.findall(body or "")})
@@ -411,10 +436,14 @@ def collect(repository: str, pr_number: int, expected_sha: str, token: str) -> d
     issue: dict[str, Any] = {}
     if len(primary) == 1:
         issue = request_json(f"repos/{repository}/issues/{primary[0]}", token) or {}
-    active = active_release(pages(f"repos/{repository}/milestones?state=all", token))
+    base_sha = str(((pr.get("base") or {}).get("sha")) or "")
+    if not base_sha:
+        raise GitHubReadError("PR base SHA is required for active release discovery")
+    backlog_policy = content_text(repository, "config/governance/backlog-policy.yaml", base_sha, token)
+    milestones = pages(f"repos/{repository}/milestones?state=all", token)
+    active = active_release(milestones, backlog_policy)
     active_issue_numbers: set[int] = set()
     if active is not None:
-        milestones = pages(f"repos/{repository}/milestones?state=all", token)
         matches = [row for row in milestones if row.get("title") == f"DDDA {active['version']}" and row.get("state") == "open"]
         if len(matches) != 1:
             raise GitHubReadError("Active release milestone evidence is ambiguous")


### PR DESCRIPTION
Implements #16

## Scope

Fixes merge-eligibility discovery so that the single active DDDA train is read from the versioned PR-base backlog policy and then evidenced by exactly one live open milestone. Open future milestones remain planned roadmap items and cannot become active merely because their GitHub milestone is open.

## Evidence

- regression coverage proves 0.1.1 remains active while open 0.1.2 and 0.2.0 remain planned;
- missing live evidence for the configured active train fails closed;
- ADR 0012 records the authority boundary.

Classification: `ORCHESTRATION`, `CLI`, `TESTING`, `RELEASE`, `SECURITY-GOVERNANCE`; impact: `HIGH`; breaking: `false`; primary CR: #16.

No DDDA 0.1.1 scope, Project, live milestone, candidate, merge, release, promotion, tag, GitHub Release, or issue state is changed.