### PR TITLE
fix(release): rebase HRDR milestone discovery

### DIFF
--- a/docs/adr/0013-controlled-release-candidate-validation.md
+++ b/docs/adr/0013-controlled-release-candidate-validation.md
@@ -103,3 +103,17 @@ This keeps the HRDR bound to the already validated physical package. It neither
 rebuilds a candidate nor permits a filename-only or ambient-artifact fallback;
 an unsupported or missing evidence handoff fails before any pending HRDR comment
 is written.
+
+
+## HRDR milestone discovery boundary
+
+The pending-HRDR command reads the live milestone and its issue scope through
+paginated GitHub API responses. In PowerShell, directly wrapping the API command
+in an array expression can preserve a JSON array as one nested object. That makes
+a real milestone appear absent and must fail before any HRDR comment is written.
+
+The command therefore first assigns each API response and only then materializes
+its items for both pagination loops: milestones and milestone issues. It still
+requires exactly one `DDDA <version>` milestone and preserves all fail-closed
+checks; the change does not create, edit or close a milestone, issue, Project
+item, release, tag or promotion.

--- a/runtime/platform/tests/test_controlled_release_candidate.py
+++ b/runtime/platform/tests/test_controlled_release_candidate.py
@@ -150,3 +150,16 @@ def test_hrdr_scaffold_forwards_report_bound_package_through_public_review_entry
     assert 'if (-not [string]::IsNullOrWhiteSpace($CandidatePackagePath)) { $arguments += @("-CandidatePackagePath", $CandidatePackagePath) }' in cli
     assert "[string]$CandidatePackagePath" in review_command
     assert "-PackagePath $CandidatePackagePath" in review_command
+
+
+def test_hrdr_milestone_discovery_materializes_paginated_api_arrays_without_nesting() -> None:
+    support = (ROOT / "scripts/platform/DDDAReleaseGovernanceSupport.ps1").read_text(encoding="utf-8-sig")
+    start = support.index("function Get-DDDAReleaseMilestoneScope")
+    end = support.index("function Get-DDDAHrdrComments")
+    scope_reader = support[start:end]
+
+    assert '$response = Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/milestones?state=all&per_page=100&page=$page" -Token $Token' in scope_reader
+    assert '$response = Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/issues?state=all&milestone=$([int]$milestone.number)&per_page=100&page=$page" -Token $Token' in scope_reader
+    assert scope_reader.count("$batch = @($response)") == 2
+    assert "@(Invoke-DDDAGitHubApi -Method GET -Path \"repos/$RepositorySlug/milestones" not in scope_reader
+    assert "@(Invoke-DDDAGitHubApi -Method GET -Path \"repos/$RepositorySlug/issues" not in scope_reader

--- a/scripts/platform/DDDAReleaseGovernanceSupport.ps1
+++ b/scripts/platform/DDDAReleaseGovernanceSupport.ps1
@@ -93,7 +93,8 @@ function Get-DDDAReleaseMilestoneScope {
     $wantedTitle = "DDDA $Version"
     $milestones = [System.Collections.Generic.List[object]]::new()
     for ($page = 1; ; $page++) {
-        $batch = @(Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/milestones?state=all&per_page=100&page=$page" -Token $Token)
+        $response = Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/milestones?state=all&per_page=100&page=$page" -Token $Token
+        $batch = @($response)
         foreach ($row in $batch) { $milestones.Add($row) }
         if ($batch.Count -lt 100) { break }
     }
@@ -105,7 +106,8 @@ function Get-DDDAReleaseMilestoneScope {
 
     $issues = [System.Collections.Generic.List[int]]::new()
     for ($page = 1; ; $page++) {
-        $batch = @(Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/issues?state=all&milestone=$([int]$milestone.number)&per_page=100&page=$page" -Token $Token)
+        $response = Invoke-DDDAGitHubApi -Method GET -Path "repos/$RepositorySlug/issues?state=all&milestone=$([int]$milestone.number)&per_page=100&page=$page" -Token $Token
+        $batch = @($response)
         foreach ($row in $batch) {
             if ($null -eq $row.PSObject.Properties["pull_request"]) {
                 $issues.Add([int]$row.number)


### PR DESCRIPTION
Implements #96

## Purpose

Replacement for PR #121 after the active-release-train correction in PR #122. It preserves the same fail-closed fix for paginated HRDR milestone discovery, now directly on current `main`.

## Scope

- materialize every paginated GitHub API response before milestone and milestone-issue enumeration;
- retain fail-closed uniqueness and scope checks;
- regression coverage and ADR documentation.

Changed paths are exactly:

- `docs/adr/0013-controlled-release-candidate-validation.md`
- `runtime/platform/tests/test_controlled_release_candidate.py`
- `scripts/platform/DDDAReleaseGovernanceSupport.ps1`

## Replacement boundary

PR #118 and PR #121 remain open and unmerged. Their heads predate the active-release-train correction, so their dry-runs evaluate stale governance. This PR is a single-parent commit from current `main` and preserves the same three implementation blobs.

## Boundary

No candidate reconstruction, merge, release, promotion, tag, GitHub Release, Project or milestone mutation, or scope change. No closure of #16, #96, #98 or #113.

Classification: RELEASE, SECURITY-GOVERNANCE, TESTING, DOC; impact HIGH; migration non-breaking.

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"impact":"HIGH"}
```