### PR TITLE
fix(release): allow pending HRDR PR comment publication

### DIFF
--- a/.github/workflows/controlled-release-candidate-validation.yml
+++ b/.github/workflows/controlled-release-candidate-validation.yml
@@ -40,7 +40,7 @@ permissions:
   checks: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: controlled-release-candidate-${{ inputs.candidate_pr }}-${{ inputs.source_sha }}-${{ inputs.operation }}

--- a/docs/adr/0013-controlled-release-candidate-validation.md
+++ b/docs/adr/0013-controlled-release-candidate-validation.md
@@ -117,3 +117,17 @@ its items for both pagination loops: milestones and milestone issues. It still
 requires exactly one `DDDA <version>` milestone and preserves all fail-closed
 checks; the change does not create, edit or close a milestone, issue, Project
 item, release, tag or promotion.
+
+
+## HRDR PR-comment permission boundary
+
+A pending HRDR is an auditable comment on the controlled candidate PR, not a
+review approval or a release action. The scaffold operation consequently needs
+write access to that PR conversation in addition to the existing issue-comment
+capability. Its workflow permission is explicitly `pull-requests: write`.
+
+This narrow permission allows the one pending HRDR record to be published after
+all identity and evidence checks. It does not grant repository-content write
+access and does not create, approve, merge or close a pull request; candidate
+reconstruction, release, tag, promotion, milestone and Project changes remain
+outside this operation.

--- a/runtime/platform/tests/test_controlled_release_candidate.py
+++ b/runtime/platform/tests/test_controlled_release_candidate.py
@@ -163,3 +163,13 @@ def test_hrdr_milestone_discovery_materializes_paginated_api_arrays_without_nest
     assert scope_reader.count("$batch = @($response)") == 2
     assert "@(Invoke-DDDAGitHubApi -Method GET -Path \"repos/$RepositorySlug/milestones" not in scope_reader
     assert "@(Invoke-DDDAGitHubApi -Method GET -Path \"repos/$RepositorySlug/issues" not in scope_reader
+
+
+def test_hrdr_scaffold_has_only_the_pr_comment_write_capability_it_needs() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "issues: write" in workflow
+    assert "pull-requests: write" in workflow
+    assert "pull-requests: read" not in workflow
+    assert "pull-requests: write\n  contents: write" not in workflow
+    assert "contents: write" not in workflow


### PR DESCRIPTION
## Purpose

Implements #96

This change restores the controlled workflow's narrowly scoped ability to publish a pending HRDR scaffold as a comment on its controlled candidate PR.

## Scope

- `pull-requests: write` for the existing PR-comment operation only;
- regression coverage for the least-privilege permission contract;
- ADR documentation of the boundary.

## Explicitly excluded

No candidate reconstruction, merge, release, promotion, tag, GitHub Release, Project/milestone/scope change, or closure of #16, #96, #98, or #113.

<!-- ddda:impact:v1 -->
```json
{"schema_version":1,"impact":"HIGH","rationale":"Changes controlled release workflow permission so its already identity-bound HRDR scaffold can publish an audit comment; repository-content and lifecycle mutation permissions remain absent."}
```