### PR TITLE
fix(governance): bound CI check-run repair eligibility

### DIFF
--- a/docs/adr/0012-future-release-metadata-merge-eligibility.md
+++ b/docs/adr/0012-future-release-metadata-merge-eligibility.md
@@ -81,3 +81,16 @@ through this allowance.
 ## Active-train marker regression
 
 An open future milestone is planning data, not an active release train. The guard selects exactly one open train carrying the explicit `pre_release_prerequisites` marker. Missing or duplicate markers fail closed; future open milestones cannot block an implementation merge for the active train. The former single-open-train policy remains supported only when no `release_train` section exists; it is never used as a fallback for an ambiguous current release train.
+
+
+## Check-run aggregation repair boundary
+
+A second bounded governance-repair class is permitted for the exact GitHub
+check-run aggregation implementation: DDDAGitHubSupport.ps1 and
+Invoke-DDDAPlatformTest.ps1 must be modified, and
+Test-DDDAGitHubCheckRuns.ps1 must be added. The sole primary CR remains #16,
+and the complete versioned governance bootstrap—including the active release
+scope—must remain byte-for-data unchanged. Any other path, status, primary CR
+or governance change fails closed. This allows a later successful retry to
+supersede only its historical same-name check run; it does not allow a failed
+or missing current check to pass.

--- a/runtime/platform/tests/test_merge_release_eligibility_collector.py
+++ b/runtime/platform/tests/test_merge_release_eligibility_collector.py
@@ -302,3 +302,49 @@ milestones:
         assert "marker-designated" in str(exc)
     else:
         raise AssertionError("expected unmarked release_train to fail closed")
+
+
+def test_governance_repair_allows_exact_ci_check_run_aggregation_set(monkeypatch):
+    base = bootstrap([9, 12])
+    pr = future_plan_pr()
+    monkeypatch.setattr(
+        COLLECTOR,
+        "pr_files",
+        lambda *_args: [
+            {"filename": path, "status": status}
+            for path, status in COLLECTOR.CI_CHECK_RUN_REPAIR_FILE_STATUSES.items()
+        ],
+    )
+    monkeypatch.setattr(COLLECTOR, "content_text", lambda *_args: json.dumps(base))
+    result = COLLECTOR.governance_repair_evidence(
+        repository="romanhlavac/ddd-accelerator",
+        pr=pr,
+        active={"version": "0.1.1"},
+        active_issue_numbers={9, 12},
+        primary=[16],
+        token="not-used",
+    )
+    assert result["status"] == "PASS"
+
+
+def test_governance_repair_rejects_ci_check_run_status_change(monkeypatch):
+    base = bootstrap([9, 12])
+    pr = future_plan_pr()
+    statuses = dict(COLLECTOR.CI_CHECK_RUN_REPAIR_FILE_STATUSES)
+    statuses["tests/powershell/Test-DDDAGitHubCheckRuns.ps1"] = "modified"
+    monkeypatch.setattr(
+        COLLECTOR,
+        "pr_files",
+        lambda *_args: [{"filename": path, "status": status} for path, status in statuses.items()],
+    )
+    monkeypatch.setattr(COLLECTOR, "content_text", lambda *_args: json.dumps(base))
+    result = COLLECTOR.governance_repair_evidence(
+        repository="romanhlavac/ddd-accelerator",
+        pr=pr,
+        active={"version": "0.1.1"},
+        active_issue_numbers={9, 12},
+        primary=[16],
+        token="not-used",
+    )
+    assert result["status"] == "FAIL"
+    assert "MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_FILE_STATUS_INVALID" in result["failures"]

--- a/scripts/platform/Test-DDDAMergeReleaseEligibility.py
+++ b/scripts/platform/Test-DDDAMergeReleaseEligibility.py
@@ -100,6 +100,14 @@ GOVERNANCE_REPAIR_PATHS = frozenset(
         "scripts/platform/Test-DDDAMergeReleaseEligibility.py",
     }
 )
+# This is a second, equally bounded repair class: GitHub retries leave
+# historical check-runs immutable, so the aggregation code and its regression
+# test must be mergeable without changing any release or backlog authority.
+CI_CHECK_RUN_REPAIR_FILE_STATUSES = {
+    "scripts/platform/DDDAGitHubSupport.ps1": "modified",
+    "scripts/platform/Invoke-DDDAPlatformTest.ps1": "modified",
+    "tests/powershell/Test-DDDAGitHubCheckRuns.ps1": "added",
+}
 GOVERNANCE_REPAIR_TRANSITION_PATHS = GOVERNANCE_REPAIR_PATHS | {
     "runtime/platform/release_governance.py",
 }
@@ -355,18 +363,29 @@ def governance_repair_evidence(
         rows = pr_files(repository, int(pr["number"]), token)
         paths = {str(row.get("filename") or "") for row in rows}
         integration_merge = False
-        if paths != GOVERNANCE_REPAIR_PATHS:
+        allowed_path_sets = (
+            GOVERNANCE_REPAIR_PATHS,
+            frozenset(CI_CHECK_RUN_REPAIR_FILE_STATUSES),
+        )
+        if paths not in allowed_path_sets:
             normalized = integration_merge_files(repository, pr, token)
             if normalized is not None:
                 head_sha, rows = normalized
                 paths = {str(row.get("filename") or "") for row in rows}
                 integration_merge = True
+        expected_statuses: dict[str, str] | None = None
+        if paths == GOVERNANCE_REPAIR_PATHS:
+            expected_statuses = {path: "modified" for path in GOVERNANCE_REPAIR_PATHS}
+        elif paths == frozenset(CI_CHECK_RUN_REPAIR_FILE_STATUSES):
+            expected_statuses = CI_CHECK_RUN_REPAIR_FILE_STATUSES
         if primary != [TRANSITION_PRIMARY_CR]:
             failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_PRIMARY_CR_INVALID")
-        if paths != GOVERNANCE_REPAIR_PATHS:
+        if expected_statuses is None:
             failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_PATHS_INVALID")
-        if any(str(row.get("status") or "") != "modified" for row in rows):
-            failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_FILE_STATUS_INVALID")
+        else:
+            statuses = {str(row.get("filename") or ""): str(row.get("status") or "") for row in rows}
+            if statuses != expected_statuses:
+                failures.append("MERGE_ELIGIBILITY_GOVERNANCE_REPAIR_FILE_STATUS_INVALID")
 
         base = json.loads(content_text(repository, "config/governance/github-bootstrap.json", base_sha, token))
         head = json.loads(content_text(repository, "config/governance/github-bootstrap.json", head_sha, token))


### PR DESCRIPTION
Implements #16

## CI check-run repair eligibility

Extends the existing fail-closed governance-repair allowance with one exact path/status set required for PR #129:

- scripts/platform/DDDAGitHubSupport.ps1 — modified
- scripts/platform/Invoke-DDDAPlatformTest.ps1 — modified
- tests/powershell/Test-DDDAGitHubCheckRuns.ps1 — added

The sole primary CR remains #16. The collector still proves that the complete bootstrap and active DDDA 0.1.1 scope are unchanged; any other path, status, primary CR, missing check or currently failed check remains blocked.

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"impact":"HIGH"}
```