### PR TITLE
fix(release): permit ready candidate scope dry-run

### DIFF
--- a/runtime/platform/tests/test_controlled_release_candidate.py
+++ b/runtime/platform/tests/test_controlled_release_candidate.py
@@ -44,6 +44,15 @@ def test_rejects_non_draft_or_wrong_branch_even_with_matching_sha():
     assert "CONTROLLED_CANDIDATE_BRANCH_INVALID" in result["failures"]
 
 
+def test_scope_gate_allows_only_the_exact_ready_candidate_state():
+    ready = validate(candidate(draft=False), operation="release_scope_dry_run")
+    assert ready["status"] == "PASS"
+
+    draft = validate(candidate(), operation="release_scope_dry_run")
+    assert draft["status"] == "FAIL"
+    assert "CONTROLLED_CANDIDATE_SCOPE_DRY_RUN_REQUIRES_READY" in draft["failures"]
+
+
 def test_rejects_sha_drift_and_unknown_operation():
     result = validate(candidate(), source_sha="b" * 40, operation="publish_release")
     assert result["status"] == "FAIL"

--- a/scripts/platform/Test-DDDAControlledReleaseCandidate.py
+++ b/scripts/platform/Test-DDDAControlledReleaseCandidate.py
@@ -31,7 +31,15 @@ def validate_request(
     expected_ref = f"release/{version}-controlled-recovery-source"
     if int(pr.get("number") or -1) != pr_number:
         failures.append("CONTROLLED_CANDIDATE_PR_IDENTITY_INVALID")
-    if pr.get("state") != "open" or pr.get("draft") is not True:
+    if pr.get("state") != "open":
+        failures.append("CONTROLLED_CANDIDATE_MUST_REMAIN_OPEN")
+    elif operation == "release_scope_dry_run":
+        # Scope evidence is evaluated only after the explicit Human Release
+        # Decision on the Ready candidate. It does not authorize promotion,
+        # tag creation, or GitHub Release publication.
+        if pr.get("draft") is not False:
+            failures.append("CONTROLLED_CANDIDATE_SCOPE_DRY_RUN_REQUIRES_READY")
+    elif pr.get("draft") is not True:
         failures.append("CONTROLLED_CANDIDATE_MUST_REMAIN_OPEN_DRAFT")
     if str(head.get("sha") or "") != source_sha:
         failures.append("CONTROLLED_CANDIDATE_HEAD_SHA_MISMATCH")


### PR DESCRIPTION
Implements #96

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"change_types":["RELEASE","SECURITY-GOVERNANCE","TESTING"],"impact":"HIGH","migration_impact":"non-breaking"}
```

## Scope

Repair the controlled release-candidate selector only for the already-authorized Physical Release Scope Gate dry-run:

- `technical_validation` and `publish_hrdr_scaffold` still require an open Draft candidate;
- `release_scope_dry_run` requires the same open, exact, repository-local candidate in Ready-for-review state;
- all identity, version, branch and exact-SHA checks remain fail-closed.

## Boundaries

No candidate source/diff change, release-scope/Project/milestone mutation, candidate merge, promotion, tag, GitHub Release, or Issue closure.