### PR TITLE
fix(release): preserve controlled-candidate scope evidence

### DIFF
--- a/runtime/platform/tests/test_release_scope_collectors.py
+++ b/runtime/platform/tests/test_release_scope_collectors.py
@@ -101,3 +101,63 @@ def test_scope_collector_emits_utf8_evidence_without_windows_charmap(capsysbinar
 
     captured = capsysbinary.readouterr()
     assert captured.out == payload.encode("utf-8")
+
+
+def test_physical_scope_preserves_candidate_source_sha_and_derives_metadata_tip():
+    ns = _scope_namespace()
+    candidate_sha = "d" * 40
+    recovered_sha = "b" * 40
+    source_merge_sha = "e" * 40
+    ns.previous_release_tag = lambda *_: {"tag": "v0.1.0", "sha": "a" * 40}
+    ns.compare_commits = lambda *_: ("ahead", [{"sha": recovered_sha}, {"sha": candidate_sha}])
+    ns.recovery_ledger_at_source = lambda *_: {
+        "schema_version": 1,
+        "version": "0.1.1",
+        "previous_release_tag": "v0.1.0",
+        "entries": [{
+            "recovered_commit_sha": recovered_sha,
+            "source_pr": 77,
+            "source_merge_commit_sha": source_merge_sha,
+            "primary_cr": 96,
+        }],
+    }
+    ns.commit_path_hashes = lambda _repo, sha, _token: (
+        {ns.RECOVERY_LEDGER_PATH: "ledger"} if sha == candidate_sha else {"file": sha}
+    )
+    ns.shipping_row = lambda _repo, number, _token, _rows: {
+        "number": number,
+        "merged": True,
+        "merge_commit_sha": source_merge_sha,
+        "primary_crs": [96],
+        "milestone": "DDDA 0.1.1",
+        "target_release": "0.1.1",
+    }
+
+    actual = ns.physical_scope_snapshot(
+        "owner/repo", "0.1.1", candidate_sha, "token", {96: {"Target Release": "0.1.1"}}
+    )
+
+    assert actual["release_source_sha"] == candidate_sha
+    assert actual["recovery_ledger"]["metadata_commit_shas"] == [candidate_sha]
+
+
+def test_physical_scope_does_not_classify_non_metadata_candidate_tip():
+    ns = _scope_namespace()
+    candidate_sha = "d" * 40
+    ns.previous_release_tag = lambda *_: {"tag": "v0.1.0", "sha": "a" * 40}
+    ns.compare_commits = lambda *_: ("ahead", [{"sha": candidate_sha}])
+    ns.recovery_ledger_at_source = lambda *_: {
+        "schema_version": 1,
+        "version": "0.1.1",
+        "previous_release_tag": "v0.1.0",
+        "entries": [],
+    }
+    ns.commit_path_hashes = lambda *_: {ns.RECOVERY_LEDGER_PATH: "ledger", "other": "x"}
+    ns.rest_pages = lambda *_: []
+
+    actual = ns.physical_scope_snapshot(
+        "owner/repo", "0.1.1", candidate_sha, "token", {}
+    )
+
+    assert actual["recovery_ledger"]["metadata_commit_shas"] == []
+    assert actual["unmapped_commit_shas"] == [candidate_sha]

--- a/scripts/platform/Test-DDDAReleaseScope.py
+++ b/scripts/platform/Test-DDDAReleaseScope.py
@@ -390,7 +390,8 @@ def physical_scope_snapshot(
     ledger_entries = (ledger or {}).get("entries") if isinstance(ledger, dict) else None
     entries_by_commit: dict[str, dict[str, Any]] = {}
     ordered_entries: list[tuple[str, dict[str, Any]]] = []
-    metadata_commits: set[str] = set()
+    declared_metadata_commits: set[str] = set()
+    metadata_candidates: set[str] = set()
     ledger_evidence: dict[str, Any] | None = None
     if ledger is not None:
         if not isinstance(ledger_entries, list):
@@ -402,12 +403,24 @@ def physical_scope_snapshot(
                     ordered_entries.append((row["recovered_commit_sha"], row))
             raw_metadata = ledger.get("metadata_commit_shas") if isinstance(ledger, dict) else []
             if isinstance(raw_metadata, list):
-                metadata_commits = {str(value) for value in raw_metadata}
+                declared_metadata_commits = {str(value) for value in raw_metadata}
+            metadata_candidates = set(declared_metadata_commits)
+            # A recovery ledger's metadata commit cannot name itself in the
+            # content it creates. Derive only the exact candidate tip and only
+            # when its complete diff is the ledger file; all other shapes stay
+            # unclassified and therefore fail closed downstream.
+            candidate_tip_paths = commit_path_hashes(repository, source_sha, token)
+            if (
+                candidate_tip_paths is not None
+                and set(candidate_tip_paths) == {RECOVERY_LEDGER_PATH}
+                and source_sha not in entries_by_commit
+            ):
+                metadata_candidates.add(source_sha)
             ledger_evidence = {
                 "schema_version": ledger.get("schema_version"),
                 "version": ledger.get("version"),
                 "previous_release_tag": ledger.get("previous_release_tag"),
-                "metadata_commit_shas": sorted(metadata_commits),
+                "metadata_commit_shas": sorted(metadata_candidates),
                 "entries": [],
             }
 
@@ -416,7 +429,7 @@ def physical_scope_snapshot(
     metadata_only: set[str] = set()
     for commit in commits:
         sha = str(commit.get("sha") or "")
-        if sha in metadata_commits:
+        if sha in metadata_candidates:
             paths = commit_path_hashes(repository, sha, token)
             if paths is not None and set(paths) == {RECOVERY_LEDGER_PATH}:
                 metadata_only.add(sha)
@@ -448,8 +461,8 @@ def physical_scope_snapshot(
             except (TypeError, ValueError):
                 number = primary = 0
             source = shipping_row(repository, number, token, project_rows) if number > 0 else {}
-            source_sha = str(entry.get("source_merge_commit_sha") or "")
-            source_paths = commit_path_hashes(repository, source_sha, token) if source_sha else None
+            source_merge_sha = str(entry.get("source_merge_commit_sha") or "")
+            source_paths = commit_path_hashes(repository, source_merge_sha, token) if source_merge_sha else None
             recovered_paths = commit_path_hashes(repository, sha, token)
             ledger_evidence["entries"].append(
                 {
@@ -458,7 +471,7 @@ def physical_scope_snapshot(
                     "primary_cr": primary,
                     "source_pr_merged": source.get("merged"),
                     "source_primary_crs": source.get("primary_crs"),
-                    "source_merge_commit_sha": source_sha,
+                    "source_merge_commit_sha": source_merge_sha,
                     "observed_source_merge_commit_sha": source.get("merge_commit_sha"),
                     "changed_path_hashes_match": source_paths is not None and source_paths == recovered_paths,
                 }


### PR DESCRIPTION
## Scope

Implements #96

Narrow repair of the read-only Release Scope Gate collector.

- preserves the controlled candidate's exact source SHA while collecting recovery-ledger evidence;
- derives a metadata-only ledger commit only when the exact candidate-tip commit changes exactly `config/governance/release-source-recovery-ledger.json`;
- fails closed for every other metadata shape;
- adds collector regression coverage.

## Boundaries

No change to controlled candidate PR #103, recovery-ledger data, Project, milestone, release scope, Issue state, merge, promotion, package, tag, or GitHub Release.