### PR TITLE
fix(release): emit scope evidence as UTF-8

### DIFF
--- a/runtime/platform/tests/test_release_scope_collectors.py
+++ b/runtime/platform/tests/test_release_scope_collectors.py
@@ -91,3 +91,13 @@ def test_merge_collector_recognizes_one_open_release_train_and_tbd_target():
     }
     assert ns.primary_changes("Implements #96\nCloses #96\n") == [96]
     assert ns.target_release("Target Release: `TBD`\n") == "TBD"
+
+
+def test_scope_collector_emits_utf8_evidence_without_windows_charmap(capsysbinary):
+    ns = _scope_namespace()
+    payload = '{"note":"ř"}\\n'
+
+    ns.emit_utf8(payload)
+
+    captured = capsysbinary.readouterr()
+    assert captured.out == payload.encode("utf-8")

--- a/scripts/platform/Test-DDDAReleaseScope.py
+++ b/scripts/platform/Test-DDDAReleaseScope.py
@@ -47,6 +47,11 @@ class GitHubReadError(RuntimeError):
     pass
 
 
+def emit_utf8(text: str) -> None:
+    """Write result evidence without depending on the Windows console code page."""
+    sys.stdout.buffer.write(text.encode("utf-8"))
+
+
 def _headers(token: str) -> dict[str, str]:
     return {
         "Authorization": f"Bearer {token}",
@@ -620,7 +625,7 @@ def main() -> int:
             out = Path(args.output)
             out.parent.mkdir(parents=True, exist_ok=True)
             out.write_text(text, encoding="utf-8")
-        print(text, end="")
+        emit_utf8(text)
         return 0 if result.status == "PASS" else 1
     except (OSError, ValueError, GitHubReadError) as exc:
         print(f"Release Scope Gate FAIL: {exc}", file=sys.stderr)


### PR DESCRIPTION
Implements #96

## Scope

Fixes only the Release Scope Gate's successful-evidence console output on Windows runners. The gate now emits its JSON through UTF-8 bytes rather than the active console code page, and a regression test covers a Czech non-ASCII character.

## Boundaries

- No change to the evaluated release scope, Project, milestone, HRDR, or controlled candidate #103.
- No release, promotion, release package, tag, GitHub Release, or Issue closure.
- Draft-only remediation; no merge authorization is implied.