### PR TITLE
gov(roadmap): rebase release-train planning

### DIFF
--- a/config/governance/backlog-policy.yaml
+++ b/config/governance/backlog-policy.yaml
@@ -165,7 +165,7 @@ native_sub_issue_mapping:
     parent_issue: 61
     children: [36, 37, 38, 39, 40, 41]
   Other:
-    unparented_items: [16, 42, 44, 45, 49, 65, 66, 67, 68, 69, 70, 73, 75, 85, 88, 96, 98]
+    unparented_items: [16, 42, 44, 45, 49, 65, 66, 67, 68, 69, 70, 73, 75, 85, 88, 94, 96, 98, 113]
 
 dependency_edges:
   WP-08:
@@ -326,18 +326,55 @@ baseline_compatibility:
 
 milestones:
   naming: 'DDDA <semver>'
-  initial:
+  release_train:
     - name: DDDA 0.1.0
       state: closed
       issues: [10, 11, 13, 14]
       pulls: [8]
-      excluded_future_items: [9, 12, 45, 53, 54, 55, 56, 57, 65, 66, 67, 68, 69, 70, 73, 75, 85, 88]
     - name: DDDA 0.1.1
       state: open
       issues: [9, 12, 67, 68, 70, 96, 98]
       pulls: []
       pre_release_prerequisites: [44]
-      explicitly_deferred_items: [65, 66, 69, 73, 85, 88]
+    - name: DDDA 0.1.2
+      state: open
+      issues: [16, 65, 69, 73, 85, 94, 113]
+      pulls: []
+      outcome: governance consolidation after the first controlled release
+    - name: DDDA 0.2.0
+      state: open
+      issues: [34, 35, 48, 52, 66]
+      pulls: []
+      outcome: EventStorming MVP
+    - name: DDDA 0.3.0
+      state: open
+      issues: [27, 28, 29, 30, 31, 32, 33, 47, 62, 46]
+      pulls: []
+      outcome: enterprise ingestion and EventStorming evidence integration
+    - name: DDDA 0.3.1
+      state: open
+      issues: [53, 54, 55, 56, 57]
+      pulls: []
+      outcome: Miro platform lifecycle
+    - name: DDDA 0.4.0
+      state: open
+      issues: [21, 22, 23, 24, 25, 50, 26, 51]
+      pulls: []
+      outcome: strategy and portfolio capability
+    - name: DDDA 0.5.0
+      state: open
+      issues: [36, 37, 38, 39, 40, 41]
+      pulls: []
+      outcome: multi-agent orchestration
+  explicitly_unplanned:
+    - issue: 44
+      rationale: pre-release control prerequisite for 0.1.1; not a release-scope item
+    - issue: 45
+      rationale: cross-cutting Artifact Registry dashboard requires a separate public/private publication decision
+    - issue: 49
+      rationale: role-based documentation IA waits for its explicit cross-stream blockers
+    - issue: 88
+      rationale: control-plane enabler requires a separate scope decision before it enters a release
   parent_work_packages_counted_in_release_progress: false
   unplanned_work_packages_target_release: TBD
   membership_is_release_scope_not_approval: true

--- a/config/governance/github-bootstrap.json
+++ b/config/governance/github-bootstrap.json
@@ -663,7 +663,7 @@
         "Status": "Backlog",
         "Work Package": "WP-09",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.4.0",
         "Blocked": "No",
         "Human Review": "Not required"
       }
@@ -682,7 +682,7 @@
         "Status": "Backlog",
         "Work Package": "WP-09",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.4.0",
         "Blocked": "Yes",
         "Human Review": "Not required"
       }
@@ -696,7 +696,7 @@
         "Status": "Backlog",
         "Work Package": "WP-10",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.3.0",
         "Blocked": "No",
         "Human Review": "Not required"
       }
@@ -710,7 +710,7 @@
         "Status": "Backlog",
         "Work Package": "WP-10",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.3.0",
         "Blocked": "Yes",
         "Human Review": "Not required"
       }
@@ -728,7 +728,7 @@
         "Status": "Backlog",
         "Work Package": "WP-10",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.3.0",
         "Blocked": "Yes",
         "Human Review": "Not required"
       }
@@ -744,7 +744,7 @@
         "Status": "Backlog",
         "Work Package": "WP-11",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.2.0",
         "Blocked": "No",
         "Human Review": "Not required"
       }
@@ -752,15 +752,13 @@
     {
       "kind": "issue",
       "numbers": [
-        35,
-        47,
-        46
+        35
       ],
       "metadata": {
         "Status": "Backlog",
         "Work Package": "WP-11",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.2.0",
         "Blocked": "Yes",
         "Human Review": "Not required"
       }
@@ -787,7 +785,7 @@
         "Status": "In progress",
         "Work Package": "Other",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.1.2",
         "Blocked": "No",
         "Human Review": "Pending"
       }
@@ -904,7 +902,7 @@
         "Status": "In progress",
         "Work Package": "WP-12",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.3.1",
         "Blocked": "Yes",
         "Human Review": "Not required",
         "Outcome summary": "Persistent DDDA Platform Lab with explicit board taxonomy, reference/adoption lifecycle, managed namespaces and governed cleanup."
@@ -919,7 +917,7 @@
         "Status": "Backlog",
         "Work Package": "WP-12",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.3.1",
         "Blocked": "Yes",
         "Human Review": "Not required",
         "Outcome summary": "Persistent DDDA Example Project board lifecycle generated from exact candidate/release packages."
@@ -934,7 +932,7 @@
         "Status": "Backlog",
         "Work Package": "WP-12",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.3.1",
         "Blocked": "Yes",
         "Human Review": "Not required",
         "Outcome summary": "Per-project Miro identity, team, Space, token and board provisioning UX."
@@ -949,7 +947,7 @@
         "Status": "Backlog",
         "Work Package": "WP-12",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.3.1",
         "Blocked": "Yes",
         "Human Review": "Not required",
         "Outcome summary": "Governed rebinding of Miro execution profiles to the corporate team/Space."
@@ -964,7 +962,7 @@
         "Status": "Backlog",
         "Work Package": "WP-12",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.3.1",
         "Blocked": "Yes",
         "Human Review": "Not required",
         "Outcome summary": "Remove generic MIRO_ACCESS_TOKEN fallback after explicit profile credential migration."
@@ -979,7 +977,7 @@
         "Status": "Backlog",
         "Work Package": "WP-13",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.5.0",
         "Blocked": "No",
         "Human Review": "Not required"
       }
@@ -993,7 +991,7 @@
         "Status": "Backlog",
         "Work Package": "WP-13",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.5.0",
         "Blocked": "Yes",
         "Human Review": "Not required"
       }
@@ -1007,7 +1005,7 @@
         "Status": "Backlog",
         "Work Package": "WP-13",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.5.0",
         "Blocked": "Yes",
         "Human Review": "Not required"
       }
@@ -1021,7 +1019,7 @@
         "Status": "Backlog",
         "Work Package": "WP-13",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.5.0",
         "Blocked": "Yes",
         "Human Review": "Not required"
       }
@@ -1035,7 +1033,7 @@
         "Status": "Backlog",
         "Work Package": "WP-13",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.5.0",
         "Blocked": "Yes",
         "Human Review": "Not required"
       }
@@ -1049,7 +1047,7 @@
         "Status": "Backlog",
         "Work Package": "WP-13",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.5.0",
         "Blocked": "Yes",
         "Human Review": "Not required"
       }
@@ -1063,7 +1061,7 @@
         "Status": "Backlog",
         "Work Package": "WP-11",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.3.0",
         "Blocked": "Yes",
         "Human Review": "Pending",
         "Outcome summary": "Package-first EventStorming E2E acceptance without mandatory multi-agent runtime."
@@ -1147,20 +1145,66 @@
     },
     {
       "kind": "issue",
-      "numbers": [
-        65,
-        66,
-        69,
-        73,
-        85
-      ],
+      "numbers": [65, 69, 73, 85],
       "metadata": {
         "Status": "Backlog",
         "Work Package": "Other",
         "Item Type": "Change Request",
-        "Target Release": "TBD",
+        "Target Release": "0.1.2",
         "Blocked": "No",
         "Human Review": "Pending"
+      }
+    },
+    {
+      "kind": "issue",
+      "numbers": [66],
+      "metadata": {
+        "Status": "Backlog",
+        "Work Package": "Other",
+        "Item Type": "Change Request",
+        "Target Release": "0.2.0",
+        "Blocked": "No",
+        "Human Review": "Pending"
+      }
+    },
+    {
+      "kind": "issue",
+      "numbers": [47, 46],
+      "metadata": {
+        "Status": "Backlog",
+        "Work Package": "WP-11",
+        "Item Type": "Change Request",
+        "Target Release": "0.3.0",
+        "Blocked": "Yes",
+        "Human Review": "Not required"
+      }
+    },
+    {
+      "kind": "issue",
+      "numbers": [94],
+      "metadata": {
+        "Status": "Backlog",
+        "Work Package": "Other",
+        "Item Type": "Defect",
+        "Target Release": "0.1.2",
+        "Blocked": "No",
+        "Human Review": "Pending"
+      }
+    },
+    {
+      "kind": "issue",
+      "numbers": [113],
+      "metadata": {
+        "Status": "Backlog",
+        "Priority": "P2",
+        "Work Package": "Other",
+        "Item Type": "Change Request",
+        "Platform Area": "DOC",
+        "Impact": "LOW",
+        "Target Release": "0.1.2",
+        "Blocked": "No",
+        "Human Review": "Pending",
+        "Outcome summary": "Expose the canonical DDDA operating model in entry-point documentation: Work as development/governance control plane, GitHub as canonical system of record, GitHub Actions as authoritative technical execution plane, and Cursor as the current reference project runtime."
       }
     },
     {
@@ -1362,6 +1406,48 @@
         96,
         98
       ],
+      "pulls": []
+    },
+    {
+      "title": "DDDA 0.1.2",
+      "state": "open",
+      "description": "Governance consolidation after DDDA 0.1.1: backlog authority, branch lifecycle, release history, mandatory-gate semantics, terminology and planning/delivery separation. Milestone membership is release scope, not release approval.",
+      "issues": [16, 65, 69, 73, 85, 94, 113],
+      "pulls": []
+    },
+    {
+      "title": "DDDA 0.2.0",
+      "state": "open",
+      "description": "EventStorming MVP: executable session, facilitation guidance, Miro/Git round-trip, DDD Starter templates and methodology. Milestone membership is release scope, not release approval.",
+      "issues": [34, 35, 48, 52, 66],
+      "pulls": []
+    },
+    {
+      "title": "DDDA 0.3.0",
+      "state": "open",
+      "description": "Enterprise ingestion and EventStorming evidence integration: manifest core, security, adapters, traceability, corpus, governed workshop round-trip, E2E acceptance and first-user explanation. Milestone membership is release scope, not release approval.",
+      "issues": [27, 28, 29, 30, 31, 32, 33, 47, 62, 46],
+      "pulls": []
+    },
+    {
+      "title": "DDDA 0.3.1",
+      "state": "open",
+      "description": "Miro platform lifecycle: Platform Lab, Example Project lifecycle, project identity UX, corporate rebinding and legacy-token fallback removal. Milestone membership is release scope, not release approval.",
+      "issues": [53, 54, 55, 56, 57],
+      "pulls": []
+    },
+    {
+      "title": "DDDA 0.4.0",
+      "state": "open",
+      "description": "Strategy and portfolio capability: P0-P10 lifecycle, intake, Wardley mapping, investment decisions, traceability, roadmap, benefits and package-first acceptance. Milestone membership is release scope, not release approval.",
+      "issues": [21, 22, 23, 24, 25, 50, 26, 51],
+      "pulls": []
+    },
+    {
+      "title": "DDDA 0.5.0",
+      "state": "open",
+      "description": "Multi-agent orchestration: capability contract, bounded fan-out/fan-in, human checkpoints, resilience, observability and package-first acceptance. Milestone membership is release scope, not release approval.",
+      "issues": [36, 37, 38, 39, 40, 41],
       "pulls": []
     }
   ]

--- a/docs/roadmap/backlog-index.md
+++ b/docs/roadmap/backlog-index.md
@@ -9,6 +9,24 @@ Parent/sub-issue represents capability ownership. Native `blocked by` represents
 3. **WP-12 / #60 — P2**: Miro platform environments & lifecycle; may overlap WP-11 after stable PR8 Miro baseline.
 4. **WP-13 / #61 — P3**: multi-agent orchestration & evidence synthesis.
 
+## Approved release train
+
+Milestone membership is a deliberate release-scope decision, not release approval. No target date is implied.
+
+| Release | Scope |
+| --- | --- |
+| DDDA 0.1.1 | Stabilization/release safety only: #9, #12, #67, #68, #70, #96, #98. Do not add scope. |
+| DDDA 0.1.2 | Governance consolidation: #16, #65, #69, #73, #85, #94, #113. |
+| DDDA 0.2.0 | EventStorming MVP: #34, #35, #48, #52, #66. |
+| DDDA 0.3.0 | Enterprise ingestion and EventStorming evidence integration: #27–#33, #47, #62, #46. |
+| DDDA 0.3.1 | Miro platform lifecycle: #53–#57. |
+| DDDA 0.4.0 | Strategy and portfolio: #21–#25, #50, #26, #51. |
+| DDDA 0.5.0 | Multi-agent orchestration: #36–#41. |
+
+The plan corrects one dependency conflict in the earlier draft: #62 cannot be in 0.2.0 because it is directly blocked by #47, which needs the ingestion core and security work in 0.3.0. Therefore #62 and the resulting first-user explanation #46 are both in 0.3.0.
+
+Remain intentionally outside any milestone: #44 (0.1.1 pre-release prerequisite, not release scope), #45 and #49 (separate cross-cutting decisions), and #88 (scope decision pending).
+
 ## WP-08 — #17
 
 Children: #9–#15 only. PR #8 remains the implementation under closure. No new feature scope.
@@ -61,7 +79,8 @@ Children: #36, #37, #38, #39, #40, #41.
 
 - #16 — GitHub-native backlog governance;
 - #45 — GitHub Pages Artifact Registry dashboard (`Other`);
-- #49 — role-based documentation IA (`Other`), blocked by #16, #46, #48 and #53.
+- #49 — role-based documentation IA (`Other`), blocked by #16, #46, #48 and #53;
+- #113 — entry-point operating-model documentation (`Other`, primary `DOC`, secondary `METHODOLOGY`), planned for DDDA 0.1.2.
 
 ## Boundary invariant
 

--- a/runtime/platform/tests/test_project_backlog_delivery_governance.py
+++ b/runtime/platform/tests/test_project_backlog_delivery_governance.py
@@ -261,16 +261,28 @@ def test_release_planning_readback_retries_boundedly_until_consistent():
 
 
 
-def test_0_1_1_governance_normalization_contract():
+def test_release_train_milestone_and_project_target_contract():
     cfg = json.loads((ROOT / "config/governance/github-bootstrap.json").read_text(encoding="utf-8-sig"))
     specs = {x["title"]: x for x in cfg["milestones"]}
-    assert set(specs) == {"DDDA 0.1.0", "DDDA 0.1.1"}
+    expected = {
+        "DDDA 0.1.0": [10, 11, 13, 14],
+        "DDDA 0.1.1": [9, 12, 67, 68, 70, 96, 98],
+        "DDDA 0.1.2": [16, 65, 69, 73, 85, 94, 113],
+        "DDDA 0.2.0": [34, 35, 48, 52, 66],
+        "DDDA 0.3.0": [27, 28, 29, 30, 31, 32, 33, 47, 62, 46],
+        "DDDA 0.3.1": [53, 54, 55, 56, 57],
+        "DDDA 0.4.0": [21, 22, 23, 24, 25, 50, 26, 51],
+        "DDDA 0.5.0": [36, 37, 38, 39, 40, 41],
+    }
+    assert set(specs) == set(expected)
     assert specs["DDDA 0.1.0"]["state"] == "closed"
     assert specs["DDDA 0.1.0"]["issues"] == [10, 11, 13, 14]
     assert specs["DDDA 0.1.0"]["pulls"] == [8]
-    assert specs["DDDA 0.1.1"]["state"] == "open"
-    assert specs["DDDA 0.1.1"]["issues"] == [9, 12, 67, 68, 70, 96, 98]
-    assert specs["DDDA 0.1.1"]["pulls"] == []
+    for title, issues in expected.items():
+        assert specs[title]["issues"] == issues
+        if title != "DDDA 0.1.0":
+            assert specs[title]["state"] == "open"
+            assert specs[title]["pulls"] == []
 
     meta = {}
     for group in cfg["item_groups"]:
@@ -288,17 +300,43 @@ def test_0_1_1_governance_normalization_contract():
     assert meta[96]["Target Release"] == "0.1.1"
     assert meta[98]["Item Type"] == "Defect"
     assert meta[98]["Work Package"] == "Other"
+    for title, issues in expected.items():
+        if title == "DDDA 0.1.0":
+            continue
+        version = title.removeprefix("DDDA ")
+        for issue in issues:
+            assert meta[issue]["Target Release"] == version
+    assert meta[44]["Target Release"] == "TBD"
+    assert meta[88]["Target Release"] == "TBD"
     assert meta[98]["Target Release"] == "0.1.1"
     assert meta[98]["Priority"] == "P0"
     assert meta[98]["Platform Area"] == "RELEASE"
     assert meta[98]["Impact"] == "HIGH"
     dependencies = {entry["blocked"]: entry["blocked_by"] for entry in cfg["dependencies"]}
     assert dependencies[75] == [96, 98]
-    assert "unparented_items: [16, 42, 44, 45, 49, 65, 66, 67, 68, 69, 70, 73, 75, 85, 88, 96, 98]" in POLICY.read_text(encoding="utf-8")
+    assert "unparented_items: [16, 42, 44, 45, 49, 65, 66, 67, 68, 69, 70, 73, 75, 85, 88, 94, 96, 98, 113]" in POLICY.read_text(encoding="utf-8")
     assert meta[75]["Item Type"] == "Enabler"
     assert meta[85]["Work Package"] == "Other"
-    assert meta[85]["Target Release"] == "TBD"
+    assert meta[85]["Target Release"] == "0.1.2"
     assert meta[85]["Status"] == "Backlog"
+    assert meta[94]["Item Type"] == "Defect"
+    assert meta[94]["Work Package"] == "Other"
+    assert meta[94]["Target Release"] == "0.1.2"
+    assert meta[113]["Item Type"] == "Change Request"
+    assert meta[113]["Work Package"] == "Other"
+    assert meta[113]["Priority"] == "P2"
+    assert meta[113]["Platform Area"] == "DOC"
+    assert meta[113]["Impact"] == "LOW"
+    assert meta[113]["Target Release"] == "0.1.2"
+    assert meta[113]["Status"] == "Backlog"
+    assert meta[113]["Blocked"] == "No"
+    assert meta[113]["Human Review"] == "Pending"
+    assert meta[113]["Outcome summary"] == (
+        "Expose the canonical DDDA operating model in entry-point documentation: "
+        "Work as development/governance control plane, GitHub as canonical system of record, "
+        "GitHub Actions as authoritative technical execution plane, and Cursor as the current "
+        "reference project runtime."
+    )
     assert meta[88]["Item Type"] == "Enabler"
     assert meta[88]["Work Package"] == "Other"
     assert meta[88]["Target Release"] == "TBD"


### PR DESCRIPTION
Implements #16

## Purpose

Replacement transport for PR #116. It materializes the identical versioned future-release planning contract directly from current `main`, preserving the DDDA 0.1.1 release boundary.

## Scope

- versioned release train DDDA 0.1.2 through 0.5.0;
- corresponding versioned Project Target Release planning metadata;
- roadmap release-train documentation;
- regression coverage for the release-planning projection;
- canonical planning projection for CR #113 into DDDA 0.1.2 only.

Changed paths are exactly:

- `config/governance/backlog-policy.yaml`
- `config/governance/github-bootstrap.json`
- `docs/roadmap/backlog-index.md`
- `runtime/platform/tests/test_project_backlog_delivery_governance.py`

## Replacement boundary

PR #116 remains unmerged. Its prior merge-commit refresh retained an obsolete merge base, causing the fail-closed collector to attribute already-integrated release-governance files to its diff. This replacement uses a single-parent commit from current `main`; it preserves the same four planning blobs and does not use force-push.

## Boundary

No implementation of #113. No README.md, USAGE.md or operating-model changes. No live Project or Milestone mutation, candidate reconstruction, merge, release, promotion, tag or GitHub Release. No DDDA 0.1.1 scope change and no closure of #16, #96, #98 or #113.

Classification: SECURITY-GOVERNANCE, TESTING, DOC; impact HIGH; migration non-breaking.

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"impact":"HIGH"}
```
