### PR TITLE
fix(release): bind scope gate to Project environment

### DIFF
--- a/.github/workflows/controlled-release-candidate-validation.yml
+++ b/.github/workflows/controlled-release-candidate-validation.yml
@@ -287,6 +287,7 @@ jobs:
     if: inputs.operation == 'release_scope_dry_run'
     runs-on: windows-latest
     timeout-minutes: 60
+    environment: ddda-backlog-governance
     env:
       GH_TOKEN: ${{ github.token }}
       DDDA_GITHUB_PROJECT_TOKEN: ${{ secrets.DDDA_GITHUB_PROJECT_TOKEN }}


### PR DESCRIPTION
## Purpose

Bind only the `release-scope-dry-run` job to the existing `ddda-backlog-governance` environment so its pre-existing `DDDA_GITHUB_PROJECT_TOKEN` is available to the authoritative, read-only Project scope gate.

## Exact scope

- `.github/workflows/controlled-release-candidate-validation.yml`
- one added line: `environment: ddda-backlog-governance` under `release-scope-dry-run`

## Boundaries

- Implements #96
- #96 is the sole primary CR.
- No merge, release, promotion, tag, GitHub Release, Project/milestone/scope mutation, or Issue closure.
- This PR does not alter controlled candidate #103 or its source SHA.