### PR TITLE
fix(release): bind scope gate to Project environment

### DIFF
--- a/.github/workflows/controlled-release-candidate-validation.yml
+++ b/.github/workflows/controlled-release-candidate-validation.yml
@@ -285,6 +285,7 @@ jobs:
     name: Physical Release Scope Gate dry-run
     needs: select
     if: inputs.operation == 'release_scope_dry_run'
+    environment: ddda-backlog-governance
     runs-on: windows-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
Implements #96

## Scope

Adds only `environment: ddda-backlog-governance` to the `release-scope-dry-run` job in `.github/workflows/controlled-release-candidate-validation.yml`.

This makes the existing environment-scoped `DDDA_GITHUB_PROJECT_TOKEN` available to the read-only physical Release Scope Gate. No credential value, release scope, Project, Milestone, candidate, tag, GitHub Release, promotion, or issue state is changed.

## Boundaries

- Draft-only remediation PR; no merge authorization is implied.
- The controlled release-source candidate #103 remains unmerged.
- The remediation does not run a release or promotion.