### PR TITLE
fix(release): validate derived recovery metadata commit

### DIFF
--- a/runtime/platform/release_governance.py
+++ b/runtime/platform/release_governance.py
@@ -94,10 +94,10 @@ def evaluate_recovery_ledger(
     if not physical_commits:
         failures.append("RECOVERY_LEDGER_PHYSICAL_COMMIT_EVIDENCE_MISSING")
 
-    # The metadata commit is derived from the physical inventory, rather than
-    # declared inside the ledger it creates. Requiring a commit to contain its
-    # own SHA would make a valid ledger impossible to construct.
-    metadata = _sha_values(physical.get("metadata_commit_shas"))
+    # The collector derives the metadata-only commit from the physical
+    # inventory and records it inside the recovery-ledger evidence. Requiring
+    # the ledger file itself to contain its own SHA would be impossible.
+    metadata = _sha_values(ledger.get("metadata_commit_shas"))
     if len(metadata) != 1 or not metadata.issubset(physical_commits):
         failures.append("RECOVERY_LEDGER_METADATA_COMMIT_INVALID")
 

--- a/runtime/platform/release_governance.py
+++ b/runtime/platform/release_governance.py
@@ -94,10 +94,14 @@ def evaluate_recovery_ledger(
     if not physical_commits:
         failures.append("RECOVERY_LEDGER_PHYSICAL_COMMIT_EVIDENCE_MISSING")
 
-    # The collector derives the metadata-only commit from the physical
-    # inventory and records it inside the recovery-ledger evidence. Requiring
-    # the ledger file itself to contain its own SHA would be impossible.
-    metadata = _sha_values(ledger.get("metadata_commit_shas"))
+    # Canonical collector evidence is nested under recovery_ledger. Preserve
+    # the pre-existing root-level unit-fixture shape only as a compatibility
+    # fallback when the nested field is absent; live collector output uses the
+    # nested contract and therefore exercises the canonical path.
+    if "metadata_commit_shas" in ledger:
+        metadata = _sha_values(ledger.get("metadata_commit_shas"))
+    else:
+        metadata = _sha_values(physical.get("metadata_commit_shas"))
     if len(metadata) != 1 or not metadata.issubset(physical_commits):
         failures.append("RECOVERY_LEDGER_METADATA_COMMIT_INVALID")
 

--- a/runtime/platform/tests/test_release_governance_recovery_metadata.py
+++ b/runtime/platform/tests/test_release_governance_recovery_metadata.py
@@ -1,0 +1,34 @@
+from runtime.platform.release_governance import evaluate_recovery_ledger
+
+
+def test_recovery_ledger_accepts_collector_derived_metadata_commit():
+    recovered = "d" * 40
+    metadata = "e" * 40
+    physical = {
+        "previous_release_tag": "v0.1.0",
+        "commit_shas": [recovered, metadata],
+        "recovery_ledger": {
+            "schema_version": 1,
+            "version": "0.1.1",
+            "previous_release_tag": "v0.1.0",
+            "metadata_commit_shas": [metadata],
+            "entries": [
+                {
+                    "recovered_commit_sha": recovered,
+                    "source_pr": 97,
+                    "primary_cr": 96,
+                    "source_pr_merged": True,
+                    "source_primary_crs": [96],
+                    "source_merge_commit_sha": "f" * 40,
+                    "observed_source_merge_commit_sha": "f" * 40,
+                    "changed_path_hashes_match": True,
+                }
+            ],
+        },
+    }
+
+    assert evaluate_recovery_ledger(
+        physical,
+        expected_version="0.1.1",
+        declared_scope={96},
+    ) == []


### PR DESCRIPTION
Implements #96

<!-- ddda:change-classification:v1 -->
```json
{"schema_version":1,"change_types":["RELEASE","SECURITY-GOVERNANCE","TESTING"],"impact":"HIGH","migration_impact":"non-breaking"}
```

## Scope

Narrow Release Scope Gate evaluator repair:

- validate the collector-derived metadata-only recovery-ledger commit from `physical_scope.recovery_ledger.metadata_commit_shas`;
- add regression coverage proving the collector/evaluator evidence contract.

## Boundaries

No change to controlled candidate PR #103, recovery-ledger data, Project, milestone, release scope, Issue state, promotion, release package, tag, or GitHub Release. No merge authorization is implied.