### PR TITLE
fix(release): preserve fenced HRDR records

### DIFF
--- a/scripts/platform/DDDAReleaseGovernanceSupport.ps1
+++ b/scripts/platform/DDDAReleaseGovernanceSupport.ps1
@@ -254,11 +254,11 @@ function Format-DDDAHrdrComment {
 $script:DDDAHrdrMarker
 ## $Heading
 
-> Automation may scaffold and validate this record. Only an explicit human action may change `decision` from `pending` to a release decision or alter accepted risks.
+> Automation may scaffold and validate this record. Only an explicit human action may change decision from pending to a release decision or alter accepted risks.
 
-```json
+``````json
 $json
-```
+``````
 "@
 }
 

--- a/scripts/platform/Invoke-DDDAPlatformTest.ps1
+++ b/scripts/platform/Invoke-DDDAPlatformTest.ps1
@@ -219,6 +219,7 @@ function Invoke-OneSuite {
             if ($PrePromotionCandidate) { $promotionGuardArguments += "-PrePromotionCandidate" }
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAPromotionGuards.ps1" -Arguments $promotionGuardArguments
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAReleasePublication.ps1" -Arguments @("-PlatformPath", $platformRoot)
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAHrdrComment.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroAutomation.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroEvidence.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAProjectSteering.ps1" -Arguments @("-PlatformPath", $platformRoot)
@@ -240,6 +241,7 @@ function Invoke-OneSuite {
         "regression" {
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAFirstRun.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAReleasePublication.ps1" -Arguments @("-PlatformPath", $platformRoot)
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAHrdrComment.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAProjectSteering.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroAutomation.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroEvidence.ps1" -Arguments @("-PlatformPath", $platformRoot)

--- a/tests/powershell/Test-DDDAHrdrComment.ps1
+++ b/tests/powershell/Test-DDDAHrdrComment.ps1
@@ -1,0 +1,36 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PlatformPath "scripts/platform/DDDAReleaseGovernanceSupport.ps1")
+
+function Assert-True {
+    param([Parameter(Mandatory = $true)][bool]$Condition, [Parameter(Mandatory = $true)][string]$Message)
+    if (-not $Condition) { throw $Message }
+}
+
+$record = [pscustomobject]@{
+    schema_version = 1
+    repository = "romanhlavac/ddd-accelerator"
+    pr = 103
+    source_sha = ("a" * 40)
+    candidate_package_sha256 = ("b" * 64)
+    version = "0.1.1"
+    reviewer = "romanhlavac"
+    decision_owner = "romanhlavac"
+    decision = "pending"
+    decided_at = $null
+    scope_issues = @(9, 12, 67, 68, 70, 96, 98)
+    findings = @()
+    accepted_risks = @()
+}
+
+$body = Format-DDDAHrdrComment -Record $record
+Assert-True -Condition ($body -match '(?s)```json\s*\{.*?"decision"\s*:\s*"pending".*?\}\s*```') -Message "HRDR scaffold musí obsahovat literal fenced JSON."
+$parsed = ConvertFrom-DDDAHrdrComment -Comment ([pscustomobject]@{ body = $body })
+Assert-True -Condition ([string]$parsed.decision -eq "pending") -Message "Publikovaný HRDR scaffold musí být zpětně parsovatelný."
+
+Write-Host "DDDA HRDR comment contract: PASS"


### PR DESCRIPTION
Implements #96

## HRDR serialization remediation

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"impact":"HIGH"}
```

Fixes the PowerShell formatter so its generated pending HRDR is a literal fenced JSON record and can be read back by the authoritative Release Scope Gate. Adds a regression test that validates formatter-to-parser round trip.

Boundary: this PR does not alter release scope, Project, milestones, controlled candidate #103, tags, GitHub Releases, promotion state, or Issue closure. It is an implementation remediation only; it must be validated, Human Reviewed, and separately authorized before any merge.