### PR TITLE
fix(governance): mark the single active release train

### DIFF
--- a/docs/adr/0012-future-release-metadata-merge-eligibility.md
+++ b/docs/adr/0012-future-release-metadata-merge-eligibility.md
@@ -80,4 +80,4 @@ through this allowance.
 
 ## Active-train marker regression
 
-An open future milestone is planning data, not an active release train. The guard selects exactly one open train carrying the explicit `pre_release_prerequisites` marker. Missing or duplicate markers fail closed; future open milestones cannot block an implementation merge for the active train.
+An open future milestone is planning data, not an active release train. The guard selects exactly one open train carrying the explicit `pre_release_prerequisites` marker. Missing or duplicate markers fail closed; future open milestones cannot block an implementation merge for the active train. The former single-open-train policy remains supported only when no `release_train` section exists; it is never used as a fallback for an ambiguous current release train.

--- a/docs/adr/0012-future-release-metadata-merge-eligibility.md
+++ b/docs/adr/0012-future-release-metadata-merge-eligibility.md
@@ -77,3 +77,7 @@ through this allowance.
 - unit tests cover active-train allowance, future-plan proof, incomplete proof
   rejection and the exact-base transition;
 - standard exact-SHA CI and package-first validation remain mandatory.
+
+## Active-train marker regression
+
+An open future milestone is planning data, not an active release train. The guard selects exactly one open train carrying the explicit `pre_release_prerequisites` marker. Missing or duplicate markers fail closed; future open milestones cannot block an implementation merge for the active train.

--- a/runtime/platform/tests/test_merge_release_eligibility_collector.py
+++ b/runtime/platform/tests/test_merge_release_eligibility_collector.py
@@ -267,3 +267,21 @@ milestones:
         assert "exactly one live active" in str(exc)
     else:
         raise AssertionError("expected missing live active train to fail closed")
+
+
+def test_active_release_ignores_open_future_trains_without_prerelease_marker() -> None:
+    backlog_policy = """
+milestones:
+  release_train:
+    - name: DDDA 0.1.1
+      state: open
+      issues: [9]
+      pulls: []
+      pre_release_prerequisites: [44]
+    - name: DDDA 0.1.2
+      state: open
+      issues: [16]
+      pulls: []
+"""
+    milestones = [{"title": "DDDA 0.1.1", "state": "open"}, {"title": "DDDA 0.1.2", "state": "open"}]
+    assert COLLECTOR.active_release(milestones, backlog_policy) == {"version": "0.1.1"}

--- a/runtime/platform/tests/test_merge_release_eligibility_collector.py
+++ b/runtime/platform/tests/test_merge_release_eligibility_collector.py
@@ -285,3 +285,20 @@ milestones:
 """
     milestones = [{"title": "DDDA 0.1.1", "state": "open"}, {"title": "DDDA 0.1.2", "state": "open"}]
     assert COLLECTOR.active_release(milestones, backlog_policy) == {"version": "0.1.1"}
+
+
+def test_active_release_fails_closed_when_release_train_has_no_marker() -> None:
+    backlog_policy = """
+milestones:
+  release_train:
+    - name: DDDA 0.1.1
+      state: open
+      issues: [9]
+      pulls: []
+"""
+    try:
+        COLLECTOR.active_release([{"title": "DDDA 0.1.1", "state": "open"}], backlog_policy)
+    except COLLECTOR.GitHubReadError as exc:
+        assert "marker-designated" in str(exc)
+    else:
+        raise AssertionError("expected unmarked release_train to fail closed")

--- a/scripts/platform/Test-DDDAMergeReleaseEligibility.py
+++ b/scripts/platform/Test-DDDAMergeReleaseEligibility.py
@@ -33,10 +33,12 @@ from release_governance import evaluate_merge_release_eligibility  # noqa: E402
 API_ROOT = "https://api.github.com"
 MILESTONE_RE = re.compile(r"^DDDA (?P<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$")
 POLICY_ACTIVE_MILESTONE_RE = re.compile(
-    r"(?m)^[ \t]*-[ \t]+name:[ \t]*DDDA[ \t]+"
+    r"(?ms)^[ \t]*-[ \t]+name:[ \t]*DDDA[ \t]+"
     r"(?P<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))[ \t]*\r?$"
-    r"\n^[ \t]+state:[ \t]*open[ \t]*\r?$"
+    r"(?:(?!^[ \t]*-[ \t]+name:).)*?^[ \t]+state:[ \t]*open[ \t]*\r?$"
+    r"(?:(?!^[ \t]*-[ \t]+name:).)*?^[ \t]+pre_release_prerequisites:[ \t]*\[[^\]]+\][ \t]*\r?$"
 )
+
 PRIMARY_RE = re.compile(r"(?im)^\s*(?:[-*]\s*)?(?:Implements|Closes)\s+#(\d+)\s*$")
 TARGET_RE = re.compile(
     r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?Target\s+Release(?:\*\*)?\s*:\s*`?([^`\r\n]+)"

--- a/scripts/platform/Test-DDDAMergeReleaseEligibility.py
+++ b/scripts/platform/Test-DDDAMergeReleaseEligibility.py
@@ -39,6 +39,12 @@ POLICY_ACTIVE_MILESTONE_RE = re.compile(
     r"(?:(?!^[ \t]*-[ \t]+name:).)*?^[ \t]+pre_release_prerequisites:[ \t]*\[[^\]]+\][ \t]*\r?$"
 )
 
+LEGACY_POLICY_ACTIVE_MILESTONE_RE = re.compile(
+    r"(?m)^[ \t]*-[ \t]+name:[ \t]*DDDA[ \t]+"
+    r"(?P<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))[ \t]*\r?$"
+    r"\n^[ \t]+state:[ \t]*open[ \t]*\r?$"
+)
+
 PRIMARY_RE = re.compile(r"(?im)^\s*(?:[-*]\s*)?(?:Implements|Closes)\s+#(\d+)\s*$")
 TARGET_RE = re.compile(
     r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?Target\s+Release(?:\*\*)?\s*:\s*`?([^`\r\n]+)"
@@ -140,14 +146,26 @@ def pages(path: str, token: str) -> list[Any]:
 
 
 def configured_active_release(backlog_policy: str) -> str | None:
-    matches = POLICY_ACTIVE_MILESTONE_RE.findall(backlog_policy or "")
-    if not matches:
+    policy = backlog_policy or ""
+    marked = POLICY_ACTIVE_MILESTONE_RE.findall(policy)
+    if "release_train:" in policy:
+        if len(marked) != 1:
+            raise GitHubReadError(
+                "Expected exactly one marker-designated active DDDA release train, "
+                f"found {sorted(marked)}"
+            )
+        return marked[0]
+
+    # Older policy layouts predate release-train planning. Preserve their
+    # single-open-train contract, but never use it when release_train exists.
+    legacy = LEGACY_POLICY_ACTIVE_MILESTONE_RE.findall(policy)
+    if not legacy:
         return None
-    if len(matches) != 1:
+    if len(legacy) != 1:
         raise GitHubReadError(
-            f"Expected exactly one versioned active DDDA release train, found {sorted(matches)}"
+            f"Expected exactly one versioned active DDDA release train, found {sorted(legacy)}"
         )
-    return matches[0]
+    return legacy[0]
 
 
 def active_release(


### PR DESCRIPTION
Implements #16

## Purpose

Repairs the active-release-train selector exposed by PR #121 dry-run. Open future milestones are planning data; exactly one open train carrying the explicit pre-release marker is eligible as the active train.

## Scope

- fail-closed active-train discovery;
- regression coverage for open future milestones;
- ADR documentation.

## Boundary

No DDDA 0.1.1 scope, Project, milestone, candidate, merge, release, promotion, tag or GitHub Release change. No closure of #16, #96, #98 or #113.

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"impact":"HIGH"}
```