### PR TITLE
fix(governance): evaluate latest CI check attempts

### DIFF
--- a/scripts/platform/DDDAGitHubSupport.ps1
+++ b/scripts/platform/DDDAGitHubSupport.ps1
@@ -154,6 +154,42 @@ function Get-DDDAGitHubPullRequest {
     return $result
 }
 
+function Get-DDDALatestCheckRunsByName {
+    param([Parameter(Mandatory = $true)][object[]]$CheckRuns)
+
+    $selected = [System.Collections.Generic.List[object]]::new()
+    foreach ($group in @($CheckRuns | Group-Object -Property { [string]$_.name })) {
+        if ([string]::IsNullOrWhiteSpace([string]$group.Name)) {
+            throw "CI check run without a name cannot be evaluated."
+        }
+        $ordered = @(
+            $group.Group | Sort-Object -Property @(
+                @{
+                    Expression = {
+                        $raw = [string]$_.started_at
+                        if ([string]::IsNullOrWhiteSpace($raw)) {
+                            throw "CI check run '$([string]$_.name)' is missing started_at."
+                        }
+                        try {
+                            ([DateTimeOffset]::Parse($raw)).UtcDateTime.Ticks
+                        }
+                        catch {
+                            throw "CI check run '$([string]$_.name)' has an invalid started_at '$raw'."
+                        }
+                    }
+                    Descending = $true
+                },
+                @{
+                    Expression = { [Int64]$_.id }
+                    Descending = $true
+                }
+            )
+        )
+        $selected.Add($ordered[0])
+    }
+    return @($selected)
+}
+
 function Assert-DDDAGitHubChecksPassed {
     param(
         [Parameter(Mandatory = $true)][string]$RepositorySlug,
@@ -177,9 +213,13 @@ function Assert-DDDAGitHubChecksPassed {
         throw "GitHub nevrátil žádné CI check runs pro commit $Commit."
     }
 
+    # Retries leave immutable historical check-runs on the same commit. Evaluate
+    # the newest run per name; a current failure still fails closed.
+    $evaluatedCheckRuns = @(Get-DDDALatestCheckRunsByName -CheckRuns @($checkRuns))
+
     $allowedConclusions = @("success", "neutral", "skipped")
     $notPassed = @(
-        $checkRuns |
+        $evaluatedCheckRuns |
             Where-Object {
                 [string]$_.name -notin $IgnoredCheckRunNames -and (
                 [string]$_.status -ne "completed" -or
@@ -208,6 +248,7 @@ function Assert-DDDAGitHubChecksPassed {
 
     return [pscustomobject]@{
         CheckRunCount = $checkRuns.Count
+        EvaluatedCheckRunCount = $evaluatedCheckRuns.Count
         CommitStatusCount = $commitStatuses.Count
     }
 }

--- a/scripts/platform/Invoke-DDDAPlatformTest.ps1
+++ b/scripts/platform/Invoke-DDDAPlatformTest.ps1
@@ -219,6 +219,7 @@ function Invoke-OneSuite {
             if ($PrePromotionCandidate) { $promotionGuardArguments += "-PrePromotionCandidate" }
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAPromotionGuards.ps1" -Arguments $promotionGuardArguments
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAReleasePublication.ps1" -Arguments @("-PlatformPath", $platformRoot)
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAGitHubCheckRuns.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroAutomation.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroEvidence.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAProjectSteering.ps1" -Arguments @("-PlatformPath", $platformRoot)
@@ -240,6 +241,7 @@ function Invoke-OneSuite {
         "regression" {
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAFirstRun.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAReleasePublication.ps1" -Arguments @("-PlatformPath", $platformRoot)
+            Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAGitHubCheckRuns.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAProjectSteering.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroAutomation.ps1" -Arguments @("-PlatformPath", $platformRoot)
             Invoke-TestScript -RelativePath "tests/powershell/Test-DDDAMiroEvidence.ps1" -Arguments @("-PlatformPath", $platformRoot)

--- a/tests/powershell/Test-DDDAGitHubCheckRuns.ps1
+++ b/tests/powershell/Test-DDDAGitHubCheckRuns.ps1
@@ -1,0 +1,47 @@
+﻿[CmdletBinding()]
+param(
+    [string]$PlatformPath = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+. (Join-Path $PlatformPath "scripts/platform/DDDAGitHubSupport.ps1")
+
+function Assert-True {
+    param([bool]$Condition, [Parameter(Mandatory = $true)][string]$Message)
+    if (-not $Condition) { throw $Message }
+}
+function Assert-Throws {
+    param([Parameter(Mandatory = $true)][scriptblock]$Action, [Parameter(Mandatory = $true)][string]$Message)
+    $thrown = $false
+    try { & $Action } catch { $thrown = $true }
+    if (-not $thrown) { throw $Message }
+}
+
+$script:checkRuns = @(
+    [pscustomobject]@{ name = "reconcile"; id = 101; started_at = "2026-08-31T08:00:00Z"; status = "completed"; conclusion = "failure" },
+    [pscustomobject]@{ name = "reconcile"; id = 102; started_at = "2026-08-31T08:05:00Z"; status = "completed"; conclusion = "success" },
+    [pscustomobject]@{ name = "Platform validation"; id = 103; started_at = "2026-08-31T08:06:00Z"; status = "completed"; conclusion = "success" }
+)
+
+$latest = @(Get-DDDALatestCheckRunsByName -CheckRuns $script:checkRuns)
+Assert-True -Condition ($latest.Count -eq 2) -Message "Exactly one newest check run per name must be evaluated."
+$reconcile = @($latest | Where-Object { $_.name -eq "reconcile" })
+Assert-True -Condition ($reconcile.Count -eq 1 -and [Int64]$reconcile[0].id -eq 102) -Message "A newer successful retry must supersede the historical failed attempt."
+
+function Invoke-DDDAGitHubApi {
+    param([string]$Method, [string]$Path, [string]$Token)
+    if ($Path -like "*/check-runs*") { return @{ check_runs = $script:checkRuns } }
+    if ($Path -like "*/status") { return @{ statuses = @(); state = "success" } }
+    throw "Unexpected mocked GitHub path: $Path"
+}
+
+$result = Assert-DDDAGitHubChecksPassed -RepositorySlug "romanhlavac/ddd-accelerator" -Commit ("a" * 40) -Token "test"
+Assert-True -Condition ($result.CheckRunCount -eq 3 -and $result.EvaluatedCheckRunCount -eq 2) -Message "Check evidence must retain observed and evaluated counts."
+
+$script:checkRuns[1].conclusion = "failure"
+Assert-Throws -Action {
+    Assert-DDDAGitHubChecksPassed -RepositorySlug "romanhlavac/ddd-accelerator" -Commit ("a" * 40) -Token "test" | Out-Null
+} -Message "The newest failed retry must block the governed gate."
+
+Write-Host "DDDA GitHub check-run aggregation contract: PASS"


### PR DESCRIPTION
Implements #16

## Governed check-run remediation

A retry creates immutable historical GitHub check-runs on the same commit. The merge gate must evaluate the newest run for each check name: a current failure still blocks, while a later successful retry supersedes a historical failed attempt.

Scope is limited to the gate aggregation function and its regression coverage. This PR does not modify Project, milestones, release scope, controlled candidate #103, tags, GitHub Releases, promotion, or Issue closure.

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"impact":"HIGH"}
```